### PR TITLE
Fix Tier0 lane isolation for Linux CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
           swift build --target BlazeInfo
 
       - name: Test Tier 0
-        run: swift test --filter BlazeDB_Tier0
+        run: BLAZEDB_TEST_SCOPE=tier0 swift test --filter BlazeDB_Tier0
 
       - name: Test Tier 1 (fast)
         run: swift test --skip-build --filter BlazeDB_Tier1Fast
@@ -103,4 +103,4 @@ jobs:
           swift build --target BlazeInfo
 
       - name: Test Tier 0
-        run: swift test --filter BlazeDB_Tier0
+        run: BLAZEDB_TEST_SCOPE=tier0 swift test --filter BlazeDB_Tier0

--- a/Docs/Testing/CI_AND_TEST_TIERS.md
+++ b/Docs/Testing/CI_AND_TEST_TIERS.md
@@ -35,7 +35,7 @@ Use this table for day-to-day expectations.
 - Runner: `macos-15`; **does not** use `swift-actions/setup-swift` — tests run with **Xcode’s** `swift` so XCTest/`XCTestCore` resolves (OSS Swift on macOS does not).
 - `actions/cache` on `.build` (keyed by `runner.os`, `Package.swift`, `Package.resolved`)
 - `swift build --target BlazeDBCore`, CLI targets (`BlazeDoctor`, `BlazeDump`, `BlazeInfo`)
-- `swift test --filter BlazeDB_Tier0`, then `swift test --skip-build --filter BlazeDB_Tier1Fast`
+- `BLAZEDB_TEST_SCOPE=tier0 swift test --filter BlazeDB_Tier0`, then `swift test --skip-build --filter BlazeDB_Tier1Fast`
 - `verify-clean-checkout.sh` and `verify-readme-quickstart.sh` are **not** part of the blocking PR lane (they remain in-repo and move to deeper lanes)
 - **Secondary (blocking):** `Linux (Swift 6.2) — core + Tier 0`
 - Runner: `ubuntu-22.04`

--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,8 @@
 // swift-tools-version:6.0
 import PackageDescription
+import Foundation
+
+let tier0OnlyTestScope = ProcessInfo.processInfo.environment["BLAZEDB_TEST_SCOPE"]?.lowercased() == "tier0"
 
 let package = Package(
     name: "BlazeDB",
@@ -182,6 +185,7 @@ let package = Package(
             ]
         ),
 
+    ] + (tier0OnlyTestScope ? [] : [
         // Tier 1 fast: default PR/local correctness gate (no measure(), no timing-dependent waits).
         // This lane is intentionally reduced to keep PR iteration speed acceptable.
         .testTarget(
@@ -242,7 +246,8 @@ let package = Package(
                 .define("BLAZEDB_CORE_ONLY"),
                 .define("BLAZEDB_LINUX_CORE", .when(platforms: [.linux, .android]))
             ]
-        ),
+        )
+    ]) + [
         // Tier 2 / Tier 3 heavy+destructive / DistributedSecurity SPM harness live under
         // BlazeDBExtraTests/ (separate package) so root `swift test` does not compile them.
         .testTarget(

--- a/Scripts/oss-readiness-local.sh
+++ b/Scripts/oss-readiness-local.sh
@@ -26,7 +26,7 @@ run_step() {
 echo "=== BlazeDB OSS readiness local check ==="
 run_step "Step 1/4: swift build" swift build
 
-run_step "Step 2/4: Tier 0 gate" swift test --filter BlazeDB_Tier0
+run_step "Step 2/4: Tier 0 gate" env BLAZEDB_TEST_SCOPE=tier0 swift test --filter BlazeDB_Tier0
 
 run_step "Step 3/4: Tier 1 fast gate" swift test --skip-build --filter BlazeDB_Tier1Fast
 

--- a/Scripts/run-tier1-strict.sh
+++ b/Scripts/run-tier1-strict.sh
@@ -13,6 +13,6 @@ if [ -n "${TEST_SLOW_CONCURRENCY}" ] && [ "${TEST_SLOW_CONCURRENCY}" != "0" ]; t
   exit 1
 fi
 
-swift test --filter BlazeDB_Tier0 || exit 1
+env BLAZEDB_TEST_SCOPE=tier0 swift test --filter BlazeDB_Tier0 || exit 1
 swift test --filter BlazeDB_Tier1Fast || exit 1
 echo "=== Tier 1 (strict) complete ==="

--- a/Scripts/verify_execution_coverage.py
+++ b/Scripts/verify_execution_coverage.py
@@ -21,8 +21,8 @@ from pathlib import Path
 TEST_ID_RE = re.compile(r"^([A-Za-z0-9_]+)\.([A-Za-z0-9_]+)/([A-Za-z0-9_]+)$")
 
 
-def run(cmd: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(cmd, cwd=str(cwd), capture_output=True, text=True, check=False)
+def run(cmd: list[str], cwd: Path, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, cwd=str(cwd), capture_output=True, text=True, check=False, env=env)
 
 
 def parse_discovered(text: str, target: str) -> set[str]:
@@ -96,7 +96,10 @@ def main() -> int:
         "--xunit-output",
         str(xunit_path),
     ]
-    run_proc = run(run_cmd, pkg_root)
+    run_env = os.environ.copy()
+    if args.target == "BlazeDB_Tier0":
+        run_env["BLAZEDB_TEST_SCOPE"] = "tier0"
+    run_proc = run(run_cmd, pkg_root, env=run_env)
 
     executed = parse_executed_from_xunit(xunit_path)
     missing = sorted(discovered - executed)


### PR DESCRIPTION
## Summary
- add `BLAZEDB_TEST_SCOPE=tier0` execution mode in `Package.swift` that omits Tier1 test targets from the graph
- update CI and Tier0/Tier1 gate scripts to run Tier0 with scoped graph isolation
- wire execution coverage script to set tier0 scope automatically when validating `BlazeDB_Tier0`

## Validation
- Reproduced current issue: `swift test --filter BlazeDB_Tier0` compiled Tier1 files and emitted Linux Darwin-API failures from Tier1 (including `BlazePaginationTests` Mach/autoreleasepool symbols)
- Verified fix path: `BLAZEDB_TEST_SCOPE=tier0 swift test list` now discovers only `BlazeDB_Tier0` (+ `BlazeDB_Staging`) with no Tier1 targets in the graph
- Confirmed branch diff is scoped to CI/test-lane isolation files only

Closes #53