### PR TITLE
ci/docs: normalize depth-lane naming and transitional tier metadata

### DIFF
--- a/.github/workflows/tier1-depth.yml
+++ b/.github/workflows/tier1-depth.yml
@@ -1,7 +1,7 @@
-# Weekly / manual deeper validation lane (pre-PR4 naming cleanup).
+# Weekly / manual depth validation lane.
 # See Docs/Testing/CI_AND_TEST_TIERS.md
 
-name: Tier2/Tier3 heavy depth (transitional companions)
+name: Depth validation (Tier2/Tier3 companions)
 
 on:
   schedule:
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: tier1-depth-${{ github.workflow }}-${{ github.ref }}
+  group: depth-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -19,7 +19,7 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
-  tier1-depth-macos:
+  depth-macos:
     name: macOS 15 — Tier2 + Tier3_Heavy (with companions)
     runs-on: macos-15
     timeout-minutes: 240
@@ -62,11 +62,11 @@ jobs:
           swift --version > .logs/swift-version.txt 2>&1 || true
           xcodebuild -version > .logs/xcode-version.txt 2>&1 || true
 
-      - name: Upload tier1-depth macOS logs
+      - name: Upload depth macOS logs
         if: always()
         uses: actions/upload-artifact@v5
         with:
-          name: tier1-depth-macos-logs
+          name: depth-macos-logs
           path: |
             .logs/
             .artifacts/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ swift test --filter BlazeDB_Tier0
 
 **Canonical Tier1 gate — `BlazeDB_Tier1`:** `BlazeDBTests/Tier1Core/` — deterministic correctness; no `measure()`, no timing-dependent sleeps, no benchmark-shaped workloads.
 
-`BlazeDB_Tier1Extended` and `BlazeDB_Tier1Perf` target names were retired; their suites now run under Tier2/Tier3 ownership via **transitional companion targets** (`BlazeDB_Tier2_Extended`, `BlazeDB_Tier3_Heavy_Perf`) pending PR4 normalization.
+`BlazeDB_Tier1Extended` and `BlazeDB_Tier1Perf` target names were retired; their suites now run under Tier2/Tier3 ownership via **transitional companion targets** (`BlazeDB_Tier2_Extended`, `BlazeDB_Tier3_Heavy_Perf`) pending filesystem/target normalization.
 
 **What goes in the fast lane:**
 - Core contracts that must stay green on every PR (persistence/security/features) without heavy timing or perf noise

--- a/Docs/Release/RELEASE_READINESS_CHECKLIST.md
+++ b/Docs/Release/RELEASE_READINESS_CHECKLIST.md
@@ -30,9 +30,10 @@ This file is the release-facing checklist only. Historical strategy notes and sp
 - [ ] Release workflow passes for tag `vX.Y.Z` (`.github/workflows/release.yml`):
 - Tier 0
 - Tier1
-- Tier1Extended
-- Tier1Perf
+- Tier2
+- Tier2_Extended (transitional companion)
 - Tier3 heavy
+- Tier3_Heavy_Perf (transitional companion)
 
 ## 4) Security And Compatibility Gates
 

--- a/Docs/SYSTEM_MAP.md
+++ b/Docs/SYSTEM_MAP.md
@@ -219,10 +219,9 @@ Additional example files in `Examples/` (`.swift` files) are standalone referenc
 | Lane | Status | Location | Notes |
 | ---- | ------ | -------- | ----- |
 | Tier 0 (PR gate) | Stable | `BlazeDBTests/Tier0Core/` | Deterministic correctness |
-| Tier 1 Fast (PR gate) | Stable | `BlazeDBTests/Tier1Core/` | Nearly full coverage; one file excluded (`SecureConnectionTests.swift` — requires Network framework) — see `CI_AND_TEST_TIERS.md` and `Package.swift` |
-| Tier 1 Extended | Stable | `BlazeDBTests/Tier1Extended/` | Weekly + manual; sync tests partially excluded |
-| Tier 1 Perf | Stable | `BlazeDBTests/Tier1Perf/` | `measure()` suites |
-| Tier 2 / Tier 3 | Stable | `BlazeDBExtraTests/` | Nested package; not in root `swift test` |
+| Tier 1 (PR gate) | Stable | `BlazeDBTests/Tier1Core/` | Canonical Tier1 target (`BlazeDB_Tier1`); see `CI_AND_TEST_TIERS.md` |
+| Tier 2 | Stable | `BlazeDBTests/Tier2Integration/` | `BlazeDB_Tier2` plus temporary companion `BlazeDB_Tier2_Extended` |
+| Tier 3 | Stable | `BlazeDBTests/Tier3Heavy/`, `BlazeDBTests/Tier3Destructive/` | `BlazeDB_Tier3_Heavy` / `BlazeDB_Tier3_Destructive` plus temporary companion `BlazeDB_Tier3_Heavy_Perf` |
 | Nightly | Stable | `.github/workflows/nightly.yml` | Depth + TSan + Linux |
 | Deep validation | Stable | `.github/workflows/deep-validation.yml` | Weekly soak |
 

--- a/Docs/Testing/CI_AND_TEST_TIERS.md
+++ b/Docs/Testing/CI_AND_TEST_TIERS.md
@@ -13,7 +13,7 @@ Use this table for day-to-day expectations.
 | Lane | Goal | Trigger | Blocking | Current workflow(s) |
 | ---- | ---- | ------- | -------- | ------------------- |
 | PR fast gate | Catch obvious breakage quickly | `pull_request`, `push` | Yes | `ci.yml` |
-| Tier1 depth | Broader Tier1 confidence | Weekly + manual | No | `tier1-depth.yml` |
+| Depth validation | Tier2/Tier3 confidence | Weekly + manual | No | `tier1-depth.yml` |
 | Release validation | Validate tagged releases | `v*` tag + manual | Release-only | `release.yml` |
 | Tag probe | Check older tags still build | Manual | No | `tag-probe.yml` |
 
@@ -47,7 +47,7 @@ Use this table for day-to-day expectations.
 
 - `.github/workflows/tier1-depth.yml`
 - Trigger: **weekly schedule** and **manual** (`workflow_dispatch`)
-- Runs `BlazeDB_Tier2` + `BlazeDB_Tier2_Extended` and `BlazeDB_Tier3_Heavy` + `BlazeDB_Tier3_Heavy_Perf` (legacy workflow name retained pending PR4 cleanup).
+- Runs `BlazeDB_Tier2` + `BlazeDB_Tier2_Extended` and `BlazeDB_Tier3_Heavy` + `BlazeDB_Tier3_Heavy_Perf`.
 
 - `.github/workflows/nightly.yml`
 - Trigger: **daily schedule** and **manual** (`workflow_dispatch`)
@@ -99,7 +99,7 @@ Use this table for day-to-day expectations.
 ## Tier Purposes
 
 - **Canonical targets (end-state taxonomy):** `BlazeDB_Tier0`, `BlazeDB_Tier1`, `BlazeDB_Tier2`, `BlazeDB_Tier3_Heavy`, `BlazeDB_Tier3_Destructive`.
-- **PR3 transitional companions (temporary, pending PR4 normalization):** `BlazeDB_Tier2_Extended`, `BlazeDB_Tier3_Heavy_Perf`.
+- **Transitional companion targets (temporary, pending filesystem/target normalization):** `BlazeDB_Tier2_Extended`, `BlazeDB_Tier3_Heavy_Perf`.
 
 - `BlazeDB_Tier0`
 - Fast deterministic correctness gate for PRs and local preflight.
@@ -130,8 +130,8 @@ Use precise language so status and dashboards do not blur the PR gate with deepe
 | -------- | ------- |
 | **Tier1 PR gate** / **Tier1** | `BlazeDB_Tier1` only—the default blocking Tier1 lane on PRs. |
 | **Canonical tiers** | `BlazeDB_Tier0`, `BlazeDB_Tier1`, `BlazeDB_Tier2`, `BlazeDB_Tier3_Heavy`, `BlazeDB_Tier3_Destructive` (end-state model). |
-| **PR3 transitional companions** | `BlazeDB_Tier2_Extended`, `BlazeDB_Tier3_Heavy_Perf`; temporary bridge targets slated for PR4 filesystem/target normalization. |
-| **Depth lane** | `tier1-depth.yml` currently runs `BlazeDB_Tier2` + `BlazeDB_Tier2_Extended` + `BlazeDB_Tier3_Heavy` + `BlazeDB_Tier3_Heavy_Perf` (workflow filename kept for compatibility until PR4). |
+| **Transitional companions** | `BlazeDB_Tier2_Extended`, `BlazeDB_Tier3_Heavy_Perf`; temporary bridge targets until filesystem/target normalization collapses them. |
+| **Depth lane** | `tier1-depth.yml` runs `BlazeDB_Tier2` + `BlazeDB_Tier2_Extended` + `BlazeDB_Tier3_Heavy` + `BlazeDB_Tier3_Heavy_Perf`. |
 | **Nightly confidence lane** | `nightly.yml`: root-owned Tier1, Tier2 strict (`BlazeDB_Tier2` + `BlazeDB_Tier2_Extended`), Tier3 heavy (`BlazeDB_Tier3_Heavy` + `BlazeDB_Tier3_Heavy_Perf`), verify lanes, Tier0 TSan, and Linux Tier0/Tier1. |
 | **Deep validation lane** | `deep-validation.yml`: Tier1 + Tier2/Tier2_Extended + Tier3_Heavy/Tier3_Heavy_Perf + Tier3 destructive + Tier0/Tier1 TSan + Linux Tier0/Tier1/Tier2/Tier2_Extended. |
 | **Canonical Tier1** | `BlazeDB_Tier1` (single canonical Tier1 target). |

--- a/Docs/Testing/PR3_RECLASSIFICATION_MAP.md
+++ b/Docs/Testing/PR3_RECLASSIFICATION_MAP.md
@@ -4,7 +4,7 @@ This artifact records the semantic reclassification performed in PR3 without fil
 
 - Scope: `BlazeDBTests/Tier1Extended/**/*.swift` and `BlazeDBTests/Tier1Perf/**/*.swift`
 - Goal: retire legacy Tier1-derived target names while preserving coverage under Tier2/Tier3 ownership
-- Transitional note: `BlazeDB_Tier2_Extended` and `BlazeDB_Tier3_Heavy_Perf` are temporary companion targets pending PR4 normalization.
+- Transitional note: `BlazeDB_Tier2_Extended` and `BlazeDB_Tier3_Heavy_Perf` are temporary companion targets pending filesystem/target normalization.
 
 | file path | old target | new target | reason |
 | --- | --- | --- | --- |

--- a/Docs/Testing/TESTS_DIRECTORY.md
+++ b/Docs/Testing/TESTS_DIRECTORY.md
@@ -2,7 +2,7 @@
 
 ## SwiftPM test targets (root package)
 
-The repository root `Package.swift` defines test targets whose sources live under **`BlazeDBTests/`** (for example `BlazeDB_Tier0`, `BlazeDB_Tier1`, `BlazeDB_Tier2`, `BlazeDB_Tier3_Heavy`). That is what `swift test` and the default CI workflow exercise when filtering those targets.
+The repository root `Package.swift` defines test targets whose sources live under **`BlazeDBTests/`** (for example `BlazeDB_Tier0`, `BlazeDB_Tier1`, `BlazeDB_Tier2`, `BlazeDB_Tier2_Extended`, `BlazeDB_Tier3_Heavy`, `BlazeDB_Tier3_Heavy_Perf`). That is what `swift test` and the default CI workflow exercise when filtering those targets.
 
 ## Top-level `Tests/` directory
 

--- a/Scripts/run-tier1-depth.sh
+++ b/Scripts/run-tier1-depth.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
-# Tier2/Tier3 heavy depth lane.
+# Depth lane: Tier2/Tier3 heavy with transitional companions.
 # See Docs/Testing/CI_AND_TEST_TIERS.md
 set -e
-echo "=== Tier2/Tier3 heavy depth ==="
+echo "=== Depth lane (Tier2/Tier3 companions) ==="
 RUN_ID="$(date +%Y%m%d-%H%M%S)"
-ARTIFACT_DIR=".artifacts/tier1-depth/${RUN_ID}"
+ARTIFACT_DIR=".artifacts/depth/${RUN_ID}"
 mkdir -p "$ARTIFACT_DIR"
 python3 ./Scripts/verify_execution_coverage.py --target BlazeDB_Tier2 --artifact-dir "$ARTIFACT_DIR" --allowed-missing 0 --num-workers 2 || exit 1
 python3 ./Scripts/verify_execution_coverage.py --target BlazeDB_Tier2_Extended --artifact-dir "$ARTIFACT_DIR" --allowed-missing 0 --num-workers 2 || exit 1
 python3 ./Scripts/verify_execution_coverage.py --target BlazeDB_Tier3_Heavy --artifact-dir "$ARTIFACT_DIR" --allowed-missing 0 --num-workers 2 || exit 1
 python3 ./Scripts/verify_execution_coverage.py --target BlazeDB_Tier3_Heavy_Perf --artifact-dir "$ARTIFACT_DIR" --allowed-missing 0 --num-workers 2 || exit 1
-echo "Tier2/Tier3 heavy artifacts: $ARTIFACT_DIR"
-echo "=== Tier2/Tier3 heavy depth complete ==="
+echo "Depth lane artifacts: $ARTIFACT_DIR"
+echo "=== Depth lane complete ==="


### PR DESCRIPTION
## Summary
- normalize depth-lane naming in `tier1-depth.yml` (workflow/job/artifact/concurrency labels)
- normalize depth-lane script naming/output/path in `Scripts/run-tier1-depth.sh`
- clean up docs and metadata wording so they reflect the current Tier2/Tier3 companion-target layout
- update release checklist and system map terminology to current target names

## Cleanup-only scope
- no target membership changes
- no workflow behavior changes
- no filesystem moves
- no taxonomy changes
- companion targets still exist (`BlazeDB_Tier2_Extended`, `BlazeDB_Tier3_Heavy_Perf`)

## Why this PR exists
PR3 intentionally introduced transitional companion targets to retire legacy Tier1-derived names without mixing in filesystem normalization. This PR only removes naming/metadata drift around that current state so lane names and docs stay truthful.

## Non-goals
- no collapse/removal of companion targets
- no claim that single-target-per-tier normalization is complete
- no additional architecture changes