### PR TITLE
ci: fix Tier3 Heavy test filter (exclude Heavy_Perf)

### DIFF
--- a/.github/workflows/deep-validation.yml
+++ b/.github/workflows/deep-validation.yml
@@ -72,7 +72,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p .logs
-          swift test --filter BlazeDB_Tier3_Heavy 2>&1 | tee .logs/tier3-heavy.log
+          swift test --filter 'BlazeDB_Tier3_Heavy\.' 2>&1 | tee .logs/tier3-heavy.log
           swift test --filter BlazeDB_Tier3_Heavy_Perf 2>&1 | tee .logs/tier3-heavy-perf.log
 
       - name: Test Tier 3 destructive/fault injection

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -54,7 +54,8 @@ jobs:
           mkdir -p .logs
           # SwiftPM enables Swift Testing alongside XCTest; this repo has no @Test suites, so the
           # Swift Testing runner exits non-zero ("0 tests") and fails the step unless disabled.
-          swift test --disable-swift-testing --filter BlazeDB_Tier3_Heavy 2>&1 | tee .logs/tier3-heavy.log
+          # Plain BlazeDB_Tier3_Heavy matches BlazeDB_Tier3_Heavy_Perf (regex substring); require the bundle dot.
+          swift test --disable-swift-testing --filter 'BlazeDB_Tier3_Heavy\.' 2>&1 | tee .logs/tier3-heavy.log
           swift test --disable-swift-testing --filter BlazeDB_Tier3_Heavy_Perf 2>&1 | tee .logs/tier3-heavy-perf.log
 
       - name: Dump diagnostics on failure

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
           set -euo pipefail
           mkdir -p .logs
           echo "Running Tier 3 heavy tests..."
-          swift test --filter BlazeDB_Tier3_Heavy 2>&1 | tee .logs/tier3-heavy.log
+          swift test --filter 'BlazeDB_Tier3_Heavy\.' 2>&1 | tee .logs/tier3-heavy.log
           swift test --filter BlazeDB_Tier3_Heavy_Perf 2>&1 | tee .logs/tier3-heavy-perf.log
 
       - name: Run sanitizer tests

--- a/.github/workflows/tier1-depth.yml
+++ b/.github/workflows/tier1-depth.yml
@@ -50,7 +50,8 @@ jobs:
       - name: Test Tier 3 heavy (+ transitional perf companion)
         run: |
           set -euo pipefail
-          swift test --filter BlazeDB_Tier3_Heavy 2>&1 | tee .logs/tier3-heavy.log
+          # Plain BlazeDB_Tier3_Heavy matches BlazeDB_Tier3_Heavy_Perf (regex substring); require the bundle dot.
+          swift test --filter 'BlazeDB_Tier3_Heavy\.' 2>&1 | tee .logs/tier3-heavy.log
           swift test --filter BlazeDB_Tier3_Heavy_Perf 2>&1 | tee .logs/tier3-heavy-perf.log
 
       - name: Dump diagnostics on failure


### PR DESCRIPTION
## Problem

`swift test --filter` uses a regular expression. The pattern `BlazeDB_Tier3_Heavy` matches **both** the intended bundle (`BlazeDB_Tier3_Heavy.*`) and `BlazeDB_Tier3_Heavy_Perf.*`, because `BlazeDB_Tier3_Heavy` is a substring of `BlazeDB_Tier3_Heavy_Perf`.

That caused the first "Heavy" invocation to also run all Perf tests, then the second step ran Perf again.

## Change

Use `'BlazeDB_Tier3_Heavy\.'` so only test names with the Heavy bundle prefix (`BlazeDB_Tier3_Heavy.`) match; `BlazeDB_Tier3_Heavy_Perf.*` does not contain `Heavy.` before `_Perf`.

## Files

- `.github/workflows/nightly.yml` (comment + filter)
- `.github/workflows/tier1-depth.yml`
- `.github/workflows/deep-validation.yml`
- `.github/workflows/release.yml`