### PR TITLE
docs(readme): fixing badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@ An encrypted, embedded document database for Swift. Single-process, zero externa
 [![Swift](https://img.shields.io/badge/Swift-6.0+-orange.svg)](https://swift.org)
 [![Platforms](https://img.shields.io/badge/Platforms-macOS%20%7C%20iOS%20%7C%20watchOS%20%7C%20tvOS%20%7C%20visionOS%20%7C%20Linux%20%7C%20Android-lightgrey.svg)](Docs/COMPATIBILITY.md)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![CI](https://github.com/Mikedan37/BlazeDB/actions/workflows/ci.yml/badge.svg)](https://github.com/Mikedan37/BlazeDB/actions/workflows/ci.yml)
-[![Nightly](https://github.com/Mikedan37/BlazeDB/actions/workflows/nightly.yml/badge.svg)](https://github.com/Mikedan37/BlazeDB/actions/workflows/nightly.yml)
 
 ---
 


### PR DESCRIPTION
## Summary
- remove CI and nightly workflow status badges from the README header
- keep Swift, platform, and license badges intact

## Test plan
- [x] Verified README header contains only product metadata badges
- [x] Confirmed docs-only change