### PR TITLE
ci(nightly): split confidence workflow into isolated jobs

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -20,3 +20,19 @@ Manual only: legacy `v*` tag release builds. Not run on push.
 ## `release.yml`
 
 Tag `v*` releases.
+
+## `nightly.yml`
+
+Daily (`schedule`) + manual (`workflow_dispatch`) nightly confidence workflow with **failure-domain isolation**.
+
+Jobs:
+
+- `macOS 15 — Tier1 depth`
+- `macOS 15 — Tier1FastFull (extra package)`
+- `macOS 15 — Tier2 strict`
+- `macOS 15 — clean-checkout verification`
+- `macOS 15 — README quickstart verification`
+- `macOS 15 — Tier0 ThreadSanitizer`
+- `Linux (Swift 6.2) — Tier0 + Tier1Fast`
+
+This split keeps nightly rerunnable by concern and avoids bundling Tier2/verify/docs into one giant macOS job.

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,11 +16,74 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
-  nightly-macos-confidence:
-    name: macOS 15 — Tier1 depth + Tier1FastFull + Tier2 + verify scripts
+  nightly-macos-tier1-depth:
+    name: macOS 15 — Tier1 depth
     runs-on: macos-15
-    # Tier1 extended + perf + FastFull + Tier2 + verify can approach multi-hour wall times on hosted runners.
-    timeout-minutes: 480
+    timeout-minutes: 240
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Cache SwiftPM build
+        uses: actions/cache@v5
+        with:
+          path: .build
+          key: nightly-${{ runner.os }}-spm-${{ hashFiles('Package.swift', 'Package.resolved') }}
+          restore-keys: |
+            nightly-${{ runner.os }}-spm-
+            ${{ runner.os }}-spm-
+
+      - name: Xcode Swift toolchain
+        run: |
+          xcodebuild -version
+          swift --version
+          which swift
+
+      - name: Build BlazeDBCore
+        run: swift build --target BlazeDBCore
+
+      - name: Prepare CI log directories
+        run: mkdir -p .logs .artifacts
+
+      - name: Test Tier 1 extended
+        run: |
+          set -euo pipefail
+          swift test --filter BlazeDB_Tier1Extended 2>&1 | tee .logs/tier1extended.log
+
+      # Do not use --skip-build here: Tier1Perf is not built by the prior Tier1Extended-only
+      # step, so a cached test bundle can run against stale library code.
+      - name: Test Tier 1 perf
+        run: |
+          set -euo pipefail
+          swift test --filter BlazeDB_Tier1Perf 2>&1 | tee .logs/tier1perf.log
+
+      - name: Dump diagnostics on failure
+        if: failure()
+        run: |
+          mkdir -p .logs
+          ps aux > .logs/ps.txt || true
+          df -h > .logs/disk.txt || true
+          swift --version > .logs/swift-version.txt 2>&1 || true
+          xcodebuild -version > .logs/xcode-version.txt 2>&1 || true
+
+      - name: Upload nightly macOS Tier1 depth logs
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: nightly-macos-tier1-depth-logs
+          path: |
+            .logs/
+            .artifacts/
+          if-no-files-found: ignore
+          retention-days: 7
+
+  nightly-macos-fastfull-extra:
+    name: macOS 15 — Tier1FastFull (extra package)
+    runs-on: macos-15
+    timeout-minutes: 180
 
     steps:
       - name: Checkout
@@ -49,24 +112,63 @@ jobs:
       - name: Prepare CI log directories
         run: mkdir -p .logs .artifacts
 
-      - name: Test Tier 1 extended
-        run: |
-          set -euo pipefail
-          swift test --filter BlazeDB_Tier1Extended 2>&1 | tee .logs/tier1extended.log
-
-      # Do not use --skip-build here: Tier1Perf is not built by the prior Tier1Extended-only
-      # step, so a cached test bundle can run against stale library code (wrong line numbers /
-      # pre-fix behavior after BlazeDBCore-only rebuild + cache restore).
-      - name: Test Tier 1 perf
-        run: |
-          set -euo pipefail
-          swift test --filter BlazeDB_Tier1Perf 2>&1 | tee .logs/tier1perf.log
-
       - name: Test Tier 1 fast full (broader deterministic)
         run: |
           set -euo pipefail
           cd BlazeDBExtraTests
           swift test --filter BlazeDB_Tier1FastFull 2>&1 | tee "${GITHUB_WORKSPACE}/.logs/tier1fastfull.log"
+
+      - name: Dump diagnostics on failure
+        if: failure()
+        run: |
+          mkdir -p .logs
+          ps aux > .logs/ps.txt || true
+          df -h > .logs/disk.txt || true
+          swift --version > .logs/swift-version.txt 2>&1 || true
+          xcodebuild -version > .logs/xcode-version.txt 2>&1 || true
+
+      - name: Upload nightly macOS Tier1FastFull logs
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: nightly-macos-tier1fastfull-logs
+          path: |
+            .logs/
+            .artifacts/
+          if-no-files-found: ignore
+          retention-days: 7
+
+  nightly-macos-tier2-strict:
+    name: macOS 15 — Tier2 strict
+    runs-on: macos-15
+    timeout-minutes: 180
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Cache SwiftPM build
+        uses: actions/cache@v5
+        with:
+          path: .build
+          key: nightly-${{ runner.os }}-spm-${{ hashFiles('Package.swift', 'Package.resolved', 'BlazeDBExtraTests/Package.swift') }}
+          restore-keys: |
+            nightly-${{ runner.os }}-spm-
+            ${{ runner.os }}-spm-
+
+      - name: Xcode Swift toolchain
+        run: |
+          xcodebuild -version
+          swift --version
+          which swift
+
+      - name: Build BlazeDBCore
+        run: swift build --target BlazeDBCore
+
+      - name: Prepare CI log directories
+        run: mkdir -p .logs .artifacts
 
       - name: Test Tier 2 integration/recovery (strict enforcement)
         run: |
@@ -74,6 +176,46 @@ jobs:
           mkdir -p .logs
           echo ">>> ./Scripts/run-tier2.sh --strict (Tier 2 strict mode; script prints strict banner)" | tee .logs/tier2.log
           ./Scripts/run-tier2.sh --strict 2>&1 | tee -a .logs/tier2.log
+
+      - name: Dump diagnostics on failure
+        if: failure()
+        run: |
+          mkdir -p .logs
+          ps aux > .logs/ps.txt || true
+          df -h > .logs/disk.txt || true
+          swift --version > .logs/swift-version.txt 2>&1 || true
+          xcodebuild -version > .logs/xcode-version.txt 2>&1 || true
+
+      - name: Upload nightly macOS Tier2 logs
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: nightly-macos-tier2-logs
+          path: |
+            .logs/
+            .artifacts/
+          if-no-files-found: ignore
+          retention-days: 7
+
+  nightly-macos-clean-checkout:
+    name: macOS 15 — clean-checkout verification
+    runs-on: macos-15
+    timeout-minutes: 120
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Xcode Swift toolchain
+        run: |
+          xcodebuild -version
+          swift --version
+          which swift
+
+      - name: Prepare CI log directories
+        run: mkdir -p .logs .artifacts
 
       - name: Install ripgrep (verification scripts)
         env:
@@ -85,6 +227,46 @@ jobs:
         run: |
           set -euo pipefail
           ./Scripts/verify-clean-checkout.sh 2>&1 | tee .logs/verify-clean-checkout.log
+
+      - name: Dump diagnostics on failure
+        if: failure()
+        run: |
+          mkdir -p .logs
+          ps aux > .logs/ps.txt || true
+          df -h > .logs/disk.txt || true
+          swift --version > .logs/swift-version.txt 2>&1 || true
+          xcodebuild -version > .logs/xcode-version.txt 2>&1 || true
+
+      - name: Upload nightly macOS clean-checkout logs
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: nightly-macos-clean-checkout-logs
+          path: |
+            .logs/
+            .artifacts/
+          if-no-files-found: ignore
+          retention-days: 7
+
+  nightly-macos-readme-quickstart:
+    name: macOS 15 — README quickstart verification
+    runs-on: macos-15
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Xcode Swift toolchain
+        run: |
+          xcodebuild -version
+          swift --version
+          which swift
+
+      - name: Prepare CI log directories
+        run: mkdir -p .logs .artifacts
 
       - name: Verify README quickstart
         run: |
@@ -100,11 +282,11 @@ jobs:
           swift --version > .logs/swift-version.txt 2>&1 || true
           xcodebuild -version > .logs/xcode-version.txt 2>&1 || true
 
-      - name: Upload nightly macOS confidence logs
+      - name: Upload nightly macOS quickstart logs
         if: always()
         uses: actions/upload-artifact@v5
         with:
-          name: nightly-macos-confidence-logs
+          name: nightly-macos-quickstart-logs
           path: |
             .logs/
             .artifacts/
@@ -160,7 +342,7 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
-  nightly-linux-depth:
+  nightly-linux-validation:
     name: Linux (Swift 6.2) — Tier0 + Tier1Fast
     runs-on: ubuntu-22.04
     # 90m was too tight: a real run exceeded it (~90.23m wall) and the job was stopped as Cancelled.
@@ -213,11 +395,11 @@ jobs:
           df -h > .logs/disk.txt || true
           swift --version > .logs/swift-version.txt 2>&1 || true
 
-      - name: Upload nightly Linux depth logs
+      - name: Upload nightly Linux validation logs
         if: always()
         uses: actions/upload-artifact@v5
         with:
-          name: nightly-linux-depth-logs
+          name: nightly-linux-validation-logs
           path: |
             .logs/
             .artifacts/

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,7 +19,8 @@ jobs:
   nightly-macos-confidence:
     name: macOS 15 — Tier1 depth + Tier1FastFull + Tier2 + verify scripts
     runs-on: macos-15
-    timeout-minutes: 360
+    # Tier1 extended + perf + FastFull + Tier2 + verify can approach multi-hour wall times on hosted runners.
+    timeout-minutes: 480
 
     steps:
       - name: Checkout

--- a/BlazeDB/Core/UniqueConstraints.swift
+++ b/BlazeDB/Core/UniqueConstraints.swift
@@ -58,8 +58,17 @@ public class UniqueConstraintManager {
     
     /// Validate unique constraint before insert
     public func validateUnique(collection: DynamicCollection, record: BlazeDataRecord, excludeId: UUID? = nil) throws {
+        // Snapshot configuration under lock so validation does not iterate the sets while another
+        // thread mutates them (TSan: concurrent read/write on Set storage).
+        let fieldsSnapshot: Set<String>
+        let compoundSnapshot: Set<String>
+        lock.lock()
+        fieldsSnapshot = uniqueFields
+        compoundSnapshot = uniqueCompoundFields
+        lock.unlock()
+
         // Check single-field unique constraints
-        for field in uniqueFields {
+        for field in fieldsSnapshot {
             guard let value = record.storage[field] else { continue }
             
             // Check if another record has this value
@@ -83,7 +92,7 @@ public class UniqueConstraintManager {
         }
         
         // Check compound unique constraints
-        for compoundKey in uniqueCompoundFields {
+        for compoundKey in compoundSnapshot {
             let fields = compoundKey.components(separatedBy: "+")
             guard fields.allSatisfy({ record.storage[$0] != nil }) else { continue }
             

--- a/Docs/Testing/CI_AND_TEST_TIERS.md
+++ b/Docs/Testing/CI_AND_TEST_TIERS.md
@@ -171,6 +171,28 @@ All other `Tier1Core` directories and files (Aggregation, API, Query, Integratio
 - `./Scripts/run-tier2.sh`
 - `./Scripts/run-tier3.sh`
 
+## Interpreting CI failures (first artifact, not last passer)
+
+The **last passing test** in the log only identifies the **next execution candidate**, not necessarily the **root cause**. Sanitizer runs, worker death, and infra limits often make the “last green” line a red herring.
+
+**Default hypothesis order for late failures when Tier0 Thread Sanitizer is currently green**
+
+1. Real XCTest failure (assertion or thrown error with test context)
+2. Order or shared-state contamination (parallel workers, globals, shared paths)
+3. Late runtime or infra failure (timeout, SIGKILL, OOM, runner cancellation)
+4. Sanitizer output — **only** when the **first** failing artifact is actually a sanitizer report (do not infer sanitizer from “we fixed a race once”)
+
+Tier0 TSan being green does **not** prove there are no races anywhere, no sanitizer-only issues in other lanes, or no parallelism-dependent failures. It **does** mean you should not treat an older, fixed failure class (for example associated-object lazy-init races) as the automatic explanation for every later failure without matching log evidence.
+
+**Buckets collapse only on the first failing artifact**, for example: first `XCTAssert…` line, first thrown error with test context, first TSan report block, first timeout or kill line, or first cancellation/OOM signal.
+
+**Quick checklist when triaging**
+
+- What is the **first** failing artifact (assertion, throw, timeout, kill, cancellation, sanitizer)?
+- Was the failure **early**, **mid-run**, or **late**?
+- Is Tier0 TSan green on the branch?
+- Is the suspect test the **named failing test**, or merely the **next execution candidate** after an unrelated last pass?
+
 ## Nightly Triage Policy
 
 - Nightly failures are treated as real work and triaged within **24–48 hours**.

--- a/Docs/Testing/CI_AND_TEST_TIERS.md
+++ b/Docs/Testing/CI_AND_TEST_TIERS.md
@@ -22,8 +22,8 @@ Use this table for day-to-day expectations.
 - Completed:
   - PR gate caching and verify-step trim in `ci.yml`
   - Tier1 PR gate reduction (`BlazeDB_Tier1Fast`) + broader deterministic lane (`BlazeDB_Tier1FastFull`)
+  - Nightly confidence split into isolated failure-domain jobs in `nightly.yml`
 - In rollout:
-  - nightly confidence lane (`nightly.yml`)
   - deep soak lane (`deep-validation.yml`)
 
 ## Workflow Inventory
@@ -51,13 +51,15 @@ Use this table for day-to-day expectations.
 
 - `.github/workflows/nightly.yml`
 - Trigger: **daily schedule** and **manual** (`workflow_dispatch`)
-- Runs medium-confidence coverage:
-  - `BlazeDB_Tier1Extended` + `BlazeDB_Tier1Perf`
-  - `BlazeDB_Tier1FastFull` (from `BlazeDBExtraTests`)
-  - Tier2 integration/recovery via `./Scripts/run-tier2.sh --strict` (blocking in nightly lane)
-  - `verify-clean-checkout.sh` and `verify-readme-quickstart.sh`
-  - ThreadSanitizer on `BlazeDB_Tier0`
-  - Linux depth run: `BlazeDB_Tier0` + `BlazeDB_Tier1Fast`
+- Runs medium-confidence coverage in **separate rerunnable jobs**:
+  - `macOS 15 — Tier1 depth`: `BlazeDB_Tier1Extended` + `BlazeDB_Tier1Perf`
+  - `macOS 15 — Tier1FastFull (extra package)`: `BlazeDB_Tier1FastFull` from `BlazeDBExtraTests`
+  - `macOS 15 — Tier2 strict`: `./Scripts/run-tier2.sh --strict` (blocking in nightly lane)
+  - `macOS 15 — clean-checkout verification`: `./Scripts/verify-clean-checkout.sh`
+  - `macOS 15 — README quickstart verification`: `./Scripts/verify-readme-quickstart.sh`
+  - `macOS 15 — Tier0 ThreadSanitizer`: `swift test --sanitize thread --filter BlazeDB_Tier0`
+  - `Linux (Swift 6.2) — Tier0 + Tier1Fast`: `BlazeDB_Tier0` + `BlazeDB_Tier1Fast`
+- `verify-clean-checkout.sh` no longer re-runs the duplicate combined GoldenPath filter.
 - **Operational policy:** nightly failures are triaged within 24–48 hours.
 
 ### Nightly stability trade-offs (documented)
@@ -135,7 +137,7 @@ Use precise language so status and dashboards do not blur the PR gate with deepe
 | -------- | ------- |
 | **Tier1 PR gate** / **T1 fast** | `BlazeDB_Tier1Fast` only—the default blocking Tier1 lane on PRs. |
 | **Tier1 depth** | `BlazeDB_Tier1Extended` + `BlazeDB_Tier1Perf` (weekly/manual `tier1-depth.yml`, or `./Scripts/run-tier1-depth.sh`). Does *not* by itself imply `BlazeDB_Tier1Fast` ran. |
-| **Nightly confidence lane** | `nightly.yml`: Tier1 depth + `BlazeDB_Tier1FastFull` + strict Tier2 + verify scripts + Tier0 TSan + Linux Tier0/Tier1Fast. |
+| **Nightly confidence lane** | `nightly.yml`: failure-domain split jobs for Tier1 depth, `BlazeDB_Tier1FastFull` (extra package), strict Tier2, clean-checkout verify, README quickstart verify, Tier0 TSan, and Linux Tier0/Tier1Fast. |
 | **Deep validation lane** | `deep-validation.yml`: full Tier1 + Tier2 + Tier3 heavy/destructive + Tier0/Tier1Fast TSan + Linux extended lane. |
 | **Full Tier1** / **Tier1 all lanes** | `BlazeDB_Tier1Fast` + `BlazeDB_Tier1FastFull` + `BlazeDB_Tier1Extended` + `BlazeDB_Tier1Perf` (broader deterministic coverage via `BlazeDBExtraTests`). |
 

--- a/Scripts/verify-clean-checkout.sh
+++ b/Scripts/verify-clean-checkout.sh
@@ -125,11 +125,6 @@ step_test() {
     "$RUN_LOG_DIR/step2_tier1_golden.log" \
     env -i PATH="$PATH" HOME="$HOME" TERM="${TERM:-dumb}" \
     swift test --skip-build --filter BlazeDB_Tier1Fast.GoldenPathIntegrationTests
-  step_test \
-    "Combined GoldenPath filter" \
-    "$RUN_LOG_DIR/step2_combined_golden.log" \
-    env -i PATH="$PATH" HOME="$HOME" TERM="${TERM:-dumb}" \
-    swift test --skip-build --filter GoldenPathIntegrationTests
   if env -i PATH="$PATH" HOME="$HOME" TERM="${TERM:-dumb}" bash -c 'cd BlazeDBExtraTests && swift test list >/dev/null 2>&1'; then
     step_test \
       "Tier2 CrossVersion harness" \


### PR DESCRIPTION
## Summary
- split nightly confidence into separate failure-domain jobs for macOS Tier1 depth, extra-package Tier1FastFull, strict Tier2, clean-checkout verify, README quickstart verify, plus existing TSan and Linux axes
- keep commands and coverage intent intact while making nightly failures easier to triage and rerun in isolation
- remove the duplicate combined GoldenPath run from `Scripts/verify-clean-checkout.sh` and update nightly docs to reflect the new workflow topology

## Test plan
- [x] Parse `.github/workflows/nightly.yml` as YAML (`ruby -e 'require "yaml"; YAML.load_file(...)'`)
- [x] Validate `Scripts/verify-clean-checkout.sh` shell syntax (`bash -n`)
- [x] Confirm changed files are lint-clean (`ReadLints`)