### PR TITLE
fix: resolve Tier1Fast Linux functional mismatches (C/D)

### DIFF
--- a/BlazeDB/Query/QueryBuilder+Explain.swift
+++ b/BlazeDB/Query/QueryBuilder+Explain.swift
@@ -94,7 +94,12 @@ extension QueryBuilder {
         let riskLevel: QueryExplanation.RiskLevel
         let suggestion: String
         
-        if filterFields.isEmpty {
+        if filterFields.isEmpty && !filters.isEmpty {
+            // Some builds cannot introspect filter fields (for example reduced Linux-core paths).
+            // Preserve explainability semantics by reporting unknown risk instead of "OK".
+            riskLevel = .unknown
+            suggestion = "Filter fields could not be inferred in this build. Use explain() for a detailed plan."
+        } else if filterFields.isEmpty {
             riskLevel = .ok
             suggestion = "Query has no filters - will scan all records."
         } else if indexedFields.isEmpty {

--- a/BlazeDBTests/Tier1Core/Security/EncryptionRoundTripVerificationTests.swift
+++ b/BlazeDBTests/Tier1Core/Security/EncryptionRoundTripVerificationTests.swift
@@ -295,7 +295,8 @@ final class EncryptionRoundTripVerificationTests: XCTestCase {
             let description = String(describing: error)
             XCTAssertTrue(error.localizedDescription.contains("authentication") ||
                          error.localizedDescription.contains("corrupt") ||
-                         description.contains("authenticationFailure"),
+                         description.contains("authenticationFailure") ||
+                         description.contains("underlyingCoreCryptoError"),
                          "Should detect corruption, got: \(error)")
         }
     }


### PR DESCRIPTION
## Summary
- return .unknown explain risk when filters exist but filter-field introspection is unavailable
- accept Linux corecrypto corruption error wrapper in corruption-detection assertion

## Validation
- swift test --filter 'DXQueryExplainTests.testExplain_WarnsForUnindexedFilter'
- swift test --filter 'EncryptionRoundTripVerificationTests.testDetectFileCorruption'
