### PR TITLE
fix: expose compression availability in API and docs

### DIFF
--- a/BlazeDB/Storage/CompressionSupport.swift
+++ b/BlazeDB/Storage/CompressionSupport.swift
@@ -8,6 +8,19 @@
 
 import Foundation
 
+extension BlazeDBClient {
+    /// Indicates whether compression APIs are compiled into this build.
+    ///
+    /// Use this to feature-detect compression support in cross-platform code.
+    public static var isCompressionAvailable: Bool {
+        #if canImport(Compression)
+        true
+        #else
+        false
+        #endif
+    }
+}
+
 #if canImport(Compression)
 import Compression
 

--- a/Docs/Design/COMPRESSION_DESIGN.md
+++ b/Docs/Design/COMPRESSION_DESIGN.md
@@ -10,6 +10,12 @@
 
 Compression in BlazeDB is a **pure performance optimization** that reduces storage and network bandwidth. It is **completely optional** and **transparent** to the application. Compression failures never corrupt data or prevent database operations.
 
+## Platform Availability
+
+- Compression currently depends on Apple's `Compression` framework.
+- Compression APIs are available on Apple platforms and compiled out on Linux.
+- Use `BlazeDBClient.isCompressionAvailable` to feature-detect support in cross-platform code before calling compression APIs.
+
 ---
 
 ## Design Principles
@@ -199,6 +205,11 @@ store.disableCompression()
 ### Field-Level Compression
 
 ```swift
+guard BlazeDBClient.isCompressionAvailable else {
+    // Linux/core-only build: skip compression setup
+    return
+}
+
 // Enable compression with custom config
 var config = CompressionConfig()
 config.algorithm =.lz4
@@ -224,7 +235,7 @@ db.disableCompression()
 ## Migration and Compatibility
 
 ### Reading Compressed Data
-- Databases with compressed pages can be read without enabling compression
+- Databases with compressed pages can be read without enabling compression (on builds where compression support exists)
 - Decompression happens automatically during read
 - Old uncompressed pages continue to work
 
@@ -232,6 +243,7 @@ db.disableCompression()
 - Compression is opt-in per database instance
 - Enabling compression does not retroactively compress existing pages
 - New pages are compressed if compression is enabled
+- Compressed pages are not portable to builds where compression support is unavailable (for example, Linux core-only deployments)
 
 ### Backup/Restore
 - Backups preserve compression state

--- a/Docs/GettingStarted/LINUX_PLATFORM_MODEL.md
+++ b/Docs/GettingStarted/LINUX_PLATFORM_MODEL.md
@@ -23,6 +23,7 @@ This document explains the feature matrix, design rationale, and explicit limita
 | **Query Builder** | | | Type-safe query construction |
 | **MVCC (Multi-Version Concurrency)** | | | Snapshot isolation, version management |
 | **Encryption (AES-256-GCM)** | | | Per-page encryption, PBKDF2/Argon2 KDF |
+| **Compression APIs** | | | Apple-only (`Compression` framework). Check `BlazeDBClient.isCompressionAvailable` before enabling compression in shared code |
 | **Backup & Restore** | | | Full database backup with metadata |
 | **Async Queries** | | | `async/await` APIs gated on Apple |
 | **SwiftUI Bindings** | | | `@BlazeQuery`, `@BlazeQueryTyped` property wrappers |
@@ -56,6 +57,7 @@ This document explains the feature matrix, design rationale, and explicit limita
 - **Certificate Pinning**: No Network.framework TLS validation (transport security is external)
 - **Biometric Authentication**: No LocalAuthentication integration (password-only key derivation)
 - **App Attest**: No Apple-specific attestation mechanisms
+- **Compression.framework**: No Apple Compression framework integration (compression APIs are compiled out)
 
 ### Transport Security on Linux
 


### PR DESCRIPTION
## Summary
- add `BlazeDBClient.isCompressionAvailable` as a cross-platform feature-detection API compiled on all platforms
- clarify compression docs that support is Apple-only today and recommend gating compression setup in shared code
- document compressed-page portability limits for builds where compression support is unavailable

## Test plan
- [x] `swift build` on Linux
- [x] review diff for API and docs alignment with issue #33

Closes #33