### PR TITLE
tests: fix RLS viewer scenario and harden Tier3 write progress

### DIFF
--- a/BlazeDBTests/Tier2Integration/BlazeDBIntegrationTests/RLSIntegrationTests.swift
+++ b/BlazeDBTests/Tier2Integration/BlazeDBIntegrationTests/RLSIntegrationTests.swift
@@ -202,6 +202,8 @@ final class RLSIntegrationTests: XCTestCase {
         
         // Enable RLS
         db.rls.enable()
+        // Read-only requires an explicit SELECT allow for viewers.
+        db.rls.addPolicy(.viewerCanSelect())
         db.rls.addPolicy(.viewerReadOnly())
         db.rls.addPolicy(SecurityPolicy(
             name: "editor_can_write",
@@ -224,13 +226,17 @@ final class RLSIntegrationTests: XCTestCase {
         db.rls.setContext(viewer.toSecurityContext())
         let viewerRecords = try db.rls.filterRecords(operation: .select, records: try db.fetchAll())
         XCTAssertEqual(viewerRecords.count, 1)
+        guard let viewerRecord = viewerRecords.first else {
+            XCTFail("Viewer should be able to read one record")
+            return
+        }
         print("  ✅ Viewer can read document")
         
         // Viewer cannot update
         let canUpdate = db.rls.policyEngine.isAllowed(
             operation: .update,
             context: viewer.toSecurityContext(),
-            record: viewerRecords[0]
+            record: viewerRecord
         )
         XCTAssertFalse(canUpdate)
         print("  ✅ Viewer cannot update document")
@@ -239,7 +245,7 @@ final class RLSIntegrationTests: XCTestCase {
         let canDelete = db.rls.policyEngine.isAllowed(
             operation: .delete,
             context: viewer.toSecurityContext(),
-            record: viewerRecords[0]
+            record: viewerRecord
         )
         XCTAssertFalse(canDelete)
         print("  ✅ Viewer cannot delete document")

--- a/BlazeDBTests/Tier3Heavy/BlazeDBStressTests.swift
+++ b/BlazeDBTests/Tier3Heavy/BlazeDBStressTests.swift
@@ -252,7 +252,8 @@ final class BlazeDBStressTests: XCTestCase {
         // Reduced counts for more reliable test execution
         let readerCount = 10
         let writerCount = 5
-        let duration: TimeInterval = 2.0  // Run for 2 seconds
+        let isCI = ProcessInfo.processInfo.environment["CI"] == "true"
+        let duration: TimeInterval = isCI ? 3.0 : 2.0  // Give CI more time to avoid startup starvation
         
         print("📊 Testing concurrent reads (\(readerCount)) and writes (\(writerCount)) for \(duration)s...")
         
@@ -286,31 +287,7 @@ final class BlazeDBStressTests: XCTestCase {
         let writeCount = StressThreadSafeInt()
         let errorBag = StressErrorBag()
         
-        // Start readers
-        for readerID in 0..<readerCount {
-            group.enter()
-            queue.async {
-                defer { group.leave() }
-                var localReads = 0
-                while DispatchTime.now() < deadline {
-                    let randomID = seeds.randomElement()!
-                    _ = try? db.fetch(id: randomID)
-                    readCount.increment()
-                    localReads += 1
-                    // Optimized: shorter delay for default tests, longer for thorough testing
-                    let readDelay = ProcessInfo.processInfo.environment["TEST_SLOW_CONCURRENCY"] == "1" ? 1000 : 100
-                    usleep(UInt32(readDelay))
-                }
-                if localReads > 0 {
-                    print("  Reader \(readerID) completed \(localReads) reads")
-                }
-            }
-        }
-        
-        // Start writers with delay (optimized for faster tests)
-        let startupDelay = ProcessInfo.processInfo.environment["TEST_SLOW_CONCURRENCY"] == "1" ? 100000 : 10000
-        usleep(UInt32(startupDelay))  // 10ms default, 100ms for thorough testing
-        
+        // Start writers first so we don't fail with zero writes on busy CI hosts.
         for writerID in 0..<writerCount {
             group.enter()
             queue.async {
@@ -336,6 +313,30 @@ final class BlazeDBStressTests: XCTestCase {
                 }
                 if localWrites > 0 {
                     print("  Writer \(writerID) completed \(localWrites) writes")
+                }
+            }
+        }
+        
+        // Start readers after a short writer head-start.
+        let startupDelay = ProcessInfo.processInfo.environment["TEST_SLOW_CONCURRENCY"] == "1" ? 100000 : 20000
+        usleep(UInt32(startupDelay))  // 20ms default, 100ms for thorough testing
+        
+        for readerID in 0..<readerCount {
+            group.enter()
+            queue.async {
+                defer { group.leave() }
+                var localReads = 0
+                while DispatchTime.now() < deadline {
+                    let randomID = seeds.randomElement()!
+                    _ = try? db.fetch(id: randomID)
+                    readCount.increment()
+                    localReads += 1
+                    // Optimized: shorter delay for default tests, longer for thorough testing
+                    let readDelay = ProcessInfo.processInfo.environment["TEST_SLOW_CONCURRENCY"] == "1" ? 1000 : 100
+                    usleep(UInt32(readDelay))
+                }
+                if localReads > 0 {
+                    print("  Reader \(readerID) completed \(localReads) reads")
                 }
             }
         }


### PR DESCRIPTION
## Summary
- fix `testRLS_ViewerReadOnlyScenario` by adding explicit viewer-select policy and guarding record access to avoid index-out-of-range after assertion failure
- harden `testConcurrentReadsAndWrites` against CI startup starvation by prioritizing writers and giving a short writer head-start
- keep this PR focused on deterministic correctness + stress harness reliability (no perf-threshold policy changes)

## Evidence
- Before:
  - Tier2 RLS scenario failed deterministically (`viewerRecords.count` 0 vs expected 1) and then crashed on index access
  - Tier3 stress test intermittently failed with `No writes completed`
- After (targeted reruns):
  - `BlazeDB_Tier2.RLSIntegrationTests/testRLS_ViewerReadOnlyScenario`: 3/3 pass
  - `BlazeDB_Tier3_Heavy.BlazeDBStressTests/testConcurrentReadsAndWrites`: 5/5 pass

## Test Plan
- [x] `swift test --filter BlazeDB_Tier2.RLSIntegrationTests/testRLS_ViewerReadOnlyScenario` (repeated)
- [x] `swift test --filter BlazeDB_Tier3_Heavy.BlazeDBStressTests/testConcurrentReadsAndWrites` (repeated)
- [x] lint check on edited files