### PR TITLE
fix(core): unique validation snapshot; nightly macOS timeout; CI triage doc

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,7 +19,8 @@ jobs:
   nightly-macos-confidence:
     name: macOS 15 — Tier1 depth + Tier1FastFull + Tier2 + verify scripts
     runs-on: macos-15
-    timeout-minutes: 360
+    # Tier1 extended + perf + FastFull + Tier2 + verify can approach multi-hour wall times on hosted runners.
+    timeout-minutes: 480
 
     steps:
       - name: Checkout

--- a/BlazeDB/Core/UniqueConstraints.swift
+++ b/BlazeDB/Core/UniqueConstraints.swift
@@ -58,8 +58,17 @@ public class UniqueConstraintManager {
     
     /// Validate unique constraint before insert
     public func validateUnique(collection: DynamicCollection, record: BlazeDataRecord, excludeId: UUID? = nil) throws {
+        // Snapshot configuration under lock so validation does not iterate the sets while another
+        // thread mutates them (TSan: concurrent read/write on Set storage).
+        let fieldsSnapshot: Set<String>
+        let compoundSnapshot: Set<String>
+        lock.lock()
+        fieldsSnapshot = uniqueFields
+        compoundSnapshot = uniqueCompoundFields
+        lock.unlock()
+
         // Check single-field unique constraints
-        for field in uniqueFields {
+        for field in fieldsSnapshot {
             guard let value = record.storage[field] else { continue }
             
             // Check if another record has this value
@@ -83,7 +92,7 @@ public class UniqueConstraintManager {
         }
         
         // Check compound unique constraints
-        for compoundKey in uniqueCompoundFields {
+        for compoundKey in compoundSnapshot {
             let fields = compoundKey.components(separatedBy: "+")
             guard fields.allSatisfy({ record.storage[$0] != nil }) else { continue }
             

--- a/Docs/Testing/CI_AND_TEST_TIERS.md
+++ b/Docs/Testing/CI_AND_TEST_TIERS.md
@@ -171,6 +171,28 @@ All other `Tier1Core` directories and files (Aggregation, API, Query, Integratio
 - `./Scripts/run-tier2.sh`
 - `./Scripts/run-tier3.sh`
 
+## Interpreting CI failures (first artifact, not last passer)
+
+The **last passing test** in the log only identifies the **next execution candidate**, not necessarily the **root cause**. Sanitizer runs, worker death, and infra limits often make the “last green” line a red herring.
+
+**Default hypothesis order for late failures when Tier0 Thread Sanitizer is currently green**
+
+1. Real XCTest failure (assertion or thrown error with test context)
+2. Order or shared-state contamination (parallel workers, globals, shared paths)
+3. Late runtime or infra failure (timeout, SIGKILL, OOM, runner cancellation)
+4. Sanitizer output — **only** when the **first** failing artifact is actually a sanitizer report (do not infer sanitizer from “we fixed a race once”)
+
+Tier0 TSan being green does **not** prove there are no races anywhere, no sanitizer-only issues in other lanes, or no parallelism-dependent failures. It **does** mean you should not treat an older, fixed failure class (for example associated-object lazy-init races) as the automatic explanation for every later failure without matching log evidence.
+
+**Buckets collapse only on the first failing artifact**, for example: first `XCTAssert…` line, first thrown error with test context, first TSan report block, first timeout or kill line, or first cancellation/OOM signal.
+
+**Quick checklist when triaging**
+
+- What is the **first** failing artifact (assertion, throw, timeout, kill, cancellation, sanitizer)?
+- Was the failure **early**, **mid-run**, or **late**?
+- Is Tier0 TSan green on the branch?
+- Is the suspect test the **named failing test**, or merely the **next execution candidate** after an unrelated last pass?
+
 ## Nightly Triage Policy
 
 - Nightly failures are treated as real work and triaged within **24–48 hours**.


### PR DESCRIPTION
## Summary
- **Unique constraints:** `validateUnique` copies `uniqueFields` / `uniqueCompoundFields` under the same lock used for mutation, then validates from those snapshots so validation does not iterate collections another thread may be updating.
- **Docs:** Add **Interpreting CI failures (first artifact, not last passer)** to `Docs/Testing/CI_AND_TEST_TIERS.md` (execution candidate vs root cause, hypothesis order).
- **CI:** Increase `nightly-macos-confidence` job `timeout-minutes` from **360 → 480** (Tier1 depth + Tier1FastFull + Tier2 + verify scripts on hosted runners). Complements #105 (Linux nightly depth timeout).

## Verification
- Local: `swift package resolve` in `BlazeDBExtraTests`; `swift build --target BlazeDBCore` — OK.
- Full Tier1/Tier2 suites not re-run here.