### PR TITLE
Fix silent page-0 overwrite on next page stat failure

### DIFF
--- a/BlazeDB/Core/MVCC/MVCCTransaction.swift
+++ b/BlazeDB/Core/MVCC/MVCCTransaction.swift
@@ -171,7 +171,7 @@ public class MVCCTransaction {
         // MVCC versions store the main page number. Large records may spill into
         // overflow pages, so use the overflow-aware writer here just like the
         // legacy insert path does.
-        var nextNewPage = pageStore.nextAvailablePageIndex()
+        var nextNewPage = try pageStore.nextAvailablePageIndex()
         let pageNumber: Int
         if let freePage = versionManager.pageGC.getFreePage() {
             pageNumber = freePage

--- a/BlazeDB/Storage/PageStore.swift
+++ b/BlazeDB/Storage/PageStore.swift
@@ -1012,18 +1012,13 @@ public final class PageStore: @unchecked Sendable {
     
     /// Get the next available page index for MVCC
     /// This calculates based on current file size
-    public func nextAvailablePageIndex() -> Int {
+    public func nextAvailablePageIndex() throws -> Int {
         #if DEBUG
         dispatchPrecondition(condition: .notOnQueue(queue))
         #endif
-        return queue.sync {
-            do {
-                let currentSize = try self.fileSize()
-                return currentSize / pageSize
-            } catch {
-                BlazeLogger.error("pageCount(): failed to stat file — returning 0: \(error)")
-                return 0
-            }
+        return try queue.sync {
+            let currentSize = try self.fileSize()
+            return currentSize / pageSize
         }
     }
     

--- a/BlazeDBTests/Tier0Core/Durability/PageStoreUnifiedWALTests.swift
+++ b/BlazeDBTests/Tier0Core/Durability/PageStoreUnifiedWALTests.swift
@@ -210,4 +210,16 @@ final class PageStoreUnifiedWALTests: XCTestCase {
 
         store.close()
     }
+
+    func testNextAvailablePageIndexThrowsOnStatFailure() throws {
+        let dbURL = tempDir.appendingPathComponent("test-next-index-failure.db")
+        let store = try PageStore(fileURL: dbURL, key: testKey, walMode: .unified)
+        try store.writePage(index: 0, plaintext: Data(repeating: 0x11, count: 64))
+
+        // Closing invalidates the backing file descriptor; nextAvailablePageIndex
+        // must surface the failure instead of returning page index 0.
+        store.close()
+
+        XCTAssertThrowsError(try store.nextAvailablePageIndex())
+    }
 }


### PR DESCRIPTION
## Summary
- change `PageStore.nextAvailablePageIndex()` to throw instead of swallowing `fstat` failures and returning `0`
- propagate that error through the MVCC write path (`MVCCTransaction.write`) so allocation failures abort the transaction instead of targeting page 0
- add Tier0 regression coverage asserting `nextAvailablePageIndex()` throws when the underlying descriptor stat path fails

## Why this fixes #36
`nextAvailablePageIndex()` previously converted stat failures into a valid-looking page index (`0`).
MVCC used that value as a writable page number, which could overwrite the first record.
With this change, stat failures are surfaced as errors, so callers cannot silently write to page 0 on allocation failure.

## Validation
- `swift build --target BlazeDBCore` ✅
- `swift test --filter BlazeDB_Tier0.PageStoreUnifiedWALTests/testNextAvailablePageIndexThrowsOnStatFailure` currently blocked in this environment by existing test-graph/toolchain instability (`error: fatalError`) while compiling unrelated Tier1 suites before the filtered test executes
- regression test added: `PageStoreUnifiedWALTests.testNextAvailablePageIndexThrowsOnStatFailure`

Closes #36