### PR TITLE
chore(gitignore): ignore .cursor local artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ DerivedData/
 
 # Claude Code / AI tooling
 .claude/
+.cursor/
 .artifacts/
 
 # Secrets and certificates


### PR DESCRIPTION
## Summary
- add `.cursor/` to `.gitignore`
- prevent local AI/editor planning artifacts from appearing as untracked noise

## Out of scope
- no code or test changes
- no CI behavior changes

## Validation
- verified working tree no longer reports `.cursor/plans/` as untracked after ignore rule is present