### PR TITLE
refactor(pkg): simplify public surface and center direct CRUD as primary API

### DIFF
--- a/BlazeDB/Codable/CodableIntegration.swift
+++ b/BlazeDB/Codable/CodableIntegration.swift
@@ -178,43 +178,60 @@ private func convertToJSON(
     }
 }
 
-// MARK: - BlazeDBClient Codable Extensions
+// MARK: - Direct Model CRUD
 
+/// Primary typed CRUD API for `BlazeStorable` models.
+///
+/// These methods are the recommended way to work with BlazeDB in app code:
+///
+/// ```swift
+/// let db = try BlazeDBClient.open()
+///
+/// try db.insert(user)
+/// let u = try db.fetch(User.self, id: userId)
+/// let all = try db.fetchAll(User.self)
+/// try db.update(user)
+/// try db.upsert(user)
+/// try db.delete(user)
+/// ```
+///
+/// For advanced query building, see ``query(_:)-swift.method`` and ``QueryBuilder``.
+/// For batch or scoped stores, see ``TypedStore`` (optional).
 extension BlazeDBClient {
     
     // MARK: - Insert
     
-    /// Insert any Codable type directly
+    /// Insert a model into the database.
     ///
-    /// Example:
+    /// This is the primary way to store a `BlazeStorable` object. The model's `id` is used
+    /// as the record key.
+    ///
     /// ```swift
-    /// struct Bug: Codable, Identifiable {
-    ///     var id: UUID
-    ///     var title: String
-    ///     var priority: Int
-    /// }
-    ///
-    /// let bug = Bug(id: UUID(), title: "Login broken", priority: 5)
-    /// try db.insert(bug)
+    /// let user = User(name: "Alice", age: 30)
+    /// try db.insert(user)
     /// ```
+    @discardableResult
     public func insert<T: BlazeStorable>(_ object: T) throws -> UUID {
         let record = try object.toBlazeRecord()
         return try self.insert(record)
     }
     
-    /// Insert Codable async
+    /// Insert a model (async).
+    @discardableResult
     public func insert<T: BlazeStorable>(_ object: T) async throws -> UUID {
         let record = try object.toBlazeRecord()
         return try await self.insert(record)
     }
     
-    /// Insert many Codable objects
+    /// Insert multiple models in one call.
+    @discardableResult
     public func insertMany<T: BlazeStorable>(_ objects: [T]) throws -> [UUID] {
         let records = try objects.map { try $0.toBlazeRecord() }
         return try self.insertMany(records)
     }
     
-    /// Insert many async
+    /// Insert multiple models (async).
+    @discardableResult
     public func insertMany<T: BlazeStorable>(_ objects: [T]) async throws -> [UUID] {
         let records = try objects.map { try $0.toBlazeRecord() }
         return try await self.insertMany(records)
@@ -222,12 +239,10 @@ extension BlazeDBClient {
     
     // MARK: - Fetch
     
-    /// Fetch Codable type by ID
+    /// Fetch a single model by its ID, returning `nil` if not found.
     ///
-    /// Example:
     /// ```swift
-    /// let bug = try db.fetch(Bug.self, id: bugID)
-    /// print(bug?.title)
+    /// let user = try db.fetch(User.self, id: userId)
     /// ```
     public func fetch<T: BlazeStorable>(_ type: T.Type, id: UUID) throws -> T? {
         guard let record = try self.fetch(id: id) else {
@@ -236,7 +251,7 @@ extension BlazeDBClient {
         return try T.fromBlazeRecord(record)
     }
     
-    /// Fetch async
+    /// Fetch a single model by ID (async).
     public func fetch<T: BlazeStorable>(_ type: T.Type, id: UUID) async throws -> T? {
         guard let record = try await self.fetch(id: id) else {
             return nil
@@ -244,13 +259,17 @@ extension BlazeDBClient {
         return try T.fromBlazeRecord(record)
     }
     
-    /// Fetch all as Codable type, filtering out records that cannot decode as `T`.
+    /// Fetch all models of a given type.
+    ///
+    /// ```swift
+    /// let users = try db.fetchAll(User.self)
+    /// ```
     public func fetchAll<T: BlazeStorable>(_ type: T.Type) throws -> [T] {
         let records = try self.fetchAll()
         return records.compactMap { try? T.fromBlazeRecord($0) }
     }
     
-    /// Fetch all async, filtering out records that cannot decode as `T`.
+    /// Fetch all models of a given type (async).
     public func fetchAll<T: BlazeStorable>(_ type: T.Type) async throws -> [T] {
         let records = try await self.fetchAll()
         return records.compactMap { try? T.fromBlazeRecord($0) }
@@ -258,33 +277,51 @@ extension BlazeDBClient {
     
     // MARK: - Update
     
-    /// Update Codable object
+    /// Update an existing model. The record is identified by the model's `id`.
+    ///
+    /// ```swift
+    /// user.name = "Bob"
+    /// try db.update(user)
+    /// ```
     public func update<T: BlazeStorable>(_ object: T) throws {
         let record = try object.toBlazeRecord()
         try self.update(id: object.id, with: record)
     }
     
-    /// Update async
+    /// Update an existing model (async).
     public func update<T: BlazeStorable>(_ object: T) async throws {
         let record = try object.toBlazeRecord()
         try await self.update(id: object.id, data: record)
     }
     
-    /// Update many Codable objects
+    /// Update multiple models in one call.
     public func updateMany<T: BlazeStorable>(_ objects: [T]) throws {
         for object in objects {
             try self.update(object)
         }
     }
     
-    /// Update many async
+    /// Update multiple models (async).
     public func updateMany<T: BlazeStorable>(_ objects: [T]) async throws {
         for object in objects {
             try await self.update(object)
         }
     }
     
-    // Note: Type-safe query builder is defined in QueryBuilderKeyPath.swift
-    // This avoids duplication and uses the KeyPath-enabled builder
+    // MARK: - Delete
+    
+    /// Delete a model by its `id`.
+    ///
+    /// ```swift
+    /// try db.delete(user)
+    /// ```
+    public func delete<T: BlazeStorable>(_ object: T) throws {
+        try self.delete(id: object.id)
+    }
+    
+    /// Delete a model by its `id` (async).
+    public func delete<T: BlazeStorable>(_ object: T) async throws {
+        try await self.delete(id: object.id)
+    }
 }
 

--- a/BlazeDB/Codable/TypedStore.swift
+++ b/BlazeDB/Codable/TypedStore.swift
@@ -1,46 +1,41 @@
 import Foundation
 
-/// A typed view over a `BlazeDBClient` that binds all CRUD and query operations to a
-/// single `BlazeStorable` model type, eliminating the need to repeat `T.self` on every call.
+/// An **optional** typed view over a `BlazeDBClient` that binds CRUD and query operations
+/// to a single `BlazeStorable` model type, so you don't have to repeat `T.self` on every call.
+///
+/// > **Tip:** For most code, calling methods directly on ``BlazeDBClient`` is simpler:
+/// >
+/// > ```swift
+/// > try db.insert(user)
+/// > let u = try db.fetch(User.self, id: userId)
+/// > ```
+/// >
+/// > Use `TypedStore` when you want a scoped handle — e.g. passing a "users"
+/// > store to a view model or service layer.
 ///
 /// `TypedStore` does **not** create a separate physical collection or table — BlazeDB stores
 /// all records in one encrypted document collection per database file. `TypedStore` is purely
 /// a convenience layer that encodes/decodes through the `BlazeStorable` (Codable) bridge.
 ///
-/// ## Quick start
+/// ## Usage
 ///
 /// ```swift
-/// struct User: BlazeStorable {
-///     var id: UUID = UUID()
-///     var name: String
-///     var age: Int
-/// }
-///
-/// let db = try BlazeDBClient.open(named: "myapp", password: "Secure-Password-2026!")
 /// let users = db.typed(User.self)
 ///
-/// // Insert
-/// let alice = User(name: "Alice", age: 30)
 /// try users.insert(alice)
-///
-/// // Fetch
 /// let fetched = try users.fetch(alice.id)
 ///
-/// // Query with KeyPaths
 /// let seniors = try users.query()
 ///     .where(\.age, greaterThanOrEqual: 65)
 ///     .all()
-///
-/// // Fetch all
-/// let everyone = try users.fetchAll()
 /// ```
 ///
 /// ## Nested Codable types
 ///
-/// Nested `Codable` structs/classes are currently stored as serialized JSON strings inside
-/// `BlazeDocumentField.string`. Round-tripping works, but the nested fields are **not**
-/// individually queryable via KeyPath filters. If you need to query nested fields, flatten
-/// them into top-level properties or use the raw `BlazeDataRecord` query API.
+/// Nested `Codable` structs/classes are stored as serialized JSON strings inside
+/// `BlazeDocumentField.string`. Round-tripping works, but nested fields are **not**
+/// individually queryable via KeyPath filters. Flatten them into top-level properties
+/// or use the raw `BlazeDataRecord` query API if you need per-field queries.
 public struct TypedStore<T: BlazeStorable>: Sendable {
     private let db: BlazeDBClient
 
@@ -127,20 +122,16 @@ public struct TypedStore<T: BlazeStorable>: Sendable {
 
 extension BlazeDBClient {
 
-    /// Create a typed store for convenient, type-safe CRUD operations.
+    /// Create a scoped, typed handle for CRUD operations on a single model type.
     ///
-    /// The returned `TypedStore` binds all operations to the given `BlazeStorable` type
-    /// so you never need to repeat `T.self`. This is the **recommended** API for most
-    /// applications.
+    /// Use this when you want to pass a type-bound store to a view model or
+    /// service layer. For simple one-off operations, calling `insert(_:)`,
+    /// `fetch(_:id:)`, etc. directly on `BlazeDBClient` is simpler.
     ///
     /// ```swift
     /// let users = db.typed(User.self)
     /// try users.insert(User(name: "Alice", age: 30))
-    /// let all = try users.fetchAll()
     /// ```
-    ///
-    /// > **Note:** `TypedStore` is a typed view, not a separate physical table.
-    /// > All records share the same underlying encrypted collection.
     public func typed<T: BlazeStorable>(_ type: T.Type) -> TypedStore<T> {
         TypedStore<T>(db: self)
     }

--- a/BlazeDBTests/Tier1Core/Integration/CodableIntegrationTests.swift
+++ b/BlazeDBTests/Tier1Core/Integration/CodableIntegrationTests.swift
@@ -138,6 +138,57 @@ final class CodableIntegrationTests: XCTestCase {
         XCTAssertNil(fetched)
     }
     
+    func testTypedDeleteByModel() throws {
+        let bug = SimpleBug(title: "Typed Delete", priority: 7)
+        _ = try requireFixture(db).insert(bug)
+        
+        XCTAssertNotNil(try requireFixture(db).fetch(SimpleBug.self, id: bug.id))
+        
+        try requireFixture(db).delete(bug)
+        
+        XCTAssertNil(try requireFixture(db).fetch(SimpleBug.self, id: bug.id))
+    }
+    
+    func testTypedDeleteByModelAsync() async throws {
+        let client = try requireFixture(db)
+        let bug = SimpleBug(title: "Async Typed Delete", priority: 4)
+        _ = try await client.insert(bug)
+        
+        let before = try await client.fetch(SimpleBug.self, id: bug.id)
+        XCTAssertNotNil(before)
+        
+        try await client.delete(bug)
+        
+        let after = try await client.fetch(SimpleBug.self, id: bug.id)
+        XCTAssertNil(after)
+    }
+    
+    // MARK: - Direct CRUD Golden Path
+    
+    func testDirectCRUDGoldenPath() throws {
+        let db = try requireFixture(self.db)
+        
+        var user = SimpleBug(title: "Alice", priority: 5)
+        try db.insert(user)
+        
+        let fetched = try db.fetch(SimpleBug.self, id: user.id)
+        XCTAssertEqual(fetched?.title, "Alice")
+        
+        let all = try db.fetchAll(SimpleBug.self)
+        XCTAssertTrue(all.contains { $0.id == user.id })
+        
+        user.title = "Alice (updated)"
+        user.priority = 9
+        try db.update(user)
+        XCTAssertEqual(try db.fetch(SimpleBug.self, id: user.id)?.title, "Alice (updated)")
+        
+        let wasInsert = try db.upsert(user)
+        XCTAssertFalse(wasInsert)
+        
+        try db.delete(user)
+        XCTAssertNil(try db.fetch(SimpleBug.self, id: user.id))
+    }
+    
     // MARK: - Complex Types
     
     func testComplexCodableType() throws {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Changed
+
+- **Package surface simplified:** Published SwiftPM products reduced to `BlazeDB` (umbrella) and `BlazeDBCore` (advanced). Tool, example, and benchmark executables (BlazeShell, HelloBlazeDB, BlazeDoctor, BlazeDump, BlazeInfo, BlazeDBBenchmarks, BasicExample, ReferenceConsumer) are still buildable locally via `swift run <name>` but no longer appear in Xcode's "Add Package Dependencies" picker. If you previously depended on one of these executable products from another package, reference the target directly instead.
+- **Direct CRUD is now the documented primary API.** `db.insert(model)`, `db.fetch(T.self, id:)`, `db.fetchAll(T.self)`, `db.update(model)`, `db.upsert(model)`, `db.delete(model)`, and `db.query(T.self)` are the recommended path. `TypedStore` (`db.typed(T.self)`) remains available as an optional scoped handle for view models and service layers.
+
+### Added
+
+- `BlazeDBClient.delete(_:)` typed convenience for `BlazeStorable` models (sync + async).
+
 ---
 
 ## [2.7.4] - 2026-04-08

--- a/Docs/GettingStarted/HOW_TO_USE_BLAZEDB.md
+++ b/Docs/GettingStarted/HOW_TO_USE_BLAZEDB.md
@@ -29,9 +29,10 @@ If you need multiple processes writing to the same database, BlazeDB is not the 
 
 ## 2. Quick Start
 
-BlazeDB has three public API tiers:
+BlazeDB has several API tiers:
 
-- **Typed (recommended):** `BlazeStorable` + `db.typed(T.self)`
+- **Direct CRUD (recommended):** `BlazeStorable` + `db.insert(model)` / `db.fetch(T.self, id:)` / `db.query(T.self)`
+- **TypedStore (optional):** `db.typed(T.self)` — scoped handle for view models / service layers
 - **Raw explicit:** `BlazeDataRecord` + string-field query builder
 - **Manual mapping:** `BlazeDocument` with `toStorage()` / `init(from:)`
 
@@ -46,14 +47,13 @@ struct Counter: BlazeStorable {
 
 // Open database (creates if needed, always encrypted)
 let db = try BlazeDBClient.open(named: "myapp", password: "your-secure-password")
-let counters = db.typed(Counter.self)
 
-// Insert typed records
-try counters.insert(Counter(name: "Alice", count: 10))
-try counters.insert(Counter(name: "Bob", count: 20))
+// Insert
+try db.insert(Counter(name: "Alice", count: 10))
+try db.insert(Counter(name: "Bob", count: 20))
 
 // Query with KeyPaths
-let results = try counters.query()
+let results = try db.query(Counter.self)
     .where(\.count, greaterThan: 15)
     .all()
 

--- a/Docs/GettingStarted/README.md
+++ b/Docs/GettingStarted/README.md
@@ -17,7 +17,7 @@ Add to your `Package.swift`:
 
 ```swift
 dependencies: [
- .package(url: "https://github.com/Mikedan37/BlazeDB.git", from: "2.7.2")
+ .package(url: "https://github.com/Mikedan37/BlazeDB.git", from: "2.7.4")
 ],
 targets: [
  .target(name: "YourApp", dependencies: ["BlazeDB"])
@@ -58,14 +58,14 @@ struct User: BlazeStorable {
 // 2. Open database (creates if needed, always encrypted)
 let db = try BlazeDBClient.open(named: "myapp", password: "My-Secure-Password-2026!")
 
-// 3. Get a typed store
-let users = db.typed(User.self)
+// 3. Insert
+try db.insert(User(name: "Alice", age: 30, active: true))
 
-// 4. Insert
-try users.insert(User(name: "Alice", age: 30, active: true))
+// 4. Fetch
+let alice = try db.fetch(User.self, id: aliceId)
 
 // 5. Query with KeyPaths
-let activeUsers = try users.query()
+let activeUsers = try db.query(User.self)
     .where(\.active, equals: true)
     .all()
 
@@ -94,11 +94,12 @@ BlazeDB offers three API tiers. Use whichever fits your needs:
 
 | Tier | Protocol | Best for |
 |------|----------|----------|
-| **Typed (recommended)** | `BlazeStorable` + `TypedStore` | Most apps — Codable models, KeyPath queries, minimal boilerplate |
+| **Direct CRUD (recommended)** | `BlazeStorable` + `db.insert(model)` / `db.fetch(T.self, id:)` | Most apps — Codable models, KeyPath queries, minimal boilerplate |
+| **TypedStore (optional)** | `db.typed(T.self)` → scoped handle | View models, service layers that want a bound store |
 | **Raw explicit** | `BlazeDataRecord` | Dynamic schemas, migration scripts, schemaless exploration |
 | **Manual mapping** | `BlazeDocument` | Custom serialization, non-Codable types, full field control |
 
-### Typed API (Recommended)
+### Direct CRUD (Recommended)
 
 ```swift
 struct Task: BlazeStorable {
@@ -108,16 +109,14 @@ struct Task: BlazeStorable {
     var done: Bool
 }
 
-let tasks = db.typed(Task.self)
-
 // Insert
-try tasks.insert(Task(title: "Ship v3", priority: 9, done: false))
+try db.insert(Task(title: "Ship v3", priority: 9, done: false))
 
 // Fetch by ID
-let task = try tasks.fetch(someID)
+let task = try db.fetch(Task.self, id: someID)
 
 // Query with KeyPaths
-let urgent = try tasks.query()
+let urgent = try db.query(Task.self)
     .where(\.priority, greaterThan: 7)
     .orderBy(\.title)
     .all()
@@ -125,10 +124,10 @@ let urgent = try tasks.query()
 // Update
 var t = task!
 t.done = true
-try tasks.update(t)
+try db.update(t)
 
 // Delete
-try tasks.delete(t.id)
+try db.delete(t)
 ```
 
 ### SwiftUI Query Observation (App Dev DX)

--- a/Package.swift
+++ b/Package.swift
@@ -257,37 +257,18 @@ let package = Package(
         // Linux support available (implicit when not specified)
     ],
     products: [
-        // Umbrella library — re-exports BlazeDBCore
+        // Default app-developer library. Most consumers should depend on this.
         .library(
             name: "BlazeDB",
             targets: ["BlazeDB"]),
+        // Advanced / lower-level core module. Use only if you need the implementation
+        // module name directly (e.g. for test targets or core-only embedding).
         .library(
             name: "BlazeDBCore",
             targets: ["BlazeDBCore"]),
-        .executable(
-            name: "BlazeShell",
-            targets: ["BlazeShell"]),
-        .executable(
-            name: "BasicExample",
-            targets: ["BasicExample"]),
-        .executable(
-            name: "BlazeDoctor",
-            targets: ["BlazeDoctor"]),
-        .executable(
-            name: "BlazeDump",
-            targets: ["BlazeDump"]),
-        .executable(
-            name: "BlazeInfo",
-            targets: ["BlazeInfo"]),
-        .executable(
-            name: "BlazeDBBenchmarks",
-            targets: ["BlazeDBBenchmarks"]),
-        .executable(
-            name: "HelloBlazeDB",
-            targets: ["HelloBlazeDB"]),
-        .executable(
-            name: "ReferenceConsumer",
-            targets: ["ReferenceConsumer"])
+        // Tool / example / benchmark executable targets remain in the package for local
+        // `swift run` but are not published as products — they are not intended as
+        // downstream SwiftPM dependencies. See CHANGELOG.md for the migration note.
     ],
     dependencies: [
         // Core OSS dependency set only. Distributed transport dependencies

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ An encrypted, embedded document database for Swift. Single-process, zero externa
 
 | Tier | API | Use case |
 |------|-----|----------|
-| **Typed (recommended)** | `BlazeStorable` + `db.typed(T.self)` | Codable models, KeyPath queries |
+| **Direct CRUD (recommended)** | `BlazeStorable` + `db.insert(model)` / `db.fetch(T.self, id:)` | Codable models, most app code |
+| **TypedStore (optional)** | `db.typed(T.self)` → scoped handle | View models, service layers that want a bound store |
 | **Raw** | `BlazeDataRecord` + `db.insert(record)` | Dynamic schemas, migrations |
 | **Manual mapping** | `BlazeDocument` | Custom storage control, `@BlazeQueryTyped` |
 
@@ -58,19 +59,21 @@ struct User: BlazeStorable {
 }
 
 let db = try BlazeDBClient.open(named: "myapp", password: "MyApp-Password-2026A!")
-let users = db.typed(User.self)
 
 // Insert
-try users.insert(User(name: "Alice", age: 30, active: true))
+try db.insert(User(name: "Alice", age: 30, active: true))
 
-// Query with KeyPaths
-let activeUsers = try users.query()
-    .where(\.active, equals: true)
-    .all()
+// Fetch one
+let alice = try db.fetch(User.self, id: aliceId)
 
 // Fetch all
-let everyone = try users.fetchAll()
+let everyone = try db.fetchAll(User.self)
 print("Users: \(everyone.count)")
+
+// Query with KeyPaths
+let activeUsers = try db.query(User.self)
+    .where(\.active, equals: true)
+    .all()
 
 try db.close()
 ```
@@ -106,13 +109,13 @@ Or in Xcode: **File → Add Package Dependencies** → paste `https://github.com
 
 ### Single-collection architecture
 
-BlazeDB stores all records in one encrypted document collection per database file. When you call `db.typed(User.self)`, you get a typed lens (a `TypedStore<User>`) — not a separate physical table. The typed store encodes/decodes through the `BlazeStorable` Codable bridge and filters records by decodability.
+BlazeDB stores all records in one encrypted document collection per database file. All typed APIs (`db.insert(model)`, `db.typed(T.self)`, etc.) encode/decode through the `BlazeStorable` Codable bridge and filter records by decodability — they are not separate physical tables.
 
 ### Two typed protocols
 
 | Protocol | Purpose | Used with |
 |----------|---------|-----------|
-| **`BlazeStorable`** | Automatic Codable serialization, KeyPath queries | `TypedStore`, `db.typed(T.self)` |
+| **`BlazeStorable`** | Automatic Codable serialization, KeyPath queries | `db.insert(model)`, `db.fetch(T.self, id:)`, `db.query(T.self)`, `db.typed(T.self)` |
 | **`BlazeDocument`** | Manual `toStorage()`/`init(from:)` mapping, more control | `@BlazeQueryTyped` SwiftUI wrapper |
 
 `BlazeStorable` is the recommended starting point. `BlazeDocument` is for when you need manual control over how your model maps to `BlazeDataRecord` storage. Both require `Codable` and `Identifiable` with `ID == UUID`.
@@ -129,26 +132,33 @@ The production runtime is always encrypted at rest. Every data page is sealed wi
 
 ## API Overview
 
-### TypedStore (recommended)
+### Direct CRUD (recommended)
 
-`TypedStore<T>` provides full CRUD and query operations bound to a single `BlazeStorable` model type:
+Call typed methods directly on `BlazeDBClient`:
 
 ```swift
-let users = db.typed(User.self)
+try db.insert(user)                              // Insert one
+try db.insertMany([user1, user2])                // Insert batch
+let user = try db.fetch(User.self, id: userId)   // Fetch by UUID
+let all = try db.fetchAll(User.self)             // Fetch all
+try db.update(user)                              // Update by id
+try db.upsert(user)                              // Insert or update
+try db.delete(user)                              // Delete by model
 
-try users.insert(user)                          // Insert one
-try users.insertMany([user1, user2])             // Insert batch
-let user = try users.fetch(id)                   // Fetch by UUID
-let all = try users.fetchAll()                   // Fetch all
-try users.update(user)                           // Update by id
-try users.upsert(user)                           // Insert or update
-try users.delete(id)                             // Delete by id
-let count = try users.count()                    // Count all
-
-let results = try users.query()
+let results = try db.query(User.self)
     .where(\.age, greaterThanOrEqual: 21)
     .orderBy(\.name, descending: false)
     .all()
+```
+
+### TypedStore (optional)
+
+`TypedStore<T>` wraps the same operations into a scoped handle, useful when you want to pass a "users store" to a view model:
+
+```swift
+let users = db.typed(User.self)
+try users.insert(user)
+let all = try users.fetchAll()
 ```
 
 ### Raw API


### PR DESCRIPTION
## Summary

- **Trim published SwiftPM products** to `BlazeDB` + `BlazeDBCore` only. Tool, example, and benchmark executables (BlazeShell, HelloBlazeDB, BlazeDoctor, BlazeDump, BlazeInfo, BlazeDBBenchmarks, BasicExample, ReferenceConsumer) remain buildable locally via `swift run` / `swift build --target` but no longer appear in Xcode's "Add Package Dependencies" picker.
- **Center direct model-based CRUD on `BlazeDBClient`** as the documented golden path (`insert`, `fetch`, `fetchAll`, `update`, `upsert`, `delete`, `query`). These methods already existed — this is a documentation and emphasis change, not a new API surface.
- **Add typed `delete(_:)` convenience** (sync + async) for `BlazeStorable` models, completing CRUD symmetry.
- **Reposition `TypedStore`** as an optional scoped handle rather than the recommended default.
- **Update README, Getting Started, HOW_TO_USE, Quick Help doc comments, and CHANGELOG** to reflect the simplified package surface and primary API path.

## CI risk assessment

- No CI workflow references the removed published products via `--product` or `swift run`. All existing CLI tool builds use `--target`, which resolves against the target definition (still present).
- The only runtime addition is `delete<T: BlazeStorable>(_:)` — no overload ambiguity with existing `delete(id:)`.
- 33/33 `CodableIntegrationTests` pass locally with zero regressions.

## Test plan

- [x] `testTypedDeleteByModel` — sync typed delete on BlazeDBClient (new)
- [x] `testTypedDeleteByModelAsync` — async typed delete (new)
- [x] `testDirectCRUDGoldenPath` — full insert -> fetch -> fetchAll -> update -> upsert -> delete cycle (new)
- [x] All 30 pre-existing CodableIntegrationTests pass unchanged
- [x] `swift build --target BlazeDB` succeeds
- [x] `swift build --target BlazeDoctor` succeeds (verifies `--target` still works for unpublished targets)
- [x] `swift package dump-package` confirms only `['BlazeDB', 'BlazeDBCore']` in products