### PR TITLE
CI: add deep validation workflow for soak lanes

### DIFF
--- a/.github/workflows/deep-validation.yml
+++ b/.github/workflows/deep-validation.yml
@@ -1,0 +1,151 @@
+name: Deep validation
+
+on:
+  schedule:
+    - cron: "0 3 * * 0"
+  workflow_dispatch:
+
+concurrency:
+  group: deep-validation-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  deep-macos-full:
+    name: macOS 15 — full deep validation
+    runs-on: macos-15
+    timeout-minutes: 480
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Cache SwiftPM build
+        uses: actions/cache@v4
+        with:
+          path: .build
+          key: deep-${{ runner.os }}-spm-${{ hashFiles('Package.swift', 'Package.resolved', 'BlazeDBExtraTests/Package.swift') }}
+          restore-keys: |
+            deep-${{ runner.os }}-spm-
+            nightly-${{ runner.os }}-spm-
+            ${{ runner.os }}-spm-
+
+      - name: Xcode Swift toolchain
+        run: |
+          xcodebuild -version
+          swift --version
+          which swift
+
+      - name: Build BlazeDBCore
+        run: swift build --target BlazeDBCore
+
+      - name: Test Tier 0
+        run: swift test --filter BlazeDB_Tier0
+
+      - name: Test Tier 1 fast (PR-critical subset)
+        run: swift test --skip-build --filter BlazeDB_Tier1Fast
+
+      - name: Test Tier 1 fast full (broader deterministic)
+        run: swift test --filter BlazeDB_Tier1FastFull
+        working-directory: BlazeDBExtraTests
+
+      - name: Test Tier 1 extended
+        run: swift test --filter BlazeDB_Tier1Extended
+
+      - name: Test Tier 1 perf
+        run: swift test --skip-build --filter BlazeDB_Tier1Perf
+
+      - name: Test Tier 2 integration/recovery
+        run: ./Scripts/run-tier2.sh
+
+      - name: Test Tier 3 heavy stress/fuzz
+        env:
+          RUN_HEAVY_STRESS: "1"
+        run: |
+          cd BlazeDBExtraTests
+          swift test --filter BlazeDB_Tier3_Heavy
+
+      - name: Test Tier 3 destructive/fault injection
+        run: ./Scripts/run-tier3.sh
+
+  deep-macos-tsan:
+    name: macOS 15 — Tier0 + Tier1Fast ThreadSanitizer
+    runs-on: macos-15
+    timeout-minutes: 360
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Xcode Swift toolchain
+        run: |
+          xcodebuild -version
+          swift --version
+
+      - name: Run thread sanitizer on Tier 0
+        run: |
+          SANITIZER_LOG=$(mktemp)
+          swift test -Xswiftc -sanitize=thread --filter BlazeDB_Tier0 | tee "$SANITIZER_LOG"
+          if grep -q "Executed 0 tests" "$SANITIZER_LOG"; then
+            echo "Tier 0 sanitizer lane ran zero tests"
+            exit 1
+          fi
+
+      - name: Run thread sanitizer on Tier 1 fast
+        run: |
+          SANITIZER_LOG=$(mktemp)
+          swift test -Xswiftc -sanitize=thread --filter BlazeDB_Tier1Fast | tee "$SANITIZER_LOG"
+          if grep -q "Executed 0 tests" "$SANITIZER_LOG"; then
+            echo "Tier 1 fast sanitizer lane ran zero tests"
+            exit 1
+          fi
+
+  deep-linux-extended:
+    name: Linux (Swift 6.2) — Tier0 + Tier1Fast + Tier1Extended
+    runs-on: ubuntu-22.04
+    timeout-minutes: 360
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Cache SwiftPM build
+        uses: actions/cache@v4
+        with:
+          path: .build
+          key: deep-${{ runner.os }}-spm-${{ hashFiles('Package.swift', 'Package.resolved') }}
+          restore-keys: |
+            deep-${{ runner.os }}-spm-
+            nightly-${{ runner.os }}-spm-
+            ${{ runner.os }}-spm-
+
+      - name: Setup Swift 6.2
+        uses: swift-actions/setup-swift@v2
+        with:
+          swift-version: "6.2"
+
+      - name: Swift version
+        run: swift --version
+
+      - name: Build core
+        run: swift build --target BlazeDBCore
+
+      - name: Test Tier 0
+        run: swift test --filter BlazeDB_Tier0
+
+      - name: Test Tier 1 fast
+        run: swift test --skip-build --filter BlazeDB_Tier1Fast
+
+      - name: Test Tier 1 extended
+        run: swift test --skip-build --filter BlazeDB_Tier1Extended

--- a/Docs/Testing/CI_AND_TEST_TIERS.md
+++ b/Docs/Testing/CI_AND_TEST_TIERS.md
@@ -40,6 +40,15 @@ For branch discipline and PR hygiene, see `Docs/Guides/WORKFLOW_AND_STYLE_GUIDE.
   - Linux depth run: `BlazeDB_Tier0` + `BlazeDB_Tier1Fast`
 - **Operational policy:** nightly failures are triaged within 24–48 hours.
 
+- `.github/workflows/deep-validation.yml`
+- Trigger: **weekly schedule** and **manual** (`workflow_dispatch`)
+- Runs deep/manual soak coverage:
+  - Full Tier1 (`BlazeDB_Tier1Fast` + `BlazeDB_Tier1FastFull` + `BlazeDB_Tier1Extended` + `BlazeDB_Tier1Perf`)
+  - Tier2 via `./Scripts/run-tier2.sh`
+  - Tier3 heavy (`BlazeDB_Tier3_Heavy` with `RUN_HEAVY_STRESS=1`) and Tier3 destructive (`./Scripts/run-tier3.sh`)
+  - ThreadSanitizer on `BlazeDB_Tier0` and `BlazeDB_Tier1Fast`
+  - Linux extended lane (`BlazeDB_Tier0` + `BlazeDB_Tier1Fast` + `BlazeDB_Tier1Extended`)
+
 - `.github/workflows/release.yml`
 - Trigger: tag push `v*`
 - Behavior:
@@ -90,6 +99,7 @@ Use precise language so status and dashboards do not blur the PR gate with deepe
 | **Tier1 PR gate** / **T1 fast** | `BlazeDB_Tier1Fast` only—the default blocking Tier1 lane on PRs. |
 | **Tier1 depth** | `BlazeDB_Tier1Extended` + `BlazeDB_Tier1Perf` (weekly/manual `tier1-depth.yml`, or `./Scripts/run-tier1-depth.sh`). Does *not* by itself imply `BlazeDB_Tier1Fast` ran. |
 | **Nightly confidence lane** | `nightly.yml`: Tier1 depth + `BlazeDB_Tier1FastFull` + Tier2 script + verify scripts + Tier0 TSan + Linux Tier0/Tier1Fast. |
+| **Deep validation lane** | `deep-validation.yml`: full Tier1 + Tier2 + Tier3 heavy/destructive + Tier0/Tier1Fast TSan + Linux extended lane. |
 | **Full Tier1** / **Tier1 all lanes** | `BlazeDB_Tier1Fast` + `BlazeDB_Tier1FastFull` + `BlazeDB_Tier1Extended` + `BlazeDB_Tier1Perf` (broader deterministic coverage via `BlazeDBExtraTests`). |
 
 Inventory/bootstrap code may still bucket all three SwiftPM modules under a single **`T1`** label for file-level manifests; that is a storage convenience. **Human-facing** summaries (CI names, release notes, team chat) should use the table above, not a vague “T1 passed.”


### PR DESCRIPTION
This PR adds the deep/manual soak lane and updates testing docs accordingly.

Changes:
- adds `.github/workflows/deep-validation.yml` (weekly + manual) with:
  - macOS full deep validation: Tier0 + Tier1Fast + Tier1FastFull + Tier1Extended + Tier1Perf + Tier2 + Tier3 heavy/destructive
  - macOS ThreadSanitizer on Tier0 and Tier1Fast
  - Linux extended lane: Tier0 + Tier1Fast + Tier1Extended
- updates `Docs/Testing/CI_AND_TEST_TIERS.md` with deep workflow inventory and reporting vocabulary

Notes:
- no PR-lane changes are included in this PR
- `tier1-depth.yml` remains in place during rollout