### PR TITLE
Fix Swift 6 Sendable diagnostics in observation flow and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Build BlazeDBCore
         run: swift build --target BlazeDBCore
 
+      - name: Sendable observation regression check
+        run: ./Scripts/check-sendable-observation.sh
+
       - name: Build CLI tools
         run: |
           swift build --target BlazeDoctor
@@ -87,6 +90,9 @@ jobs:
 
       - name: Build core
         run: swift build --target BlazeDBCore
+
+      - name: Sendable observation regression check
+        run: ./Scripts/check-sendable-observation.sh
 
       - name: Test Tier 0
         run: swift test --filter BlazeDB_Tier0

--- a/BlazeDB/Core/ChangeObservation.swift
+++ b/BlazeDB/Core/ChangeObservation.swift
@@ -11,8 +11,8 @@ import Foundation
 // MARK: - Database Change Types
 
 /// Represents a change to the database
-public struct DatabaseChange {
-    public enum ChangeType {
+public struct DatabaseChange: Sendable {
+    public enum ChangeType: Sendable {
         case insert(UUID)
         case update(UUID)
         case delete(UUID)
@@ -157,6 +157,48 @@ internal final class ChangeNotificationManager: @unchecked Sendable {
     }
 }
 
+// Bridges `BlazeDBClient` into a `@Sendable` change handler without capturing
+// a non-Sendable client reference in the outer closure (Swift 6 / Linux).
+private final class FilteredChangeBridge: @unchecked Sendable {
+    private weak var client: BlazeDBClient?
+    private let predicate: @Sendable (BlazeDataRecord) -> Bool
+    private let forward: ChangeObserver
+
+    init(
+        client: BlazeDBClient,
+        predicate: @escaping @Sendable (BlazeDataRecord) -> Bool,
+        forward: @escaping ChangeObserver
+    ) {
+        self.client = client
+        self.predicate = predicate
+        self.forward = forward
+    }
+
+    func handleChanges(_ changes: [DatabaseChange]) {
+        guard let client else { return }
+
+        var relevantChanges: [DatabaseChange] = []
+
+        for change in changes {
+            if case .insert(let id) = change.type,
+               let record = try? client.fetch(id: id),
+               predicate(record) {
+                relevantChanges.append(change)
+            } else if case .update(let id) = change.type,
+                      let record = try? client.fetch(id: id),
+                      predicate(record) {
+                relevantChanges.append(change)
+            } else if case .delete = change.type {
+                relevantChanges.append(change)
+            }
+        }
+
+        if !relevantChanges.isEmpty {
+            forward(relevantChanges)
+        }
+    }
+}
+
 // MARK: - BlazeDBClient Observation Extension
 
 extension BlazeDBClient {
@@ -247,35 +289,11 @@ extension BlazeDBClient {
         where predicate: @escaping @Sendable (BlazeDataRecord) -> Bool,
         changes observer: @escaping ChangeObserver
     ) -> ObserverToken {
-        // Filtered observer: only notify if change matches predicate
-        let filteredObserver: ChangeObserver = { [weak self] changes in
-            guard let self = self else { return }
-            
-            var relevantChanges: [DatabaseChange] = []
-            
-            for change in changes {
-                // Check if this change affects matching records
-                if case .insert(let id) = change.type,
-                   let record = try? self.fetch(id: id),
-                   predicate(record) {
-                    relevantChanges.append(change)
-                }
-                else if case .update(let id) = change.type,
-                        let record = try? self.fetch(id: id),
-                        predicate(record) {
-                    relevantChanges.append(change)
-                }
-                else if case .delete = change.type {
-                    // Can't check deleted record, include all deletes
-                    relevantChanges.append(change)
-                }
-            }
-            
-            if !relevantChanges.isEmpty {
-                observer(relevantChanges)
-            }
+        let bridge = FilteredChangeBridge(client: self, predicate: predicate, forward: observer)
+        let filteredObserver: ChangeObserver = { [bridge] changes in
+            bridge.handleChanges(changes)
         }
-        
+
         let id = ChangeNotificationManager.shared.registerObserver(filteredObserver)
         
         BlazeLogger.info("📡 Filtered database observer registered")

--- a/BlazeDB/SwiftUI/BlazeQuery.swift
+++ b/BlazeDB/SwiftUI/BlazeQuery.swift
@@ -144,6 +144,28 @@ public enum BlazeQueryComparison {
     case contains // For strings
 }
 
+@MainActor
+fileprivate protocol BlazeQueryObserverRefreshable: AnyObject {
+    func refresh()
+}
+
+extension BlazeQueryObserver: BlazeQueryObserverRefreshable {}
+
+private final class BlazeQueryRefreshSink: @unchecked Sendable {
+    private weak var target: (any BlazeQueryObserverRefreshable)?
+
+    func attach(_ o: any BlazeQueryObserverRefreshable) {
+        target = o
+    }
+
+    func notifyChange() {
+        guard let t = target else { return }
+        Task { @MainActor in
+            t.refresh()
+        }
+    }
+}
+
 // MARK: - BlazeQuery Observer
 
 /// Observable object that manages query execution and result updates
@@ -181,6 +203,7 @@ public final class BlazeQueryObserver: ObservableObject {
     private var refreshTask: Task<Void, Never>?
     private var changeObserverToken: ObserverToken?
     @MainActor private var autoRefreshTimer: Timer?
+    private let refreshSink = BlazeQueryRefreshSink()
     
     // MARK: - Initialization
     
@@ -200,12 +223,11 @@ public final class BlazeQueryObserver: ObservableObject {
         // Initial fetch
         refresh()
 
+        refreshSink.attach(self)
+
         // Subscribe to DB change events so wrappers refresh on writes without polling.
-        self.changeObserverToken = db.observe { [weak self] _ in
-            guard let self = self else { return }
-            Task { @MainActor in
-                self.refresh()
-            }
+        self.changeObserverToken = db.observe { [refreshSink] _ in
+            refreshSink.notifyChange()
         }
     }
     

--- a/BlazeDB/SwiftUI/BlazeQueryTyped.swift
+++ b/BlazeDB/SwiftUI/BlazeQueryTyped.swift
@@ -125,6 +125,29 @@ public struct BlazeQueryTyped<T: BlazeDocument>: DynamicProperty {
 
 // MARK: - Type-Safe Query Observer
 
+@MainActor
+fileprivate protocol BlazeQueryTypedRefreshable: AnyObject {
+    func refresh()
+}
+
+extension BlazeQueryTypedObserver: BlazeQueryTypedRefreshable {}
+
+/// Non-generic so `@Sendable` `observe` does not close over `T.Type` (#SendableMetatypes).
+private final class BlazeQueryTypedRefreshSink: @unchecked Sendable {
+    private weak var target: (any BlazeQueryTypedRefreshable)?
+
+    func attach(_ o: any BlazeQueryTypedRefreshable) {
+        target = o
+    }
+
+    func notifyChange() {
+        guard let t = target else { return }
+        Task { @MainActor in
+            t.refresh()
+        }
+    }
+}
+
 /// Observable object that manages type-safe query execution and result updates
 @MainActor
 public final class BlazeQueryTypedObserver<T: BlazeDocument>: ObservableObject {
@@ -160,6 +183,7 @@ public final class BlazeQueryTypedObserver<T: BlazeDocument>: ObservableObject {
     private var refreshTask: Task<Void, Never>?
     private var changeObserverToken: ObserverToken?
     @MainActor private var autoRefreshTimer: Timer?
+    private let refreshSink = BlazeQueryTypedRefreshSink()
     
     // MARK: - Initialization
     
@@ -179,12 +203,11 @@ public final class BlazeQueryTypedObserver<T: BlazeDocument>: ObservableObject {
         // Initial fetch
         refresh()
 
+        refreshSink.attach(self)
+
         // Subscribe to DB change events so wrappers refresh on writes without polling.
-        self.changeObserverToken = db.observe { [weak self] _ in
-            guard let self = self else { return }
-            Task { @MainActor in
-                self.refresh()
-            }
+        self.changeObserverToken = db.observe { [refreshSink] _ in
+            refreshSink.notifyChange()
         }
     }
     

--- a/BlazeDBTests/Tier1Core/Concurrency/BlazeDBConcurrencyTests.swift
+++ b/BlazeDBTests/Tier1Core/Concurrency/BlazeDBConcurrencyTests.swift
@@ -11,7 +11,7 @@ import XCTest
 
 /// A thin wrapper around BlazeDBClient that serializes writes.
 /// Reads (fetch) remain concurrent.
-final class ThreadSafeBlazeDBClient {
+final class ThreadSafeBlazeDBClient: @unchecked Sendable {
     private let client: BlazeDBClient
     private let writeQueue = DispatchQueue(label: "blazedb.write.queue")
 

--- a/BlazeDBTests/Tier1Core/Encoding/BlazeBinaryUltimateBulletproofTests.swift
+++ b/BlazeDBTests/Tier1Core/Encoding/BlazeBinaryUltimateBulletproofTests.swift
@@ -13,6 +13,23 @@ import XCTest
 @testable import BlazeDB
 #endif
 
+private final class LockedIntCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value = 0
+
+    func increment() {
+        lock.lock()
+        value += 1
+        lock.unlock()
+    }
+
+    func get() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return value
+    }
+}
+
 final class BlazeBinaryUltimateBulletproofTests: XCTestCase {
     
     // MARK: - The Gauntlet (Tests That Break Everything)
@@ -273,8 +290,7 @@ final class BlazeBinaryUltimateBulletproofTests: XCTestCase {
         expectation.expectedFulfillmentCount = 10_000
         
         let queue = DispatchQueue(label: "test", attributes: .concurrent)
-        var failureCount = 0
-        let lock = NSLock()
+        let failureCount = LockedIntCounter()
         
         for i in 0..<10_000 {
             queue.async {
@@ -289,14 +305,10 @@ final class BlazeBinaryUltimateBulletproofTests: XCTestCase {
                     let decoded = try BlazeBinaryDecoder.decode(encoded)
                     
                     if decoded.storage["id"]?.intValue != i {
-                        lock.lock()
-                        failureCount += 1
-                        lock.unlock()
+                        failureCount.increment()
                     }
                 } catch {
-                    lock.lock()
-                    failureCount += 1
-                    lock.unlock()
+                    failureCount.increment()
                 }
                 
                 expectation.fulfill()
@@ -306,10 +318,11 @@ final class BlazeBinaryUltimateBulletproofTests: XCTestCase {
         wait(for: [expectation], timeout: 60)
         
         print("  Operations: 10,000")
-        print("  Failures: \(failureCount)")
-        print("  Success rate: \(String(format: "%.2f", (10000 - failureCount) / 100))%")
+        let failures = failureCount.get()
+        print("  Failures: \(failures)")
+        print("  Success rate: \(String(format: "%.2f", (10000 - failures) / 100))%")
         
-        XCTAssertEqual(failureCount, 0, "Should have ZERO failures in concurrent ops!")
+        XCTAssertEqual(failures, 0, "Should have ZERO failures in concurrent ops!")
         
         print("  ✅ 10,000 concurrent operations: 100.00% success!")
     }
@@ -551,8 +564,7 @@ final class BlazeBinaryUltimateBulletproofTests: XCTestCase {
         expectation.expectedFulfillmentCount = 1000
         
         let queue = DispatchQueue(label: "finalBoss", attributes: .concurrent)
-        var failureCount = 0
-        let lock = NSLock()
+        let failureCount = LockedIntCounter()
         
         for i in 0..<1000 {
             queue.async {
@@ -589,27 +601,19 @@ final class BlazeBinaryUltimateBulletproofTests: XCTestCase {
                     
                     // Verify integrity
                     if decoded.storage.count != storage.count {
-                        lock.lock()
-                        failureCount += 1
-                        lock.unlock()
+                        failureCount.increment()
                     }
                     
                     if decoded.storage["id"]?.intValue != i {
-                        lock.lock()
-                        failureCount += 1
-                        lock.unlock()
+                        failureCount.increment()
                     }
                     
                     if decoded.storage["extreme"]?.intValue != Int.min {
-                        lock.lock()
-                        failureCount += 1
-                        lock.unlock()
+                        failureCount.increment()
                     }
                     
                 } catch {
-                    lock.lock()
-                    failureCount += 1
-                    lock.unlock()
+                    failureCount.increment()
                 }
                 
                 expectation.fulfill()
@@ -619,10 +623,11 @@ final class BlazeBinaryUltimateBulletproofTests: XCTestCase {
         wait(for: [expectation], timeout: 120)
         
         print("  Operations: 1,000 pathological records")
-        print("  Failures: \(failureCount)")
-        print("  Success rate: \(String(format: "%.1f", Double(1000 - failureCount) / 10))%")
+        let failures = failureCount.get()
+        print("  Failures: \(failures)")
+        print("  Success rate: \(String(format: "%.1f", Double(1000 - failures) / 10))%")
         
-        XCTAssertEqual(failureCount, 0, "THE FINAL BOSS: ZERO failures allowed!")
+        XCTAssertEqual(failures, 0, "THE FINAL BOSS: ZERO failures allowed!")
         
         print("  🏆 THE FINAL BOSS: DEFEATED! BlazeBinary is FLAWLESS!")
     }

--- a/BlazeDBTests/Tier1Core/MVCC/MVCCFoundationTests.swift
+++ b/BlazeDBTests/Tier1Core/MVCC/MVCCFoundationTests.swift
@@ -14,6 +14,25 @@ import XCTest
 @testable import BlazeDB
 #endif
 
+extension VersionManager: @unchecked Sendable {}
+
+private final class MVCCLockedCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value = 0
+
+    func increment() {
+        lock.lock()
+        value += 1
+        lock.unlock()
+    }
+
+    func get() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return value
+    }
+}
+
 final class MVCCFoundationTests: XCTestCase {
     
     var versionManager: VersionManager!
@@ -308,8 +327,8 @@ final class MVCCFoundationTests: XCTestCase {
         versionManager.addVersion(version)
         
         let group = DispatchGroup()
-        var successCount = 0
-        let lock = NSLock()
+        let successCount = MVCCLockedCounter()
+        let versionManagerRef = versionManager!
         
         // 100 concurrent reads
         for _ in 0..<100 {
@@ -317,22 +336,21 @@ final class MVCCFoundationTests: XCTestCase {
             DispatchQueue.global().async {
                 defer { group.leave() }
                 
-                if let _ = self.versionManager.getVersion(recordID: recordID, snapshot: 1) {
-                    lock.lock()
-                    successCount += 1
-                    lock.unlock()
+                if let _ = versionManagerRef.getVersion(recordID: recordID, snapshot: 1) {
+                    successCount.increment()
                 }
             }
         }
         
         group.wait()
         
-        XCTAssertEqual(successCount, 100, "All concurrent reads should succeed")
+        XCTAssertEqual(successCount.get(), 100, "All concurrent reads should succeed")
     }
     
     func testConcurrentVersionAdds() {
         let recordID = UUID()
         let group = DispatchGroup()
+        let versionManagerRef = versionManager!
         
         // 50 threads adding versions
         for i in 1...50 {
@@ -346,7 +364,7 @@ final class MVCCFoundationTests: XCTestCase {
                     pageNumber: i,
                     createdByTransaction: UInt64(i)
                 )
-                self.versionManager.addVersion(version)
+                versionManagerRef.addVersion(version)
             }
         }
         

--- a/BlazeDBTests/Tier1Core/Persistence/MetadataFlushEdgeCaseTests.swift
+++ b/BlazeDBTests/Tier1Core/Persistence/MetadataFlushEdgeCaseTests.swift
@@ -29,6 +29,23 @@ import Glibc
 @testable import BlazeDB
 #endif
 
+private final class LockedErrorList: @unchecked Sendable {
+    private let lock = NSLock()
+    private var errors: [Error] = []
+
+    func append(_ error: Error) {
+        lock.lock()
+        errors.append(error)
+        lock.unlock()
+    }
+
+    func isEmpty() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return errors.isEmpty
+    }
+}
+
 final class MetadataFlushEdgeCaseTests: XCTestCase {
     private var tempURL: URL?
     private var db: BlazeDBClient?
@@ -208,18 +225,16 @@ final class MetadataFlushEdgeCaseTests: XCTestCase {
         expectation.expectedFulfillmentCount = 10
         
         let queue = DispatchQueue(label: "test.flush", attributes: .concurrent)
-        var errors: [Error] = []
-        let errorLock = NSLock()
+        let errors = LockedErrorList()
+        let dbRef = try requireFixture(db)
         
         for i in 95..<105 {
             queue.async {
                 do {
-                    _ = try self.requireFixture(self.db).insert(BlazeDataRecord(["index": .int(i)]))
+                    _ = try dbRef.insert(BlazeDataRecord(["index": .int(i)]))
                     expectation.fulfill()
                 } catch {
-                    errorLock.lock()
                     errors.append(error)
-                    errorLock.unlock()
                     expectation.fulfill()
                 }
             }
@@ -227,7 +242,7 @@ final class MetadataFlushEdgeCaseTests: XCTestCase {
         
         wait(for: [expectation], timeout: 5.0)
         
-        XCTAssertTrue(errors.isEmpty, "No errors during concurrent flush boundary")
+        XCTAssertTrue(errors.isEmpty(), "No errors during concurrent flush boundary")
         
         // Verify all records present
         let records = try requireFixture(db).fetchAll()

--- a/BlazeDBTests/Tier1Core/SQL/ConcurrentJoinTests.swift
+++ b/BlazeDBTests/Tier1Core/SQL/ConcurrentJoinTests.swift
@@ -127,12 +127,13 @@ final class ConcurrentJoinTests: XCTestCase {
         insertExpectation.expectedFulfillmentCount = 3
         
         let queue = DispatchQueue(label: "test.join.insert", attributes: .concurrent)
+        let dbRef1 = try requireFixture(db1)
         
         // 3 threads inserting new posts concurrently (this is safe)
         for threadID in 0..<3 {
             queue.async {
                 do {
-                    _ = try self.requireFixture(self.db1).insert(BlazeDataRecord([
+                    _ = try dbRef1.insert(BlazeDataRecord([
                         "post": .string("Concurrent Post \(threadID)"),
                         "author": .uuid(userId1)
                     ]))

--- a/BlazeDBTests/Tier1Core/Security/EncryptionRoundTripVerificationTests.swift
+++ b/BlazeDBTests/Tier1Core/Security/EncryptionRoundTripVerificationTests.swift
@@ -25,6 +25,23 @@ import Crypto
 @testable import BlazeDB
 #endif
 
+private final class EncryptionLockedErrors: @unchecked Sendable {
+    private let lock = NSLock()
+    private var errors: [Error] = []
+
+    func append(_ error: Error) {
+        lock.lock()
+        errors.append(error)
+        lock.unlock()
+    }
+
+    func snapshot() -> [Error] {
+        lock.lock()
+        defer { lock.unlock() }
+        return errors
+    }
+}
+
 final class EncryptionRoundTripVerificationTests: XCTestCase {
     
     private var tempURL: URL?
@@ -309,8 +326,8 @@ final class EncryptionRoundTripVerificationTests: XCTestCase {
     /// Test: Concurrent writes to different pages
     func testConcurrentWritesDifferentPages() throws {
         let group = DispatchGroup()
-        var errors: [Error] = []
-        let errorLock = NSLock()
+        let errors = EncryptionLockedErrors()
+        let storeRef = try XCTUnwrap(store, "store should be initialized in setUpWithError")
         
         // Write 100 pages concurrently
         for i in 0..<100 {
@@ -319,17 +336,16 @@ final class EncryptionRoundTripVerificationTests: XCTestCase {
                 defer { group.leave() }
                 do {
                     let data = "Page \(i)".data(using: .utf8)!
-                    try self.store.writePage(index: i, plaintext: data)
+                    try storeRef.writePage(index: i, plaintext: data)
                 } catch {
-                    errorLock.lock()
                     errors.append(error)
-                    errorLock.unlock()
                 }
             }
         }
         
         group.wait()
-        XCTAssertTrue(errors.isEmpty, "Concurrent writes should not cause errors: \(errors)")
+        let allErrors = errors.snapshot()
+        XCTAssertTrue(allErrors.isEmpty, "Concurrent writes should not cause errors: \(allErrors)")
         
         // Verify all pages readable
         for i in 0..<100 {
@@ -347,8 +363,8 @@ final class EncryptionRoundTripVerificationTests: XCTestCase {
         }
         
         let group = DispatchGroup()
-        var errors: [Error] = []
-        let errorLock = NSLock()
+        let errors = EncryptionLockedErrors()
+        let storeRef = try XCTUnwrap(store, "store should be initialized in setUpWithError")
         
         // Concurrent readers and writers
         for _ in 0..<20 {
@@ -358,12 +374,10 @@ final class EncryptionRoundTripVerificationTests: XCTestCase {
                 defer { group.leave() }
                 do {
                     for i in 0..<50 {
-                        _ = try self.store.readPage(index: i)
+                        _ = try storeRef.readPage(index: i)
                     }
                 } catch {
-                    errorLock.lock()
                     errors.append(error)
-                    errorLock.unlock()
                 }
             }
             
@@ -373,17 +387,16 @@ final class EncryptionRoundTripVerificationTests: XCTestCase {
                 defer { group.leave() }
                 do {
                     let page = Int.random(in: 0..<50)
-                    try self.store.writePage(index: page, plaintext: "Updated".data(using: .utf8)!)
+                    try storeRef.writePage(index: page, plaintext: "Updated".data(using: .utf8)!)
                 } catch {
-                    errorLock.lock()
                     errors.append(error)
-                    errorLock.unlock()
                 }
             }
         }
         
         group.wait()
-        XCTAssertTrue(errors.isEmpty, "Concurrent read/write should be thread-safe: \(errors)")
+        let allErrors = errors.snapshot()
+        XCTAssertTrue(allErrors.isEmpty, "Concurrent read/write should be thread-safe: \(allErrors)")
     }
 }
 

--- a/BlazeDBTests/Tier1Core/Transactions/BlazeTransactionTests.swift
+++ b/BlazeDBTests/Tier1Core/Transactions/BlazeTransactionTests.swift
@@ -84,10 +84,11 @@ final class BlazeTransactionTests: XCTestCase {
         let id4 = UUID()
         let record1 = BlazeDataRecord(["message": .string("Data1")])
         let record2 = BlazeDataRecord(["message": .string("Data2")])
+        let dbRef = try requireFixture(db)
 
         DispatchQueue.global().async {
             do {
-                try self.requireFixture(self.db).insert(record1, id: id3)
+                try dbRef.insert(record1, id: id3)
                 expectation1.fulfill()
             } catch {
                 XCTFail("Write Data1 failed: \(error)")
@@ -96,7 +97,7 @@ final class BlazeTransactionTests: XCTestCase {
 
         DispatchQueue.global().async {
             do {
-                try self.requireFixture(self.db).insert(record2, id: id4)
+                try dbRef.insert(record2, id: id4)
                 expectation2.fulfill()
             } catch {
                 XCTFail("Write Data2 failed: \(error)")

--- a/BlazeDBTests/Tier1Extended/Concurrency/BlazeDBEnhancedConcurrencyTests.swift
+++ b/BlazeDBTests/Tier1Extended/Concurrency/BlazeDBEnhancedConcurrencyTests.swift
@@ -177,7 +177,7 @@ final class BlazeDBEnhancedConcurrencyTests: XCTestCase {
         expectation.expectedFulfillmentCount = 50
         
         let queue = DispatchQueue(label: "test.concurrent", attributes: .concurrent)
-        var insertedIDs = ThreadSafeArray<UUID>()
+        let insertedIDs = ThreadSafeArray<UUID>()
         guard let dbRef = db else {
             XCTFail("db not set")
             return
@@ -523,7 +523,7 @@ final class BlazeDBEnhancedConcurrencyTests: XCTestCase {
         expectation.expectedFulfillmentCount = iterations
         
         let queue = DispatchQueue(label: "test.concurrent", attributes: .concurrent)
-        var successCount = ThreadSafeCounter()
+        let successCount = ThreadSafeCounter()
         guard let dbRef = db else {
             XCTFail("db not set")
             return
@@ -566,7 +566,7 @@ final class BlazeDBEnhancedConcurrencyTests: XCTestCase {
 
 // MARK: - Helper Classes
 
-class ThreadSafeArray<T> {
+final class ThreadSafeArray<T>: @unchecked Sendable {
     private var _array: [T] = []
     private let lock = NSLock()
     
@@ -589,7 +589,7 @@ class ThreadSafeArray<T> {
     }
 }
 
-class ThreadSafeCounter {
+final class ThreadSafeCounter: @unchecked Sendable {
     private var _value: Int = 0
     private let lock = NSLock()
     

--- a/BlazeDBTests/Tier1Extended/MVCC/MVCCIntegrationTests.swift
+++ b/BlazeDBTests/Tier1Extended/MVCC/MVCCIntegrationTests.swift
@@ -14,6 +14,29 @@ import XCTest
 @testable import BlazeDB
 #endif
 
+private final class MVCCIntegrationLockedCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value = 0
+
+    func increment() {
+        lock.lock()
+        value += 1
+        lock.unlock()
+    }
+
+    func set(_ newValue: Int) {
+        lock.lock()
+        value = newValue
+        lock.unlock()
+    }
+
+    func get() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return value
+    }
+}
+
 final class MVCCIntegrationTests: XCTestCase {
     
     private var tempURL: URL?
@@ -124,9 +147,9 @@ final class MVCCIntegrationTests: XCTestCase {
         print("  ✅ Inserted 100 records")
         
         let group = DispatchGroup()
-        var successCount = 0
-        var errorCount = 0
-        let lock = NSLock()
+        let successCount = MVCCIntegrationLockedCounter()
+        let errorCount = MVCCIntegrationLockedCounter()
+        let dbRef = try requireFixture(db)
         
         // Measure time
         let start = Date()
@@ -138,14 +161,10 @@ final class MVCCIntegrationTests: XCTestCase {
                 defer { group.leave() }
                 
                 do {
-                    _ = try self.requireFixture(self.db).fetch(id: id)
-                    lock.lock()
-                    successCount += 1
-                    lock.unlock()
+                    _ = try dbRef.fetch(id: id)
+                    successCount.increment()
                 } catch {
-                    lock.lock()
-                    errorCount += 1
-                    lock.unlock()
+                    errorCount.increment()
                 }
             }
         }
@@ -154,13 +173,13 @@ final class MVCCIntegrationTests: XCTestCase {
         let duration = Date().timeIntervalSince(start)
         
         print("  📊 Concurrent reads: 100")
-        print("  📊 Success: \(successCount)")
-        print("  📊 Errors: \(errorCount)")
+        print("  📊 Success: \(successCount.get())")
+        print("  📊 Errors: \(errorCount.get())")
         print("  📊 Duration: \(String(format: "%.3f", duration))s")
         print("  📊 Throughput: \(String(format: "%.0f", 100.0 / duration)) reads/sec")
         
-        XCTAssertEqual(successCount, 100)
-        XCTAssertEqual(errorCount, 0)
+        XCTAssertEqual(successCount.get(), 100)
+        XCTAssertEqual(errorCount.get(), 0)
         
         print("  ✅ All concurrent reads successful!")
     }
@@ -177,22 +196,21 @@ final class MVCCIntegrationTests: XCTestCase {
         }
         
         let group = DispatchGroup()
-        var readCount = 0
-        var writeCount = 0
-        let lock = NSLock()
+        let readCount = MVCCIntegrationLockedCounter()
+        let writeCount = MVCCIntegrationLockedCounter()
+        let dbRef = try requireFixture(db)
+        let idList = ids
         
         let start = Date()
         
         // Readers (50 threads)
-        for id in ids {
+        for id in idList {
             group.enter()
             DispatchQueue.global().async {
                 defer { group.leave() }
                 
-                _ = try? self.requireFixture(self.db).fetch(id: id)
-                lock.lock()
-                readCount += 1
-                lock.unlock()
+                _ = try? dbRef.fetch(id: id)
+                readCount.increment()
             }
         }
         
@@ -202,20 +220,18 @@ final class MVCCIntegrationTests: XCTestCase {
             DispatchQueue.global().async {
                 defer { group.leave() }
                 
-                _ = try? self.requireFixture(self.db).insert(BlazeDataRecord([
+                _ = try? dbRef.insert(BlazeDataRecord([
                     "write": .int(i)
                 ]))
-                lock.lock()
-                writeCount += 1
-                lock.unlock()
+                writeCount.increment()
             }
         }
         
         group.wait()
         let duration = Date().timeIntervalSince(start)
         
-        print("  📊 Reads: \(readCount)")
-        print("  📊 Writes: \(writeCount)")
+        print("  📊 Reads: \(readCount.get())")
+        print("  📊 Writes: \(writeCount.get())")
         print("  📊 Duration: \(String(format: "%.3f", duration))s")
         print("  ✅ Reads and writes happened concurrently!")
     }
@@ -236,18 +252,19 @@ final class MVCCIntegrationTests: XCTestCase {
         
         // Transaction 1: Start reading
         let group = DispatchGroup()
-        var count1 = 0
-        var count2 = 0
+        let count1 = MVCCIntegrationLockedCounter()
+        let count2 = MVCCIntegrationLockedCounter()
+        let dbRef = try requireFixture(db)
         
         group.enter()
         DispatchQueue.global().async {
             defer { group.leave() }
             
             // This transaction sees snapshot at start
-            count1 = (try? self.requireFixture(self.db).count()) ?? 0
+            count1.set((try? dbRef.count()) ?? 0)
             Thread.sleep(forTimeInterval: 0.1)
             // Count should be same (snapshot isolation)
-            count2 = (try? self.requireFixture(self.db).count()) ?? 0
+            count2.set((try? dbRef.count()) ?? 0)
         }
         
         // Meanwhile, insert more records
@@ -258,8 +275,8 @@ final class MVCCIntegrationTests: XCTestCase {
         
         group.wait()
         
-        print("  📸 Snapshot count1: \(count1)")
-        print("  📸 Snapshot count2: \(count2)")
+        print("  📸 Snapshot count1: \(count1.get())")
+        print("  📸 Snapshot count2: \(count2.get())")
         print("  📊 Final count: \(try requireFixture(db).count())")
         
         // Note: Without full snapshot transactions, this might not work yet
@@ -289,11 +306,12 @@ final class MVCCIntegrationTests: XCTestCase {
         let start = Date()
         
         let group = DispatchGroup()
+        let dbRef = try requireFixture(db)
         for id in ids {
             group.enter()
             DispatchQueue.global().async {
                 defer { group.leave() }
-                _ = try? self.requireFixture(self.db).fetch(id: id)
+                _ = try? dbRef.fetch(id: id)
             }
         }
         
@@ -346,12 +364,13 @@ final class MVCCIntegrationTests: XCTestCase {
         }
         
         let group = DispatchGroup()
-        var insertCount = 0
-        var fetchCount = 0
-        var updateCount = 0
-        var deleteCount = 0
-        var errorCount = 0
-        let lock = NSLock()
+        let insertCount = MVCCIntegrationLockedCounter()
+        let fetchCount = MVCCIntegrationLockedCounter()
+        let updateCount = MVCCIntegrationLockedCounter()
+        let deleteCount = MVCCIntegrationLockedCounter()
+        let errorCount = MVCCIntegrationLockedCounter()
+        let dbRef = try requireFixture(db)
+        let idList = ids
         
         // 1000 random concurrent operations
         for _ in 0..<1000 {
@@ -364,46 +383,36 @@ final class MVCCIntegrationTests: XCTestCase {
                     
                     switch op {
                     case 0:  // Insert (25%)
-                        _ = try self.requireFixture(self.db).insert(BlazeDataRecord([
+                        _ = try dbRef.insert(BlazeDataRecord([
                             "random": .int(Int.random(in: 0...1000))
                         ]))
-                        lock.lock()
-                        insertCount += 1
-                        lock.unlock()
+                        insertCount.increment()
                         
                     case 1:  // Fetch (25%)
-                        if let id = ids.randomElement() {
-                            _ = try self.requireFixture(self.db).fetch(id: id)
+                        if let id = idList.randomElement() {
+                            _ = try dbRef.fetch(id: id)
                         }
-                        lock.lock()
-                        fetchCount += 1
-                        lock.unlock()
+                        fetchCount.increment()
                         
                     case 2:  // Update (25%)
-                        if let id = ids.randomElement() {
-                            try self.requireFixture(self.db).update(id: id, with: BlazeDataRecord([
+                        if let id = idList.randomElement() {
+                            try dbRef.update(id: id, with: BlazeDataRecord([
                                 "updated": .bool(true)
                             ]))
                         }
-                        lock.lock()
-                        updateCount += 1
-                        lock.unlock()
+                        updateCount.increment()
                         
                     case 3:  // Delete (25%)
-                        if let id = ids.randomElement(), ids.count > 20 {
-                            try self.requireFixture(self.db).delete(id: id)
+                        if let id = idList.randomElement(), idList.count > 20 {
+                            try dbRef.delete(id: id)
                         }
-                        lock.lock()
-                        deleteCount += 1
-                        lock.unlock()
+                        deleteCount.increment()
                         
                     default:
                         break
                     }
                 } catch {
-                    lock.lock()
-                    errorCount += 1
-                    lock.unlock()
+                    errorCount.increment()
                 }
             }
         }
@@ -411,11 +420,11 @@ final class MVCCIntegrationTests: XCTestCase {
         group.wait()
         
         print("  📊 Operations completed:")
-        print("     Inserts: \(insertCount)")
-        print("     Fetches: \(fetchCount)")
-        print("     Updates: \(updateCount)")
-        print("     Deletes: \(deleteCount)")
-        print("     Errors:  \(errorCount)")
+        print("     Inserts: \(insertCount.get())")
+        print("     Fetches: \(fetchCount.get())")
+        print("     Updates: \(updateCount.get())")
+        print("     Deletes: \(deleteCount.get())")
+        print("     Errors:  \(errorCount.get())")
         
         // Database should still be functional
         XCTAssertNoThrow(try requireFixture(db).fetchAll())
@@ -443,21 +452,19 @@ final class MVCCIntegrationTests: XCTestCase {
         
         // Concurrent reads
         let group = DispatchGroup()
-        var integrityFailures = 0
-        let lock = NSLock()
+        let integrityFailures = MVCCIntegrationLockedCounter()
+        let dbRef = try requireFixture(db)
         
         for (id, expected) in expectedRecords {
             group.enter()
             DispatchQueue.global().async {
                 defer { group.leave() }
                 
-                if let fetched = try? self.requireFixture(self.db).fetch(id: id) {
+                if let fetched = try? dbRef.fetch(id: id) {
                     // Verify data matches
                     if fetched["index"]?.intValue != expected["index"]?.intValue ||
                        fetched["data"]?.stringValue != expected["data"]?.stringValue {
-                        lock.lock()
-                        integrityFailures += 1
-                        lock.unlock()
+                        integrityFailures.increment()
                     }
                 }
             }
@@ -466,9 +473,9 @@ final class MVCCIntegrationTests: XCTestCase {
         group.wait()
         
         print("  📊 Integrity checks: 100")
-        print("  📊 Failures: \(integrityFailures)")
+        print("  📊 Failures: \(integrityFailures.get())")
         
-        XCTAssertEqual(integrityFailures, 0, "All data should be intact")
+        XCTAssertEqual(integrityFailures.get(), 0, "All data should be intact")
         
         print("  ✅ Data integrity verified!")
     }
@@ -497,11 +504,12 @@ final class MVCCIntegrationTests: XCTestCase {
         let start = Date()
         
         let group = DispatchGroup()
+        let dbRef = try requireFixture(db)
         for id in ids {
             group.enter()
             DispatchQueue.global().async {
                 defer { group.leave() }
-                _ = try? self.requireFixture(self.db).fetch(id: id)
+                _ = try? dbRef.fetch(id: id)
             }
         }
         

--- a/BlazeDBTests/Tier1Extended/MVCC/MVCCRegressionTests.swift
+++ b/BlazeDBTests/Tier1Extended/MVCC/MVCCRegressionTests.swift
@@ -17,6 +17,23 @@ import XCTest
 @testable import BlazeDB
 #endif
 
+private final class MVCCRegressionLockedCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value = 0
+
+    func increment() {
+        lock.lock()
+        value += 1
+        lock.unlock()
+    }
+
+    func get() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return value
+    }
+}
+
 final class MVCCRegressionTests: XCTestCase {
     
     private var tempURL: URL?
@@ -214,8 +231,8 @@ final class MVCCRegressionTests: XCTestCase {
     
     func testRegression_ConcurrentInserts() throws {
         let group = DispatchGroup()
-        var insertedCount = 0
-        let lock = NSLock()
+        let insertedCount = MVCCRegressionLockedCounter()
+        let dbRef = try requireFixture(db)
         
         for i in 0..<100 {
             group.enter()
@@ -223,12 +240,10 @@ final class MVCCRegressionTests: XCTestCase {
                 defer { group.leave() }
                 
                 do {
-                    _ = try self.requireFixture(self.db).insert(BlazeDataRecord([
+                    _ = try dbRef.insert(BlazeDataRecord([
                         "thread": .int(i)
                     ]))
-                    lock.lock()
-                    insertedCount += 1
-                    lock.unlock()
+                    insertedCount.increment()
                 } catch {
                     print("Insert error: \(error)")
                 }
@@ -237,7 +252,7 @@ final class MVCCRegressionTests: XCTestCase {
         
         group.wait()
         
-        XCTAssertEqual(insertedCount, 100)
+        XCTAssertEqual(insertedCount.get(), 100)
         XCTAssertEqual(try requireFixture(db).count(), 100)
     }
     
@@ -250,8 +265,9 @@ final class MVCCRegressionTests: XCTestCase {
         }
         
         let group = DispatchGroup()
-        var errors = 0
-        let lock = NSLock()
+        let errors = MVCCRegressionLockedCounter()
+        let dbRef = try requireFixture(db)
+        let idList = ids
         
         // 200 mixed concurrent operations
         for _ in 0..<200 {
@@ -264,30 +280,28 @@ final class MVCCRegressionTests: XCTestCase {
                     
                     switch op {
                     case 0:  // Insert
-                        _ = try self.requireFixture(self.db).insert(BlazeDataRecord([
+                        _ = try dbRef.insert(BlazeDataRecord([
                             "r": .int(Int.random(in: 0...1000))
                         ]))
                     case 1:  // Fetch
-                        if let id = ids.randomElement() {
-                            _ = try self.requireFixture(self.db).fetch(id: id)
+                        if let id = idList.randomElement() {
+                            _ = try dbRef.fetch(id: id)
                         }
                     case 2:  // Update
-                        if let id = ids.randomElement() {
-                            try self.requireFixture(self.db).update(id: id, with: BlazeDataRecord([
+                        if let id = idList.randomElement() {
+                            try dbRef.update(id: id, with: BlazeDataRecord([
                                 "updated": .bool(true)
                             ]))
                         }
                     case 3:  // Delete
-                        if ids.count > 20, let id = ids.randomElement() {
-                            try self.requireFixture(self.db).delete(id: id)
+                        if idList.count > 20, let id = idList.randomElement() {
+                            try dbRef.delete(id: id)
                         }
                     default:
                         break
                     }
                 } catch {
-                    lock.lock()
-                    errors += 1
-                    lock.unlock()
+                    errors.increment()
                 }
             }
         }
@@ -296,7 +310,7 @@ final class MVCCRegressionTests: XCTestCase {
         
         // Some operations might fail (conflicts), but database should be stable
         XCTAssertNoThrow(try requireFixture(db).fetchAll())
-        print("Errors: \(errors)/200 (conflicts expected)")
+        print("Errors: \(errors.get())/200 (conflicts expected)")
     }
     
     // MARK: - Data Types Regression

--- a/BlazeDBTests/Tier1Extended/Migration/AutoMigrationVerificationTests.swift
+++ b/BlazeDBTests/Tier1Extended/Migration/AutoMigrationVerificationTests.swift
@@ -13,6 +13,23 @@ import XCTest
 @testable import BlazeDB
 #endif
 
+private final class MigrationLockedErrors: @unchecked Sendable {
+    private let lock = NSLock()
+    private var errors: [Error] = []
+
+    func append(_ error: Error) {
+        lock.lock()
+        errors.append(error)
+        lock.unlock()
+    }
+
+    func snapshot() -> [Error] {
+        lock.lock()
+        defer { lock.unlock() }
+        return errors
+    }
+}
+
 final class AutoMigrationVerificationTests: XCTestCase {
     
     private var tempURL: URL?
@@ -611,8 +628,7 @@ final class AutoMigrationVerificationTests: XCTestCase {
         // Immediately start concurrent operations
         let client = try XCTUnwrap(self.db, "database should be open after migration reopen")
         let group = DispatchGroup()
-        var errors: [Error] = []
-        let lock = NSLock()
+        let errors = MigrationLockedErrors()
         
         for i in 100..<200 {
             group.enter()
@@ -621,9 +637,7 @@ final class AutoMigrationVerificationTests: XCTestCase {
                 do {
                     try client.insert(BlazeDataRecord(["value": .int(i)]))
                 } catch {
-                    lock.lock()
                     errors.append(error)
-                    lock.unlock()
                 }
             }
         }
@@ -631,7 +645,8 @@ final class AutoMigrationVerificationTests: XCTestCase {
         group.wait()
         
         // Should handle concurrent access during/after migration
-        XCTAssertTrue(errors.isEmpty, "Concurrent inserts after migration should work: \(errors)")
+        let allErrors = errors.snapshot()
+        XCTAssertTrue(allErrors.isEmpty, "Concurrent inserts after migration should work: \(allErrors)")
         
         let finalCount = try migrationDB().count()
         XCTAssertGreaterThanOrEqual(finalCount, 100, 

--- a/BlazeDBTests/Tier1Extended/Observability/ObservabilityTests.swift
+++ b/BlazeDBTests/Tier1Extended/Observability/ObservabilityTests.swift
@@ -15,6 +15,23 @@ import XCTest
 @testable import BlazeDB
 #endif
 
+private final class ObservabilityLockedErrors: @unchecked Sendable {
+    private let lock = NSLock()
+    private var errors: [Error] = []
+
+    func append(_ error: Error) {
+        lock.lock()
+        errors.append(error)
+        lock.unlock()
+    }
+
+    func snapshot() -> [Error] {
+        lock.lock()
+        defer { lock.unlock() }
+        return errors
+    }
+}
+
 final class ObservabilityTests: XCTestCase {
     private var tempDir: URL?
     private var db: BlazeDBClient?
@@ -155,8 +172,7 @@ final class ObservabilityTests: XCTestCase {
     func testObservability_DoesNotDeadlock() throws {
         // Concurrent operations with observability
         let group = DispatchGroup()
-        var errors: [Error] = []
-        let lock = NSLock()
+        let errors = ObservabilityLockedErrors()
         let client = try XCTUnwrap(db)
         
         for _ in 0..<10 {
@@ -168,17 +184,16 @@ final class ObservabilityTests: XCTestCase {
                     _ = try client.observe()
                     _ = try client.fetchAll()
                 } catch {
-                    lock.lock()
                     errors.append(error)
-                    lock.unlock()
                 }
                 group.leave()
             }
         }
         
         let result = group.wait(timeout: .now() + 5.0)
+        let allErrors = errors.snapshot()
         XCTAssertEqual(result, .success, "Operations should complete without deadlock")
-        XCTAssertTrue(errors.isEmpty || errors.allSatisfy { $0.localizedDescription.contains("locked") },
+        XCTAssertTrue(allErrors.isEmpty || allErrors.allSatisfy { $0.localizedDescription.contains("locked") },
                       "Only expected errors should occur")
     }
     

--- a/BlazeDBTests/Tier1Perf/Indexes/SearchPerformanceBenchmarks.swift
+++ b/BlazeDBTests/Tier1Perf/Indexes/SearchPerformanceBenchmarks.swift
@@ -16,6 +16,40 @@ import XCTest
 #endif
 import Foundation
 
+private final class SearchLockedArray<T>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var valuesStorage: [T] = []
+
+    func append(_ value: T) {
+        lock.lock()
+        valuesStorage.append(value)
+        lock.unlock()
+    }
+
+    func snapshot() -> [T] {
+        lock.lock()
+        defer { lock.unlock() }
+        return valuesStorage
+    }
+}
+
+private final class SearchLockedCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value = 0
+
+    func increment() {
+        lock.lock()
+        value += 1
+        lock.unlock()
+    }
+
+    func get() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return value
+    }
+}
+
 final class SearchPerformanceBenchmarks: XCTestCase {
     
     private var tempURL: URL?
@@ -45,9 +79,8 @@ final class SearchPerformanceBenchmarks: XCTestCase {
         let expectation = self.expectation(description: "Concurrent searches")
         expectation.expectedFulfillmentCount = searches
         let queue = DispatchQueue(label: "test.search", attributes: .concurrent)
-        var durations: [Double] = []
-        var nilResultCount = 0
-        let lock = NSLock()
+        let durations = SearchLockedArray<Double>()
+        let nilResultCount = SearchLockedCounter()
         let totalStart = Date()
 
         for _ in 1...searches {
@@ -55,19 +88,17 @@ final class SearchPerformanceBenchmarks: XCTestCase {
                 let start = Date()
                 let results = try? client.query().search("bug", in: ["title", "description"])
                 let elapsedMs = Date().timeIntervalSince(start) * 1000.0
-                lock.lock()
                 durations.append(elapsedMs)
                 if results == nil {
-                    nilResultCount += 1
+                    nilResultCount.increment()
                 }
-                lock.unlock()
                 expectation.fulfill()
             }
         }
 
         wait(for: [expectation], timeout: timeout)
-        XCTAssertEqual(nilResultCount, 0, "Concurrent query should return a result")
-        return (durationsMs: durations, totalDuration: Date().timeIntervalSince(totalStart))
+        XCTAssertEqual(nilResultCount.get(), 0, "Concurrent query should return a result")
+        return (durationsMs: durations.snapshot(), totalDuration: Date().timeIntervalSince(totalStart))
     }
     
     func testBenchmark_SearchWith1000Records() throws {

--- a/BlazeDBTests/Tier1Perf/MVCC/MVCCPerformanceTests.swift
+++ b/BlazeDBTests/Tier1Perf/MVCC/MVCCPerformanceTests.swift
@@ -263,6 +263,7 @@ final class MVCCPerformanceTests: XCTestCase {
             let id = try client.insert(BlazeDataRecord(["i": .int(i)]))
             ids.append(id)
         }
+        let idList = ids
         
         let start = Date()
         let group = DispatchGroup()
@@ -276,7 +277,7 @@ final class MVCCPerformanceTests: XCTestCase {
                 let op = i % 10  // 0-9
                 
                 if op < 8 {  // 80% reads
-                    if let id = ids.randomElement() {
+                    if let id = idList.randomElement() {
                         _ = try? client.fetch(id: id)
                     }
                 } else {  // 20% writes

--- a/Scripts/check-sendable-observation.sh
+++ b/Scripts/check-sendable-observation.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+run_and_check() {
+  local label="$1"
+  shift
+
+  local log_file
+  log_file="$(mktemp)"
+
+  echo "=== $label ==="
+  echo "Running: swift build --build-tests -Xswiftc -strict-concurrency=complete $*"
+
+  if ! swift build --build-tests -Xswiftc -strict-concurrency=complete "$@" >"$log_file" 2>&1; then
+    echo "Build failed for '$label'. Showing last 120 log lines:"
+    tail -n 120 "$log_file"
+    rm -f "$log_file"
+    exit 1
+  fi
+
+  local hits_file
+  hits_file="$(mktemp)"
+
+  # Focused regression gate: fail if strict concurrency emits Sendable diagnostics
+  # for our SwiftUI observation wrappers or the change observation core file.
+  if rg -n \
+    "(BlazeDB/SwiftUI/BlazeQuery\\.swift|BlazeDB/SwiftUI/BlazeQueryTyped\\.swift|BlazeDB/Core/ChangeObservation\\.swift):[0-9]+:[0-9]+: (warning|error): .*([sS]endable|#Sendable)" \
+    "$log_file" >"$hits_file"; then
+    echo "Sendable regression detected in observation files:"
+    cat "$hits_file"
+    rm -f "$log_file" "$hits_file"
+    exit 1
+  fi
+
+  echo "OK: no Sendable diagnostics in observation files for '$label'."
+  rm -f "$log_file" "$hits_file"
+}
+
+run_and_check "Strict concurrency (default)"
+run_and_check "Strict concurrency (BLAZEDB_LINUX_CORE)" -Xswiftc -DBLAZEDB_LINUX_CORE
+
+echo "=== Sendable observation checks passed ==="


### PR DESCRIPTION
## Summary

- Fix Swift 6 Sendable diagnostics in database observation paths and concurrent test closures.
- Add a focused CI regression check to prevent reintroducing Sendable warnings in observation-related files.

Why needed:
- Swift 6 strict concurrency (especially Linux/Android paths) surfaced Sendable capture/conformance issues that can fail strict test builds and mask real regressions.

## Scope

- In scope:
  - `BlazeDB/Core/ChangeObservation.swift`
    - `DatabaseChange` / `ChangeType` made Sendable.
    - Added a bridge for filtered observers to avoid non-Sendable captures in `@Sendable` closures.
  - `BlazeDB/SwiftUI/BlazeQuery.swift`
  - `BlazeDB/SwiftUI/BlazeQueryTyped.swift`
    - Added non-generic refresh sink pattern so observe callbacks no longer capture non-Sendable observer/metatype context.
  - Sendable-safe test updates in Tier1 Core/Extended/Perf test files (lock-backed counters/arrays, local reference capture patterns, minimal test helper Sendable annotations).
  - New script: `Scripts/check-sendable-observation.sh`
  - CI wiring in `.github/workflows/ci.yml` to run the Sendable observation regression script.

- Out of scope:
  - Feature behavior changes
  - API redesign
  - Non-Sendable refactors unrelated to strict-concurrency diagnostics

## Validation

List exact commands you ran:

```bash
./Scripts/check-sendable-observation.sh
swift test --filter BlazeDB_Tier0
swift test --test-product BlazeDB_Tier1Fast --filter BlazeDBClientConcurrencyTests
swift test --test-product BlazeDB_Tier1Fast --filter BlazeBinaryUltimateBulletproofTests
swift test --test-product BlazeDB_Tier1Fast --filter MVCCFoundationTests
swift test --test-product BlazeDB_Tier1Fast --filter MetadataFlushEdgeCaseTests
swift test --test-product BlazeDB_Tier1Fast --filter ConcurrentJoinTests
swift test --test-product BlazeDB_Tier1Fast --filter EncryptionRoundTripVerificationTests
swift test --test-product BlazeDB_Tier1Fast --filter BlazeTransactionTests
swift test --test-product BlazeDB_Tier1Fast --filter BlazeQueryObservationIntegrationTests
swift test --test-product BlazeDB_Tier1Fast --filter BlazeEncoderMigrationTests
swift test --test-product BlazeDB_Tier1Extended --filter BlazeDBEnhancedConcurrencyTests
swift test --test-product BlazeDB_Tier1Extended --filter MVCCIntegrationTests
swift test --test-product BlazeDB_Tier1Extended --filter MVCCRegressionTests
swift test --test-product BlazeDB_Tier1Extended --filter AutoMigrationVerificationTests
swift test --test-product BlazeDB_Tier1Extended --filter ObservabilityTests
swift test --test-product BlazeDB_Tier1Perf --filter SearchPerformanceBenchmarks
swift test --test-product BlazeDB_Tier1Perf --filter MVCCPerformanceTests
```

## Checklist

- [x] One branch = one concern
- [x] `git status`/`git diff` reviewed for containment
- [x] Relevant docs updated (CI regression guard added for Sendable observation checks)
- [x] CI checks pass locally
