### PR TITLE
CI: enforce Tier2 failures in nightly lane

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -55,8 +55,8 @@ jobs:
         run: swift test --filter BlazeDB_Tier1FastFull
         working-directory: BlazeDBExtraTests
 
-      - name: Test Tier 2 integration/recovery (non-blocking lane)
-        run: ./Scripts/run-tier2.sh
+      - name: Test Tier 2 integration/recovery (strict enforcement)
+        run: ./Scripts/run-tier2.sh --strict
 
       - name: Install ripgrep (verification scripts)
         env:

--- a/Docs/Testing/CI_AND_TEST_TIERS.md
+++ b/Docs/Testing/CI_AND_TEST_TIERS.md
@@ -54,7 +54,7 @@ Use this table for day-to-day expectations.
 - Runs medium-confidence coverage:
   - `BlazeDB_Tier1Extended` + `BlazeDB_Tier1Perf`
   - `BlazeDB_Tier1FastFull` (from `BlazeDBExtraTests`)
-  - Tier2 integration/recovery via `./Scripts/run-tier2.sh` (non-blocking within nightly lane)
+  - Tier2 integration/recovery via `./Scripts/run-tier2.sh --strict` (blocking in nightly lane)
   - `verify-clean-checkout.sh` and `verify-readme-quickstart.sh`
   - ThreadSanitizer on `BlazeDB_Tier0`
   - Linux depth run: `BlazeDB_Tier0` + `BlazeDB_Tier1Fast`
@@ -103,7 +103,7 @@ Use this table for day-to-day expectations.
 - `BlazeDB_Tier2`
 - Integration and recovery scenarios.
 - **Built from nested package** `BlazeDBExtraTests/` (not part of root `swift test` graph).
-- Non-blocking lane by default.
+- Non-blocking by default in script form; enforced in nightly via strict mode.
 
 - `BlazeDB_Tier3_Heavy` / `BlazeDB_Tier3_Destructive`
 - Stress, fuzz, and destructive/fault-injection lanes.
@@ -118,7 +118,7 @@ Use precise language so status and dashboards do not blur the PR gate with deepe
 | -------- | ------- |
 | **Tier1 PR gate** / **T1 fast** | `BlazeDB_Tier1Fast` only—the default blocking Tier1 lane on PRs. |
 | **Tier1 depth** | `BlazeDB_Tier1Extended` + `BlazeDB_Tier1Perf` (weekly/manual `tier1-depth.yml`, or `./Scripts/run-tier1-depth.sh`). Does *not* by itself imply `BlazeDB_Tier1Fast` ran. |
-| **Nightly confidence lane** | `nightly.yml`: daily/manual medium-confidence lane (Tier1 depth + broader deterministic Tier1 + selected integration checks + verify scripts + sanitizer checks). |
+| **Nightly confidence lane** | `nightly.yml`: Tier1 depth + `BlazeDB_Tier1FastFull` + strict Tier2 + verify scripts + Tier0 TSan + Linux Tier0/Tier1Fast. |
 | **Deep validation lane** | `deep-validation.yml`: full Tier1 + Tier2 + Tier3 heavy/destructive + Tier0/Tier1Fast TSan + Linux extended lane. |
 | **Full Tier1** / **Tier1 all lanes** | `BlazeDB_Tier1Fast` + `BlazeDB_Tier1FastFull` + `BlazeDB_Tier1Extended` + `BlazeDB_Tier1Perf` (broader deterministic coverage via `BlazeDBExtraTests`). |
 

--- a/Scripts/run-tier2.sh
+++ b/Scripts/run-tier2.sh
@@ -1,9 +1,28 @@
 #!/bin/bash
 # Tier 2: integration and recovery workflows.
-# This lane is pre-release/nightly and remains non-blocking by default.
+# This lane is pre-release/nightly. Default behavior remains non-blocking for local/manual use.
+# Use --strict (or BLAZEDB_TIER2_STRICT=1) to make failures fail the caller workflow.
 # See Docs/Testing/TEST_EXECUTION_MODEL.md
 set -e
-echo "=== Tier 2: integration/recovery (non-blocking) ==="
+STRICT_MODE="${BLAZEDB_TIER2_STRICT:-0}"
+case "${1:-}" in
+  --strict)
+    STRICT_MODE=1
+    ;;
+  "")
+    ;;
+  *)
+    echo "ERROR: unknown argument '$1'"
+    echo "Usage: ./Scripts/run-tier2.sh [--strict]"
+    exit 2
+    ;;
+esac
+
+if [[ "$STRICT_MODE" == "1" ]]; then
+  echo "=== Tier 2: integration/recovery (strict) ==="
+else
+  echo "=== Tier 2: integration/recovery (non-blocking) ==="
+fi
 RUN_ID="$(date +%Y%m%d-%H%M%S)"
 ARTIFACT_DIR=".artifacts/integration/${RUN_ID}"
 mkdir -p "$ARTIFACT_DIR"
@@ -12,6 +31,10 @@ python3 ./Scripts/verify_execution_coverage.py --target BlazeDB_Tier2 --package-
 rc=$?
 set -e
 if [[ "$rc" -ne 0 ]]; then
+  if [[ "$STRICT_MODE" == "1" ]]; then
+    echo "  >> Tier 2 failed with exit code $rc (strict mode: failing lane)"
+    exit "$rc"
+  fi
   echo "  >> Tier 2 failed with exit code $rc (non-blocking lane)"
 fi
 echo "Tier2 artifacts: $ARTIFACT_DIR"


### PR DESCRIPTION
## Summary

- Added strict-mode support to `Scripts/run-tier2.sh` so Tier2 can be either non-blocking (default) or lane-failing (`--strict`).
- Updated `nightly.yml` to invoke Tier2 with strict enforcement (`./Scripts/run-tier2.sh --strict`).
- Updated `Docs/Testing/CI_AND_TEST_TIERS.md` to reflect Tier2 strict enforcement semantics in nightly.

## Scope

- In scope:
  - `Scripts/run-tier2.sh`
  - `.github/workflows/nightly.yml`
  - `Docs/Testing/CI_AND_TEST_TIERS.md`
- Out of scope:
  - PR gate (`ci.yml`)
  - release workflow
  - target placement changes
  - deep-validation wiring (handled separately in PR #47)

## Validation

List exact commands you ran:

python3 -c "import yaml; yaml.safe_load(open('.github/workflows/nightly.yml')); print('nightly.yml parses')"

tmpbin=$(mktemp -d)
printf '#!/bin/sh\nexit 7\n' > "$tmpbin/python3"
chmod +x "$tmpbin/python3"
PATH="$tmpbin:$PATH" ./Scripts/run-tier2.sh
rm -rf "$tmpbin"

tmpbin=$(mktemp -d)
printf '#!/bin/sh\nexit 7\n' > "$tmpbin/python3"
chmod +x "$tmpbin/python3"
PATH="$tmpbin:$PATH" ./Scripts/run-tier2.sh --strict
rm -rf "$tmpbin"

## Checklist

- [x] One branch = one concern
- [x] `git status`/`git diff` reviewed for containment
- [x] Relevant docs updated (if behavior changed)
- [x] CI checks pass
