### PR TITLE
docs: clarify CI lanes and rollout status

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ This guide explains how to add tests, what will be accepted, and what will be re
 
 ## CI gate (GitHub Actions)
 
-The default branch workflow (`.github/workflows/ci.yml`) runs on every push/PR **when hosted CI is available**: a single **macOS 15** job (core + CLI + Tier0 + Tier1 fast + `verify-clean-checkout.sh` + README quickstart), plus **Linux** best-effort (`continue-on-error`). Legacy **`v*` tag buildability** is **not** part of that automatic gate; it runs only from the **manual** workflow [`.github/workflows/tag-probe.yml`](.github/workflows/tag-probe.yml) (see [CI and test tiers](Docs/Testing/CI_AND_TEST_TIERS.md)). Checkouts use **full git history** (`fetch-depth: 0`). OSS scripts run on macOS so CI matches the primary platform. **Forks and billing limits** can prevent workflows from running; in that case use the same commands locally (see [Hosted CI status](Docs/Status/OPEN_SOURCE_READINESS_CHECKLIST.md#hosted-ci-status)). The gate is **not** every test target or every file under `BlazeDBTests/` (some files are excluded per tier in `Package.swift`). Authoritative detail: [CI and test tiers](Docs/Testing/CI_AND_TEST_TIERS.md).
+The default branch workflow (`.github/workflows/ci.yml`) runs on every push/PR **when hosted CI is available**: a **macOS 15** blocking job (core + CLI + Tier0 + reduced `BlazeDB_Tier1Fast`) and a **Linux 6.2** blocking job (core + Tier0). `verify-clean-checkout.sh` and `verify-readme-quickstart.sh` are intentionally **not** in the blocking PR gate. Legacy **`v*` tag buildability** is **not** part of that automatic gate; it runs only from the manual workflow [`.github/workflows/tag-probe.yml`](.github/workflows/tag-probe.yml). Checkouts use full git history (`fetch-depth: 0`). **Forks and billing limits** can prevent workflows from running; in that case use the same commands locally (see [Hosted CI status](Docs/Status/OPEN_SOURCE_READINESS_CHECKLIST.md#hosted-ci-status)). The gate is **not** every test target or every file under `BlazeDBTests/` (some files are excluded per tier in `Package.swift`). Authoritative detail: [CI and test tiers](Docs/Testing/CI_AND_TEST_TIERS.md).
 
 ---
 
@@ -38,6 +38,8 @@ swift test --filter BlazeDB_Tier0
 ### Tier 1: Core contracts (split targets)
 
 **Default PR gate — `BlazeDB_Tier1Fast`:** `BlazeDBTests/Tier1Core/` — deterministic correctness; no `measure()`, no timing-dependent sleeps, no benchmark-shaped workloads.
+
+**Broader deterministic lane — `BlazeDB_Tier1FastFull`:** same source tree, declared in `BlazeDBExtraTests/Package.swift` for deeper/manual confidence lanes.
 
 **Depth — `BlazeDB_Tier1Extended`:** `BlazeDBTests/Tier1Extended/` — integration, sync, sleep-dependent or large-N stress.
 

--- a/Docs/Testing/CI_AND_TEST_TIERS.md
+++ b/Docs/Testing/CI_AND_TEST_TIERS.md
@@ -6,6 +6,26 @@ If this file conflicts with other docs, treat this file and `.github/workflows/*
 
 For branch discipline and PR hygiene, see `Docs/Guides/WORKFLOW_AND_STYLE_GUIDE.md`.
 
+## CI Lane Snapshot
+
+Use this table for day-to-day expectations.
+
+| Lane | Goal | Trigger | Blocking | Current workflow(s) |
+| ---- | ---- | ------- | -------- | ------------------- |
+| PR fast gate | Catch obvious breakage quickly | `pull_request`, `push` | Yes | `ci.yml` |
+| Tier1 depth | Broader Tier1 confidence | Weekly + manual | No | `tier1-depth.yml` |
+| Release validation | Validate tagged releases | `v*` tag + manual | Release-only | `release.yml` |
+| Tag probe | Check older tags still build | Manual | No | `tag-probe.yml` |
+
+### Rollout status
+
+- Completed:
+  - PR gate caching and verify-step trim in `ci.yml`
+  - Tier1 PR gate reduction (`BlazeDB_Tier1Fast`) + broader deterministic lane (`BlazeDB_Tier1FastFull`)
+- In rollout:
+  - nightly confidence lane (`nightly.yml`)
+  - deep soak lane (`deep-validation.yml`)
+
 ## Workflow Inventory
 
 - `.github/workflows/ci.yml`
@@ -98,7 +118,7 @@ Use precise language so status and dashboards do not blur the PR gate with deepe
 | -------- | ------- |
 | **Tier1 PR gate** / **T1 fast** | `BlazeDB_Tier1Fast` only—the default blocking Tier1 lane on PRs. |
 | **Tier1 depth** | `BlazeDB_Tier1Extended` + `BlazeDB_Tier1Perf` (weekly/manual `tier1-depth.yml`, or `./Scripts/run-tier1-depth.sh`). Does *not* by itself imply `BlazeDB_Tier1Fast` ran. |
-| **Nightly confidence lane** | `nightly.yml`: Tier1 depth + `BlazeDB_Tier1FastFull` + Tier2 script + verify scripts + Tier0 TSan + Linux Tier0/Tier1Fast. |
+| **Nightly confidence lane** | `nightly.yml`: daily/manual medium-confidence lane (Tier1 depth + broader deterministic Tier1 + selected integration checks + verify scripts + sanitizer checks). |
 | **Deep validation lane** | `deep-validation.yml`: full Tier1 + Tier2 + Tier3 heavy/destructive + Tier0/Tier1Fast TSan + Linux extended lane. |
 | **Full Tier1** / **Tier1 all lanes** | `BlazeDB_Tier1Fast` + `BlazeDB_Tier1FastFull` + `BlazeDB_Tier1Extended` + `BlazeDB_Tier1Perf` (broader deterministic coverage via `BlazeDBExtraTests`). |
 


### PR DESCRIPTION
This PR is docs-only and is intentionally separate from workflow/code changes.

Changes:
- updates `Docs/Testing/CI_AND_TEST_TIERS.md` with a CI lane snapshot table and rollout status section
- clarifies current lane vocabulary, including the nightly confidence lane concept
- updates `CONTRIBUTING.md` to match current PR gate behavior (blocking macOS + Linux, verify scripts not in PR gate) and documents the broader Tier1 deterministic lane

No workflow files or test code are changed in this PR.