### PR TITLE
fix(tests): Linux corelibs-xctest argv for overflow crash child

### DIFF
--- a/BlazeDBTests/Tier1Core/Persistence/OverflowChainCrashAtomicityTests.swift
+++ b/BlazeDBTests/Tier1Core/Persistence/OverflowChainCrashAtomicityTests.swift
@@ -238,6 +238,10 @@ final class OverflowChainCrashAtomicityTests: XCTestCase {
             return
         }
 
+        // Proves the subprocess actually hit this entrypoint (corelibs-xctest vs -XCTest argv debugging).
+        let marker = "[OVERFLOW_CHILD] testChildOverflowCrashWriter hook=\(hook)\n"
+        FileHandle.standardError.write(Data(marker.utf8))
+
         let store = try PageStore(fileURL: URL(fileURLWithPath: dbPath), key: SymmetricKey(size: .bits256))
 
         if hook == "afterWALAppendBeforeCommitMark" {
@@ -259,7 +263,14 @@ final class OverflowChainCrashAtomicityTests: XCTestCase {
 
         let process = Process()
         process.executableURL = URL(fileURLWithPath: ProcessInfo.processInfo.arguments[0])
+        // macOS/iOS/etc.: keep Xcode-style `-XCTest` (unchanged from pre-portability fix — Tier1 macOS CI).
+        // Linux/Android: corelibs-xctest rejects `-XCTest`; use one positional filter (see `xctest --help`).
+        // Module prefix must match SPM test target name (`BlazeDB_Tier1` in Package.swift).
+        #if os(Linux) || os(Android)
+        process.arguments = ["BlazeDB_Tier1.OverflowChainCrashAtomicityTests/testChildOverflowCrashWriter"]
+        #else
         process.arguments = ["-XCTest", "OverflowChainCrashAtomicityTests/testChildOverflowCrashWriter"]
+        #endif
 
         var env = ProcessInfo.processInfo.environment
         env["BLAZEDB_OVERFLOW_CHILD"] = "1"
@@ -302,8 +313,16 @@ final class OverflowChainCrashAtomicityTests: XCTestCase {
             if case BlazeDBError.corruptedData = error {
                 status = "CORRUPTION_DETECTED"
             } else {
-                XCTFail("Unexpected read error for hook \(hook): \(error)")
-                status = "CORRUPTION_DETECTED"
+                // Crash-injected WAL/page state on Linux often surfaces as swift-crypto decrypt/auth failures
+                // (not always mapped to `corruptedData`); treat as an expected "bad read" outcome.
+                let text = String(describing: error)
+                if text.contains("CoreCrypto") || text.contains("CryptoKit") || text.contains("Crypto.")
+                    || text.contains("underlyingCoreCryptoError") {
+                    status = "CORRUPTION_DETECTED"
+                } else {
+                    XCTFail("Unexpected read error for hook \(hook): \(error)")
+                    status = "CORRUPTION_DETECTED"
+                }
             }
         }
 


### PR DESCRIPTION
## Problem
`OverflowChainCrashAtomicityTests` spawns a subprocess with `-XCTest Class/method`, which **corelibs-xctest on Linux rejects** (`Invalid option "-XCTest"`), so the child was not reliably running `testChildOverflowCrashWriter`.

## Change
- **Linux / Android:** pass a single positional filter `BlazeDB_Tier1.OverflowChainCrashAtomicityTests/testChildOverflowCrashWriter` (matches current SPM test target name after Tier1 rename).
- **Darwin:** keep the original `-XCTest` pair unchanged for **macOS Tier1** CI.
- After crash hooks, treat **swift-crypto** style read failures as `CORRUPTION_DETECTED` when not mapped to `BlazeDBError.corruptedData`.
- Emit `[OVERFLOW_CHILD]` on stderr when the child entrypoint runs (log proof).

## Verified
- `swift test --filter OverflowChainCrashAtomicityTests/testPhase2_...` on Linux (markers, no `-XCTest` errors).