### PR TITLE
docs: clarify Android core-path support in README and compatibility

### DIFF
--- a/Docs/COMPATIBILITY.md
+++ b/Docs/COMPATIBILITY.md
@@ -66,6 +66,10 @@
 - **Status:** Core supported
 - **Notes:** Some advanced features disabled (`BLAZEDB_LINUX_CORE`)
 
+### Android
+- **Status:** Core path supported (same compile-time path as Linux)
+- **Notes:** Builds with `BLAZEDB_LINUX_CORE` path; advanced platform-dependent features may be excluded. CI validation is currently best-effort/manual.
+
 ---
 
 ## Storage Format Compatibility
@@ -159,7 +163,7 @@ See `CONTRIBUTING.md` for bug report templates and guidelines.
 
 ## Summary
 
-**Core:** Swift 6 compliant, stable, production-ready
+**Core:** Swift 6 compliant, stable, production-ready (macOS/iOS) and core-path supported on Linux/Android
 **Distributed:** Not yet compliant, excluded from core
 **Storage:** Stable format, migration support
 **APIs:** Core APIs stable, experimental APIs clearly marked

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ An encrypted embedded document store for Swift — designed for application stat
 **ACID transactions, AES-256-GCM encryption, no external service dependencies.**
 
 [![Swift](https://img.shields.io/badge/Swift-6.0-orange.svg)](https://swift.org)
-[![Platform](https://img.shields.io/badge/Platform-macOS%20%7C%20iOS%20%7C%20Linux-lightgrey.svg)](https://github.com/Mikedan37/BlazeDB)
+[![Platform](https://img.shields.io/badge/Platform-macOS%20%7C%20iOS%20%7C%20Linux%20%7C%20Android-lightgrey.svg)](https://github.com/Mikedan37/BlazeDB)
+[![Android Core Path](https://img.shields.io/badge/Android-core%20path%20enabled-blue.svg)](Docs/COMPATIBILITY.md)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 ---
@@ -179,7 +180,9 @@ BlazeDB encrypts data and overflow pages at rest using AES-GCM, and the page-lev
 > BlazeDB. It is **not required** to use the core embedded database engine and is less battle-tested than the core
 > library.
 
-**Requirements:** Swift 6.0+, macOS 15+ / iOS 15+ / Linux (core engine supported; automated CI validation is lighter than on macOS — see [Linux guide](Docs/GettingStarted/LINUX_GETTING_STARTED.md) and [Compatibility](Docs/COMPATIBILITY.md))
+**Requirements:** Swift 6.0+, macOS 15+ / iOS 15+ / Linux / Android
+
+Android currently follows the Linux-style core path (`BLAZEDB_LINUX_CORE`): core storage/query functionality builds, while some advanced platform-dependent surfaces are excluded. CI coverage for Android is currently best-effort/manual. See [Compatibility](Docs/COMPATIBILITY.md).
 
 ### Security and Benchmark Mode Note
 


### PR DESCRIPTION
## Summary

- Add Android to the platform badge and requirements line.
- Clarify Android support status as Linux-core-path parity (`BLAZEDB_LINUX_CORE`) instead of full-platform parity.

## Scope

- In scope:
- `README.md` platform badges and requirements note
- `Docs/COMPATIBILITY.md` Android platform section and summary wording

- Out of scope:
- Core runtime behavior changes
- CI behavior changes
- Sendable fixes (already covered by parent PR)

## Validation

List exact commands you ran:

```bash
git diff --stat test/swift6-sendable-observation-and-tests...HEAD
```

## Checklist

- [x] One branch = one concern
- [x] `git status`/`git diff` reviewed for containment
- [x] Relevant docs updated (platform support wording)
- [x] CI checks pass