### PR TITLE
Fix legacy WAL page-index UInt32 trap with bounds checks

### DIFF
--- a/BlazeDB/Storage/WriteAheadLog.swift
+++ b/BlazeDB/Storage/WriteAheadLog.swift
@@ -94,6 +94,11 @@ internal final class WriteAheadLog: @unchecked Sendable {
                 NSLocalizedDescriptionKey: "WAL file not open"
             ])
         }
+        guard pageIndex >= 0, pageIndex <= Int(UInt32.max) else {
+            throw NSError(domain: "WriteAheadLog", code: -1, userInfo: [
+                NSLocalizedDescriptionKey: "Page index \(pageIndex) out of UInt32 range"
+            ])
+        }
 
         // Build header
         var header = Data(capacity: walEntryHeaderSize)

--- a/BlazeDBTests/Tier0Core/Durability/WriteAheadLogBoundsTests.swift
+++ b/BlazeDBTests/Tier0Core/Durability/WriteAheadLogBoundsTests.swift
@@ -1,0 +1,39 @@
+import Foundation
+import XCTest
+@testable import BlazeDBCore
+
+final class WriteAheadLogBoundsTests: XCTestCase {
+    private var tempDir: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wal-bounds-tests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        if let dir = tempDir {
+            try? FileManager.default.removeItem(at: dir)
+        }
+        tempDir = nil
+        try super.tearDownWithError()
+    }
+
+    func testAppendRejectsNegativePageIndex() throws {
+        let walURL = tempDir.appendingPathComponent("negative-index.wal")
+        let wal = try WriteAheadLog(logURL: walURL)
+        defer { wal.close() }
+
+        XCTAssertThrowsError(try wal.append(pageIndex: -1, data: Data(repeating: 0xAA, count: 16)))
+    }
+
+    func testAppendRejectsPageIndexAboveUInt32Max() throws {
+        let walURL = tempDir.appendingPathComponent("large-index.wal")
+        let wal = try WriteAheadLog(logURL: walURL)
+        defer { wal.close() }
+
+        let tooLarge = Int(UInt32.max) + 1
+        XCTAssertThrowsError(try wal.append(pageIndex: tooLarge, data: Data(repeating: 0xBB, count: 16)))
+    }
+}


### PR DESCRIPTION
## Summary
- add explicit page-index bounds validation in `WriteAheadLog.append(pageIndex:data:)` before converting `Int` -> `UInt32`
- return a catchable error for negative and out-of-range page indices instead of triggering a runtime trap
- add Tier0 regression tests in `WriteAheadLogBoundsTests` for:
  - negative page index
  - index greater than `UInt32.max`

## Why this issue is real
The legacy WAL path directly used `UInt32(pageIndex)`, which traps for negative or out-of-range `Int` values. Unified WAL already had explicit guard checks; legacy WAL did not.

## Validation
- `swift build --target BlazeDBCore` ✅
- `swift test --filter WriteAheadLogBoundsTests` in this environment currently suffers from broad test-graph/toolchain instability and hangs compiling unrelated suites before deterministic completion; regression tests are included and should execute in CI Tier0 lane

Closes #38