### PR TITLE
ci: re-enable Linux baseline lane (core + Tier0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,11 +71,9 @@ jobs:
         run: ./Scripts/verify-readme-quickstart.sh
 
   linux:
-    name: Linux (Swift 6) — best-effort (manual)
-    if: github.event_name == 'workflow_dispatch'
+    name: Linux (Swift 6.0 baseline) — core + Tier 0
     runs-on: ubuntu-22.04
     timeout-minutes: 120
-    continue-on-error: true
 
     steps:
       - name: Checkout
@@ -91,11 +89,11 @@ jobs:
       - name: Build core
         run: swift build --target BlazeDBCore
 
-      - name: Sendable observation regression check
-        run: ./Scripts/check-sendable-observation.sh
+      - name: Build CLI tools
+        run: |
+          swift build --target BlazeDoctor
+          swift build --target BlazeDump
+          swift build --target BlazeInfo
 
       - name: Test Tier 0
-        run: swift test --filter BlazeDB_Tier0
-
-      - name: Test Tier 1 (fast)
-        run: swift test --skip-build --filter BlazeDB_Tier1Fast
+        run: swift test --test-product BlazeDB_Tier0

--- a/Docs/COMPATIBILITY.md
+++ b/Docs/COMPATIBILITY.md
@@ -64,11 +64,11 @@
 ### Linux
 - **Platform:** aarch64 (tested on Orange Pi 5 Ultra)
 - **Status:** Core supported
-- **Notes:** Some advanced features disabled (`BLAZEDB_LINUX_CORE`)
+- **Notes:** Some advanced features disabled (`BLAZEDB_LINUX_CORE`). CI baseline lane targets Swift 6.0 for core + Tier 0 stability checks.
 
 ### Android
 - **Status:** Core path supported (same compile-time path as Linux)
-- **Notes:** Builds with `BLAZEDB_LINUX_CORE` path; advanced platform-dependent features may be excluded. CI validation is currently best-effort/manual.
+- **Notes:** Builds with `BLAZEDB_LINUX_CORE` path; advanced platform-dependent features may be excluded. Android cross-compilation currently expects Swift 6.3+ plus the Swift Android SDK and Android NDK (manual/best-effort lane).
 
 ---
 
@@ -112,6 +112,7 @@ These APIs may change:
 - **Minimum:** Swift 6.0
 - **Recommended:** Latest Swift 6.x
 - **Strict Concurrency:** Enabled for core modules
+- **CI lane policy:** Linux CI runs a Swift 6.0 baseline lane for deterministic core validation; Android toolchain bring-up uses Swift 6.3+ outside the baseline lane.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ BlazeDB encrypts data and overflow pages at rest using AES-GCM, and the page-lev
 **Requirements:** Swift 6.0+, macOS 15+ / iOS 15+ / Linux / Android
 
 Android currently follows the Linux-style core path (`BLAZEDB_LINUX_CORE`): core storage/query functionality builds, while some advanced platform-dependent surfaces are excluded. CI coverage for Android is currently best-effort/manual. See [Compatibility](Docs/COMPATIBILITY.md).
+Linux CI uses a Swift 6.0 baseline lane for core validation; Android cross-compilation expects Swift 6.3+ with the Swift Android SDK + Android NDK in a separate/manual lane.
 
 ### Security and Benchmark Mode Note
 


### PR DESCRIPTION
## Summary

- Re-enabled the Linux CI lane for normal `push` / `pull_request` runs by removing manual-only gating and non-blocking behavior.
- Kept Linux checks intentionally baseline-only (`BlazeDBCore` build, core CLI build, Tier 0 tests) and documented Linux vs Android toolchain expectations (Linux CI baseline on Swift 6.0; Android bring-up remains separate/manual on Swift 6.3+ with SDK/NDK).

## Scope

- In scope:
  - `.github/workflows/ci.yml` Linux lane enablement + baseline test/build selection
  - minimal docs wording in `README.md` and `Docs/COMPATIBILITY.md` for toolchain/lane expectations

- Out of scope:
  - no Sendable/test portability fixes
  - no Darwin/Linux guard refactors
  - no Android full support or NDK cross-compile setup changes

## Validation

```bash
git status -sb
git diff -- .github/workflows/ci.yml README.md Docs/COMPATIBILITY.md
```

