### PR TITLE
CI: add nightly confidence workflow and triage policy

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,133 @@
+name: Nightly confidence
+
+on:
+  schedule:
+    - cron: "0 4 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: nightly-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  nightly-macos-confidence:
+    name: macOS 15 — Tier1 depth + Tier1FastFull + Tier2 + verify scripts
+    runs-on: macos-15
+    timeout-minutes: 360
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Cache SwiftPM build
+        uses: actions/cache@v4
+        with:
+          path: .build
+          key: nightly-${{ runner.os }}-spm-${{ hashFiles('Package.swift', 'Package.resolved', 'BlazeDBExtraTests/Package.swift') }}
+          restore-keys: |
+            nightly-${{ runner.os }}-spm-
+            ${{ runner.os }}-spm-
+
+      - name: Xcode Swift toolchain
+        run: |
+          xcodebuild -version
+          swift --version
+          which swift
+
+      - name: Build BlazeDBCore
+        run: swift build --target BlazeDBCore
+
+      - name: Test Tier 1 extended
+        run: swift test --filter BlazeDB_Tier1Extended
+
+      - name: Test Tier 1 perf
+        run: swift test --skip-build --filter BlazeDB_Tier1Perf
+
+      - name: Test Tier 1 fast full (broader deterministic)
+        run: swift test --filter BlazeDB_Tier1FastFull
+        working-directory: BlazeDBExtraTests
+
+      - name: Test Tier 2 integration/recovery (non-blocking lane)
+        run: ./Scripts/run-tier2.sh
+
+      - name: Install ripgrep (verification scripts)
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: 1
+        run: |
+          command -v rg >/dev/null 2>&1 || brew install ripgrep
+
+      - name: Verify clean-checkout flow
+        run: ./Scripts/verify-clean-checkout.sh
+
+      - name: Verify README quickstart
+        run: ./Scripts/verify-readme-quickstart.sh
+
+  nightly-macos-tsan:
+    name: macOS 15 — Tier0 ThreadSanitizer
+    runs-on: macos-15
+    timeout-minutes: 180
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Xcode Swift toolchain
+        run: |
+          xcodebuild -version
+          swift --version
+
+      - name: Run thread sanitizer on Tier 0
+        run: |
+          SANITIZER_LOG=$(mktemp)
+          swift test -Xswiftc -sanitize=thread --filter BlazeDB_Tier0 | tee "$SANITIZER_LOG"
+          if grep -q "Executed 0 tests" "$SANITIZER_LOG"; then
+            echo "Sanitizer lane ran zero tests"
+            exit 1
+          fi
+
+  nightly-linux-depth:
+    name: Linux (Swift 6.2) — Tier0 + Tier1Fast
+    runs-on: ubuntu-22.04
+    timeout-minutes: 240
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Cache SwiftPM build
+        uses: actions/cache@v4
+        with:
+          path: .build
+          key: nightly-${{ runner.os }}-spm-${{ hashFiles('Package.swift', 'Package.resolved') }}
+          restore-keys: |
+            nightly-${{ runner.os }}-spm-
+            ${{ runner.os }}-spm-
+
+      - name: Setup Swift 6.2
+        uses: swift-actions/setup-swift@v2
+        with:
+          swift-version: "6.2"
+
+      - name: Swift version
+        run: swift --version
+
+      - name: Build core
+        run: swift build --target BlazeDBCore
+
+      - name: Test Tier 0
+        run: swift test --filter BlazeDB_Tier0
+
+      - name: Test Tier 1 fast
+        run: swift test --skip-build --filter BlazeDB_Tier1Fast

--- a/Docs/Testing/CI_AND_TEST_TIERS.md
+++ b/Docs/Testing/CI_AND_TEST_TIERS.md
@@ -27,7 +27,18 @@ For branch discipline and PR hygiene, see `Docs/Guides/WORKFLOW_AND_STYLE_GUIDE.
 
 - `.github/workflows/tier1-depth.yml`
 - Trigger: **weekly schedule** and **manual** (`workflow_dispatch`)
-- Runs **`BlazeDB_Tier1Extended`** and **`BlazeDB_Tier1Perf`** only (not `BlazeDB_Tier1Fast`; that is the PR-critical lane). This is the scheduled **Tier1 depth** lane—see [Reporting vocabulary](#reporting-vocabulary) below.
+- Runs **`BlazeDB_Tier1Extended`** and **`BlazeDB_Tier1Perf`** only (not `BlazeDB_Tier1Fast`; that is the PR-critical lane). This remains available during nightly rollout.
+
+- `.github/workflows/nightly.yml`
+- Trigger: **daily schedule** and **manual** (`workflow_dispatch`)
+- Runs medium-confidence coverage:
+  - `BlazeDB_Tier1Extended` + `BlazeDB_Tier1Perf`
+  - `BlazeDB_Tier1FastFull` (from `BlazeDBExtraTests`)
+  - Tier2 integration/recovery via `./Scripts/run-tier2.sh` (non-blocking within nightly lane)
+  - `verify-clean-checkout.sh` and `verify-readme-quickstart.sh`
+  - ThreadSanitizer on `BlazeDB_Tier0`
+  - Linux depth run: `BlazeDB_Tier0` + `BlazeDB_Tier1Fast`
+- **Operational policy:** nightly failures are triaged within 24–48 hours.
 
 - `.github/workflows/release.yml`
 - Trigger: tag push `v*`
@@ -78,6 +89,7 @@ Use precise language so status and dashboards do not blur the PR gate with deepe
 | -------- | ------- |
 | **Tier1 PR gate** / **T1 fast** | `BlazeDB_Tier1Fast` only—the default blocking Tier1 lane on PRs. |
 | **Tier1 depth** | `BlazeDB_Tier1Extended` + `BlazeDB_Tier1Perf` (weekly/manual `tier1-depth.yml`, or `./Scripts/run-tier1-depth.sh`). Does *not* by itself imply `BlazeDB_Tier1Fast` ran. |
+| **Nightly confidence lane** | `nightly.yml`: Tier1 depth + `BlazeDB_Tier1FastFull` + Tier2 script + verify scripts + Tier0 TSan + Linux Tier0/Tier1Fast. |
 | **Full Tier1** / **Tier1 all lanes** | `BlazeDB_Tier1Fast` + `BlazeDB_Tier1FastFull` + `BlazeDB_Tier1Extended` + `BlazeDB_Tier1Perf` (broader deterministic coverage via `BlazeDBExtraTests`). |
 
 Inventory/bootstrap code may still bucket all three SwiftPM modules under a single **`T1`** label for file-level manifests; that is a storage convenience. **Human-facing** summaries (CI names, release notes, team chat) should use the table above, not a vague “T1 passed.”
@@ -103,6 +115,13 @@ A few files remain **excluded** from `Tier1Core` in `Package.swift` because they
 - `./Scripts/run-tier1-depth.sh` (`BlazeDB_Tier1Extended` + `BlazeDB_Tier1Perf`)
 - `./Scripts/run-tier2.sh`
 - `./Scripts/run-tier3.sh`
+
+## Nightly Triage Policy
+
+- Nightly failures are treated as real work and triaged within **24–48 hours**.
+- If nightly remains red beyond that window, either:
+  - fix the failing lane, or
+  - temporarily quarantine the failing job with an explicit issue link and owner.
 
 ## Before Merge Checklist
 


### PR DESCRIPTION
This PR adds the medium-confidence nightly lane and updates the testing docs to match.

Changes:
- adds `.github/workflows/nightly.yml` (daily + manual) with:
  - macOS Tier1Extended + Tier1Perf + Tier1FastFull + Tier2 + verify scripts
  - macOS Tier0 ThreadSanitizer
  - Linux Tier0 + Tier1Fast depth run
- updates `Docs/Testing/CI_AND_TEST_TIERS.md` with the nightly workflow inventory, reporting vocabulary, and explicit 24–48h nightly triage policy

Notes:
- `tier1-depth.yml` is intentionally kept during rollout.
- no PR-lane changes are included in this PR.