### PR TITLE
docs: rewrite README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ An encrypted, embedded document database for Swift. Single-process, zero externa
 - **Not per-type table storage.** All record types coexist in a single encrypted collection.
 - **Not distributed sync.** Sync infrastructure exists in source but is deferred and excluded from the default runtime.
 
-### Choose your path
+### API tiers
 
-| If you want... | Use... |
-|----------------|--------|
-| The easiest typed path | `BlazeStorable` + `db.typed(T.self)` → `TypedStore` |
-| Dynamic or untyped schemas | `BlazeDataRecord` + `db.insert(record)` |
-| Manual storage mapping or SwiftUI typed query wrappers | `BlazeDocument` (required for `@BlazeQueryTyped`) |
+| Tier | API | Use case |
+|------|-----|----------|
+| **Typed (recommended)** | `BlazeStorable` + `db.typed(T.self)` | Codable models, KeyPath queries |
+| **Raw** | `BlazeDataRecord` + `db.insert(record)` | Dynamic schemas, migrations |
+| **Manual mapping** | `BlazeDocument` | Custom storage control, `@BlazeQueryTyped` |
 
 ---
 


### PR DESCRIPTION
## Summary

- **What changed?** Full rewrite of `README.md` grounded in the actual codebase, Package.swift, and tests.
- **Why was it needed?** The previous README was stale (version 2.7.2 when repo is at 2.7.3), contained the `BlazeStorable` vs `BlazeDocument` footgun (users following the SwiftUI example would hit a compile error), front-loaded storage engine internals before basic API usage, made unverifiable performance claims, and hid critical architectural truths (single-collection model, single-process constraint). The shipped-core vs deferred boundaries were unclear — relates to #58.

## Scope

- In scope:
  - `README.md` — full rewrite with verified-only claims, onboarding-first structure, honest limitations, three-tier feature classification (available/advanced, present-but-not-stable, deferred) aligned to Package.swift
- Out of scope:
  - No code changes. No changes to `Package.swift`, source files, tests, or other docs.
  - HelloBlazeDB example alignment (tracked separately — HelloBlazeDB uses `open(at:)` while README uses `open(named:)`, both are valid APIs)
  - Canonical shipped-core contract doc (#58 full scope — this PR addresses the README portion only)

## Validation

```bash
# Verified README links resolve to existing files
ls Examples/HelloBlazeDB/main.swift
ls Docs/GettingStarted/HOW_TO_USE_BLAZEDB.md
ls Docs/GettingStarted/README.md
ls Docs/API/API_REFERENCE.md
ls Docs/COMPATIBILITY.md
ls Docs/Status/DURABILITY_MODE_SUPPORT.md
ls Docs/Status/DISTRIBUTED_TRANSPORT_DEFERRED.md
ls CONTRIBUTING.md CODE_OF_CONDUCT.md SECURITY.md THIRD_PARTY_NOTICES.md LICENSE

# Verified version claim
git tag | sort -V | tail -1  # v2.7.3

# Verified Package.swift platform declarations match README table
head -12 Package.swift

# Confirmed BlazeQueryTyped requires BlazeDocument (not BlazeStorable)
grep 'BlazeQueryTyped<T:' BlazeDB/SwiftUI/BlazeQueryTyped.swift
# -> public struct BlazeQueryTyped<T: BlazeDocument>: DynamicProperty
```

## Checklist

- [x] One branch = one concern
- [x] `git status`/`git diff` reviewed for containment
- [x] Relevant docs updated (if behavior changed)
- [ ] CI checks pass (docs-only change, no code affected)