### PR TITLE
ci: stream Tier2 swift test logs (verify_execution_coverage)

### DIFF
--- a/Scripts/run-tier2.sh
+++ b/Scripts/run-tier2.sh
@@ -26,9 +26,13 @@ fi
 RUN_ID="$(date +%Y%m%d-%H%M%S)"
 ARTIFACT_DIR=".artifacts/integration/${RUN_ID}"
 mkdir -p "$ARTIFACT_DIR"
+# Unbuffered Python so progress lines flush before long swift test runs.
+export PYTHONUNBUFFERED=1
 set +e
+echo ">> Tier2: starting verify_execution_coverage BlazeDB_Tier2 (swift test streams below)..."
 python3 ./Scripts/verify_execution_coverage.py --target BlazeDB_Tier2 --artifact-dir "$ARTIFACT_DIR" --allowed-missing 0 --num-workers 2
 rc_main=$?
+echo ">> Tier2: BlazeDB_Tier2 finished (exit ${rc_main}); starting BlazeDB_Tier2_Extended..."
 python3 ./Scripts/verify_execution_coverage.py --target BlazeDB_Tier2_Extended --artifact-dir "$ARTIFACT_DIR" --allowed-missing 0 --num-workers 2
 rc_extended=$?
 rc=$(( rc_main != 0 ? rc_main : rc_extended ))

--- a/Scripts/verify_execution_coverage.py
+++ b/Scripts/verify_execution_coverage.py
@@ -21,8 +21,17 @@ from pathlib import Path
 TEST_ID_RE = re.compile(r"^([A-Za-z0-9_]+)\.([A-Za-z0-9_]+)/([A-Za-z0-9_]+)$")
 
 
-def run(cmd: list[str], cwd: Path, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(cmd, cwd=str(cwd), capture_output=True, text=True, check=False, env=env)
+def run(
+    cmd: list[str],
+    cwd: Path,
+    env: dict[str, str] | None = None,
+    *,
+    capture: bool = True,
+) -> subprocess.CompletedProcess[str] | subprocess.CompletedProcess[bytes]:
+    if capture:
+        return subprocess.run(cmd, cwd=str(cwd), capture_output=True, text=True, check=False, env=env)
+    # Stream to inherited stdout/stderr so CI logs stay live during long swift test runs.
+    return subprocess.run(cmd, cwd=str(cwd), check=False, env=env)
 
 
 def parse_discovered(text: str, target: str) -> set[str]:
@@ -72,6 +81,7 @@ def main() -> int:
 
     # SwiftPM discovery flags vary by toolchain. Prefer modern `swift test list`
     # and rely on parse_discovered() to filter by target prefix.
+    print(f">> verify_execution_coverage: discovery (swift test list) for {args.target}", flush=True)
     list_cmd = ["swift", "test", "list", "--skip-build"]
     list_proc = run(list_cmd, pkg_root)
     if list_proc.returncode != 0:
@@ -83,7 +93,7 @@ def main() -> int:
         print(f"DISCOVERY_FAILED:{args.target}", file=sys.stderr)
         return 20
 
-    discovered = parse_discovered(list_proc.stdout, args.target)
+    discovered = parse_discovered(str(list_proc.stdout), args.target)
     xunit_path = artifact_dir / f"{args.target}.xunit.xml"
     run_cmd = [
         "swift",
@@ -99,7 +109,11 @@ def main() -> int:
     run_env = os.environ.copy()
     if args.target == "BlazeDB_Tier0":
         run_env["BLAZEDB_TEST_SCOPE"] = "tier0"
-    run_proc = run(run_cmd, pkg_root, env=run_env)
+    print(
+        f">> verify_execution_coverage: running swift test (parallel workers={args.num_workers}) for {args.target}",
+        flush=True,
+    )
+    run_proc = run(run_cmd, pkg_root, env=run_env, capture=False)
 
     executed = parse_executed_from_xunit(xunit_path)
     missing = sorted(discovered - executed)
@@ -124,10 +138,14 @@ def main() -> int:
     out_path = artifact_dir / f"{args.target}.execution.json"
     out_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
 
-    # First honor test execution failure.
+    # First honor test execution failure (stdout/stderr only when capture was used).
     if run_proc.returncode != 0:
-        sys.stdout.write(run_proc.stdout)
-        sys.stderr.write(run_proc.stderr)
+        out = run_proc.stdout
+        err = run_proc.stderr
+        if out:
+            sys.stdout.write(out if isinstance(out, str) else out.decode("utf-8", errors="replace"))
+        if err:
+            sys.stderr.write(err if isinstance(err, str) else err.decode("utf-8", errors="replace"))
         return run_proc.returncode
 
     if len(missing) > args.allowed_missing:


### PR DESCRIPTION
## Problem

`verify_execution_coverage.py` used `subprocess.run(..., capture_output=True)` for the main `swift test` run, so CI printed **nothing** until the entire suite finished. Tier 2 strict (via `run-tier2.sh`) looked hung right after the banner.

## Changes

- **Stream** the long `swift test` invocation (inherited stdout/stderr) so XCTest output appears live.
- Keep **captured** output for short `swift test list` discovery.
- Print **progress lines** (flushed) before discovery and before the test run.
- **`run-tier2.sh`**: `PYTHONUNBUFFERED=1` and echo markers between BlazeDB_Tier2 and BlazeDB_Tier2_Extended.

## Files

- `Scripts/verify_execution_coverage.py`
- `Scripts/run-tier2.sh`