### PR TITLE
Retire legacy overflow pointer heuristic behind explicit compatibility mode

### DIFF
--- a/BlazeDB/Storage/PageStore+Overflow.swift
+++ b/BlazeDB/Storage/PageStore+Overflow.swift
@@ -580,7 +580,11 @@ extension PageStore {
             // IMPORTANT: Only check for overflow if the data is exactly maxDataPerPage AND
             // the potential pointer points to a valid overflow page (has "OVER" magic bytes)
             BlazeLogger.debug("📖 [readPageWithOverflow] Main page data size: \(mainPageData.count), maxDataPerPage: \(maxDataPerPage)")
-            if currentOverflowIndex == 0 && mainPageData.count == maxDataPerPage && mainPageData.count >= 4 {
+            if currentOverflowIndex == 0
+                && legacyOverflowPointerHeuristicCompatibilityMode
+                && mainPageData.count == maxDataPerPage
+                && mainPageData.count >= 4
+            {
                 usingLegacyOverflowReference = true
                 BlazeLogger.debug("📖 [readPageWithOverflow] Main page is exactly maxDataPerPage, checking for overflow pointer")
                 // Extract potential overflow pointer from last 4 bytes
@@ -868,7 +872,7 @@ extension PageStore {
                 }
             }
 
-            // Legacy heuristic path remains read-compatible only.
+            // Legacy heuristic path is compatibility-mode only.
             if usingLegacyOverflowReference {
                 BlazeLogger.trace("📖 [readPageWithOverflow] Legacy overflow heuristic path used for page \(index)")
             }
@@ -1068,6 +1072,9 @@ extension PageStore {
     /// Get overflow page index from main page
     /// Uses heuristic: if main page data is exactly maxDataPerPage, check if next page is overflow
     private func _getOverflowPageIndex(from mainPageIndex: Int) throws -> UInt32 {
+        guard legacyOverflowPointerHeuristicCompatibilityMode else {
+            return 0
+        }
         // Read main page to check its size
         guard let mainPageData = try readPage(index: mainPageIndex) else {
             return 0
@@ -1177,6 +1184,7 @@ extension PageStore {
             expectedChecksum = ref.payloadChecksum
             expectedPageCount = Int(ref.chainPageCount)
         } else {
+            guard legacyOverflowPointerHeuristicCompatibilityMode else { return .valid }
             let hasPointer = mainData.count == maxDataPerPage && mainData.count >= 4
             guard hasPointer else { return .valid }
             let offset = mainData.count - 4
@@ -1260,7 +1268,7 @@ extension PageStore {
             var pointer: UInt32 = 0
             if let ref = OverflowReferenceV2.decodeIfPresent(from: main, maxDataPerPage: maxDataPerPage) {
                 pointer = ref.firstOverflowPageIndex
-            } else if main.count == maxDataPerPage, main.count >= 4 {
+            } else if legacyOverflowPointerHeuristicCompatibilityMode, main.count == maxDataPerPage, main.count >= 4 {
                 let offset = main.count - 4
                 pointer = (UInt32(main[offset]) << 24)
                     | (UInt32(main[offset + 1]) << 16)

--- a/BlazeDB/Storage/PageStore.swift
+++ b/BlazeDB/Storage/PageStore.swift
@@ -127,6 +127,7 @@ public final class PageStore: @unchecked Sendable {
     internal var knownCorruptedOverflowMainPages: Set<Int> = []
     internal var overflowCorruptionIncidentCount: Int = 0
     internal var overflowReadDegradedMode: Bool = false
+    internal let legacyOverflowPointerHeuristicCompatibilityMode: Bool
     private var isLocked: Bool = false  // Track lock state for cleanup
     private var closed: Bool = false
 
@@ -212,10 +213,18 @@ public final class PageStore: @unchecked Sendable {
     }
     #endif
 
-    public init(fileURL: URL, key: SymmetricKey, enableWAL: Bool = true, walMode: WALMode = .legacy) throws {
+    public init(
+        fileURL: URL,
+        key: SymmetricKey,
+        enableWAL: Bool = true,
+        walMode: WALMode = .legacy,
+        enableLegacyOverflowPointerHeuristicCompatibilityMode: Bool = false
+    ) throws {
         self.fileURL = fileURL
         self.walEnabled = enableWAL
         self.walMode = walMode
+        let envCompatEnabled = ProcessInfo.processInfo.environment["BLAZEDB_ENABLE_LEGACY_OVERFLOW_POINTER_HEURISTIC"] == "1"
+        self.legacyOverflowPointerHeuristicCompatibilityMode = enableLegacyOverflowPointerHeuristicCompatibilityMode || envCompatEnabled
         IOTraceSink.record(operation: "open_begin", path: fileURL.path)
 
         // Validate key size for AES-GCM

--- a/BlazeDBTests/Tier1Core/Persistence/OverflowChainCrashAtomicityTests.swift
+++ b/BlazeDBTests/Tier1Core/Persistence/OverflowChainCrashAtomicityTests.swift
@@ -124,6 +124,108 @@ final class OverflowChainCrashAtomicityTests: XCTestCase {
         XCTAssertFalse(orphans.isEmpty, "Expected unreachable overflow pages to be detected")
     }
 
+    func testLegacyOverflowHeuristic_IsCompatibilityModeOnly() throws {
+        let dbURL = try requireFixture(tempURL)
+        let key = SymmetricKey(size: .bits256)
+        let storeDefault = try PageStore(fileURL: dbURL, key: key)
+
+        var nextPage = 1
+        _ = try storeDefault.writePageWithOverflow(index: 0, plaintext: deterministicData(size: 20_000, seed: 0xC1)) {
+            defer { nextPage += 1 }
+            return nextPage
+        }
+
+        var legacyMain = try XCTUnwrap(storeDefault.readPage(index: 0))
+        let firstOverflow = try parseFirstOverflowIndexFromV2Trailer(legacyMain)
+        try rewriteMainPageAsLegacyPointer(mainPageData: &legacyMain, firstOverflowIndex: firstOverflow)
+        try storeDefault.writePage(index: 0, plaintext: legacyMain)
+        storeDefault.close()
+
+        let storeReadDefault = try PageStore(fileURL: dbURL, key: key)
+        let readDefault = try storeReadDefault.readPageWithOverflow(index: 0)
+        storeReadDefault.close()
+        XCTAssertEqual(readDefault, legacyMain, "Default mode should not traverse legacy overflow pointer heuristic")
+
+        let storeCompat = try PageStore(
+            fileURL: dbURL,
+            key: key,
+            enableLegacyOverflowPointerHeuristicCompatibilityMode: true
+        )
+        let readCompat = try XCTUnwrap(storeCompat.readPageWithOverflow(index: 0))
+        XCTAssertGreaterThan(readCompat.count, legacyMain.count, "Compatibility mode should traverse legacy overflow chain")
+    }
+
+    func testValidateOverflowChain_V2_MissingAndCircular() throws {
+        let storeMissing = try PageStore(fileURL: try requireFixture(tempURL), key: SymmetricKey(size: .bits256))
+        var nextMissing = 1
+        let missingIndices = try storeMissing.writePageWithOverflow(index: 0, plaintext: deterministicData(size: 20_000, seed: 0x71)) {
+            defer { nextMissing += 1 }
+            return nextMissing
+        }
+        XCTAssertGreaterThan(missingIndices.count, 2)
+        try storeMissing.deletePage(index: missingIndices[1])
+        if case .truncatedChain = storeMissing.validateOverflowChain(rootPageID: 0) {
+            // expected
+        } else {
+            XCTFail("Expected v2 missing-page validation failure")
+        }
+
+        let cycleURL = dbURL(named: "overflow-v2-cycle")
+        let storeCycle = try PageStore(fileURL: cycleURL, key: SymmetricKey(size: .bits256))
+        var nextCycle = 1
+        let cycleIndices = try storeCycle.writePageWithOverflow(index: 0, plaintext: deterministicData(size: 20_000, seed: 0x72)) {
+            defer { nextCycle += 1 }
+            return nextCycle
+        }
+        XCTAssertGreaterThan(cycleIndices.count, 2)
+        try overwriteOverflowNextPointer(fileURL: cycleURL, pageIndex: cycleIndices[1], nextPageIndex: UInt32(cycleIndices[1]))
+        XCTAssertEqual(storeCycle.validateOverflowChain(rootPageID: 0), .cycleDetected(cycleIndices[1]))
+    }
+
+    func testValidateOverflowChain_Legacy_MissingAndCircular_WithCompatibilityMode() throws {
+        let key = SymmetricKey(size: .bits256)
+
+        let missingURL = dbURL(named: "overflow-legacy-missing")
+        let storeLegacyMissing = try PageStore(
+            fileURL: missingURL,
+            key: key,
+            enableLegacyOverflowPointerHeuristicCompatibilityMode: true
+        )
+        var nextMissing = 1
+        let missingIndices = try storeLegacyMissing.writePageWithOverflow(index: 0, plaintext: deterministicData(size: 20_000, seed: 0x81)) {
+            defer { nextMissing += 1 }
+            return nextMissing
+        }
+        var legacyMainMissing = try XCTUnwrap(storeLegacyMissing.readPage(index: 0))
+        let firstMissing = try parseFirstOverflowIndexFromV2Trailer(legacyMainMissing)
+        try rewriteMainPageAsLegacyPointer(mainPageData: &legacyMainMissing, firstOverflowIndex: firstMissing)
+        try storeLegacyMissing.writePage(index: 0, plaintext: legacyMainMissing)
+        try storeLegacyMissing.deletePage(index: missingIndices[1])
+        if case .truncatedChain = storeLegacyMissing.validateOverflowChain(rootPageID: 0) {
+            // expected
+        } else {
+            XCTFail("Expected legacy missing-page validation failure")
+        }
+
+        let cycleURL = dbURL(named: "overflow-legacy-cycle")
+        let storeLegacyCycle = try PageStore(
+            fileURL: cycleURL,
+            key: key,
+            enableLegacyOverflowPointerHeuristicCompatibilityMode: true
+        )
+        var nextCycle = 1
+        let cycleIndices = try storeLegacyCycle.writePageWithOverflow(index: 0, plaintext: deterministicData(size: 20_000, seed: 0x82)) {
+            defer { nextCycle += 1 }
+            return nextCycle
+        }
+        var legacyMainCycle = try XCTUnwrap(storeLegacyCycle.readPage(index: 0))
+        let firstCycle = try parseFirstOverflowIndexFromV2Trailer(legacyMainCycle)
+        try rewriteMainPageAsLegacyPointer(mainPageData: &legacyMainCycle, firstOverflowIndex: firstCycle)
+        try storeLegacyCycle.writePage(index: 0, plaintext: legacyMainCycle)
+        try overwriteOverflowNextPointer(fileURL: cycleURL, pageIndex: cycleIndices[1], nextPageIndex: UInt32(cycleIndices[1]))
+        XCTAssertEqual(storeLegacyCycle.validateOverflowChain(rootPageID: 0), .cycleDetected(cycleIndices[1]))
+    }
+
     // Child-only test entrypoint used by parent Process harness.
     func testChildOverflowCrashWriter() throws {
         guard ProcessInfo.processInfo.environment["BLAZEDB_OVERFLOW_CHILD"] == "1" else { return }
@@ -210,5 +312,49 @@ final class OverflowChainCrashAtomicityTests: XCTestCase {
             bytes.append(value)
         }
         return Data(bytes)
+    }
+
+    private func dbURL(named suffix: String) -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("OverflowAtomicity-\(suffix)-\(UUID().uuidString)")
+            .appendingPathExtension("blazedb")
+    }
+
+    private func parseFirstOverflowIndexFromV2Trailer(_ mainPageData: Data) throws -> UInt32 {
+        let trailerSize = 32
+        guard mainPageData.count >= trailerSize else {
+            throw NSError(domain: "OverflowTests", code: 1, userInfo: [NSLocalizedDescriptionKey: "main page too short for v2 trailer"])
+        }
+        let start = mainPageData.count - trailerSize
+        return (UInt32(mainPageData[start + 8]) << 24)
+            | (UInt32(mainPageData[start + 9]) << 16)
+            | (UInt32(mainPageData[start + 10]) << 8)
+            | UInt32(mainPageData[start + 11])
+    }
+
+    private func rewriteMainPageAsLegacyPointer(mainPageData: inout Data, firstOverflowIndex: UInt32) throws {
+        let trailerSize = 32
+        guard mainPageData.count >= trailerSize else {
+            throw NSError(domain: "OverflowTests", code: 2, userInfo: [NSLocalizedDescriptionKey: "main page too short for legacy rewrite"])
+        }
+        let trailerStart = mainPageData.count - trailerSize
+        mainPageData.replaceSubrange(trailerStart..<(trailerStart + 4), with: [0, 0, 0, 0]) // disable v2 magic
+        let pointerOffset = mainPageData.count - 4
+        let bytes: [UInt8] = [
+            UInt8((firstOverflowIndex >> 24) & 0xff),
+            UInt8((firstOverflowIndex >> 16) & 0xff),
+            UInt8((firstOverflowIndex >> 8) & 0xff),
+            UInt8(firstOverflowIndex & 0xff)
+        ]
+        mainPageData.replaceSubrange(pointerOffset..<mainPageData.count, with: bytes)
+    }
+
+    private func overwriteOverflowNextPointer(fileURL: URL, pageIndex: Int, nextPageIndex: UInt32) throws {
+        let fileHandle = try FileHandle(forUpdating: fileURL)
+        defer { try? fileHandle.close() }
+        let pageOffset = UInt64(pageIndex * 4096)
+        try fileHandle.seek(toOffset: pageOffset + 8)
+        var nextBE = nextPageIndex.bigEndian
+        try fileHandle.write(contentsOf: Data(bytes: &nextBE, count: 4))
     }
 }

--- a/Docs/Features/OVERFLOW_PAGES_IMPLEMENTATION.md
+++ b/Docs/Features/OVERFLOW_PAGES_IMPLEMENTATION.md
@@ -15,6 +15,18 @@
 - Need to modify page header to store overflow pointer
 - Integration with `DynamicCollection` write path
 
+## Legacy Overflow Pointer Compatibility Mode
+
+Legacy overflow-pointer heuristic traversal is no longer part of the default read contract.
+
+- **Default behavior:** v2 overflow reference trailer (`OVR2`) is authoritative.
+- **Compatibility mode:** legacy heuristic traversal is only enabled when `PageStore` is opened with:
+  - `enableLegacyOverflowPointerHeuristicCompatibilityMode: true`, or
+  - environment override `BLAZEDB_ENABLE_LEGACY_OVERFLOW_POINTER_HEURISTIC=1`.
+- **Intended use:** migration/backfill readers for legacy pages that predate v2 trailers.
+
+This keeps backward compatibility available while reducing default read ambiguity and corruption-prone branch surface.
+
 ---
 
 ## **How It Works**


### PR DESCRIPTION
## Summary
- keep v2 overflow trailer traversal as the default/authoritative read contract
- gate legacy 4-byte overflow-pointer heuristic traversal behind explicit compatibility mode (`enableLegacyOverflowPointerHeuristicCompatibilityMode` or `BLAZEDB_ENABLE_LEGACY_OVERFLOW_POINTER_HEURISTIC=1`)
- apply the same compatibility gate to `validateOverflowChain` and orphan scan traversal paths so legacy heuristic behavior is migration-only
- add Tier1 overflow corruption coverage for missing/circular chains in both v2 and legacy-compat modes
- document the compatibility mode in overflow feature docs

## Why this issue is real
`readPageWithOverflow` currently falls back to legacy pointer heuristic whenever page payload is `maxDataPerPage` and no v2 trailer is detected. That branch is active by default and expands corruption-prone traversal surface. This PR makes that path opt-in only.

## Validation
- `swift build --target BlazeDBCore` ✅
- targeted overflow test invocation in this environment still compiles unrelated test graphs and is unstable (`swift test --filter OverflowChainCrashAtomicityTests/testLegacyOverflowHeuristic_IsCompatibilityModeOnly` ended with non-deterministic harness failure), but new Tier1 tests are included and will execute in CI:
  - `testLegacyOverflowHeuristic_IsCompatibilityModeOnly`
  - `testValidateOverflowChain_V2_MissingAndCircular`
  - `testValidateOverflowChain_Legacy_MissingAndCircular_WithCompatibilityMode`

Closes #56