### PR TITLE
fix(tier1): linux-only query-suite runtime relief

### DIFF
--- a/BlazeDBTests/Tier1Core/Helpers/LinuxTier1NonCryptoKDFHarness.swift
+++ b/BlazeDBTests/Tier1Core/Helpers/LinuxTier1NonCryptoKDFHarness.swift
@@ -1,0 +1,36 @@
+//  LinuxTier1NonCryptoKDFHarness.swift
+//  BlazeDBTests
+//
+//  WARNING: TEST-ONLY CI RUNTIME HARNESS.
+//  This is intentionally loud so it is not mistaken for product behavior.
+
+import XCTest
+#if canImport(BlazeDBCore)
+@testable import BlazeDBCore
+#else
+@testable import BlazeDB
+#endif
+
+/// Linux-only runtime relief harness for non-crypto Tier1 suites.
+///
+/// Why this exists:
+/// - Tier1 query/CRUD suites validate behavior, not PBKDF2 cost tuning.
+/// - Linux Tier1 wall time is dominated by repeated DB init KDF overhead.
+///
+/// Guardrail:
+/// - Crypto/security suites must NOT inherit from this class.
+open class LinuxTier1NonCryptoKDFHarness: XCTestCase {
+    override open class func setUp() {
+        super.setUp()
+        #if os(Linux)
+        KeyManager.setTestPBKDF2IterationsOverride(10_000)
+        #endif
+    }
+
+    override open class func tearDown() {
+        #if os(Linux)
+        KeyManager.setTestPBKDF2IterationsOverride(nil)
+        #endif
+        super.tearDown()
+    }
+}

--- a/BlazeDBTests/Tier1Core/Query/BlazeQueryObservationIntegrationTests.swift
+++ b/BlazeDBTests/Tier1Core/Query/BlazeQueryObservationIntegrationTests.swift
@@ -10,7 +10,7 @@ import SwiftUI
 import Combine
 
 @MainActor
-final class BlazeQueryObservationIntegrationTests: XCTestCase {
+final class BlazeQueryObservationIntegrationTests: LinuxTier1NonCryptoKDFHarness {
     private var db: BlazeDBClient?
     private var dbURL: URL?
 

--- a/BlazeDBTests/Tier1Core/Query/BlazeQueryTests.swift
+++ b/BlazeDBTests/Tier1Core/Query/BlazeQueryTests.swift
@@ -12,7 +12,7 @@ import XCTest
 @testable import BlazeDB
 #endif
 
-final class BlazeQueryTests: XCTestCase {
+final class BlazeQueryTests: LinuxTier1NonCryptoKDFHarness {
     private var db: BlazeDBClient?
     private var tempURL: URL?
 

--- a/BlazeDBTests/Tier1Core/Query/GraphQueryAPITests.swift
+++ b/BlazeDBTests/Tier1Core/Query/GraphQueryAPITests.swift
@@ -5,7 +5,7 @@ import XCTest
 @testable import BlazeDB
 #endif
 
-final class GraphQueryAPITests: XCTestCase {
+final class GraphQueryAPITests: LinuxTier1NonCryptoKDFHarness {
     private var dbURL: URL?
     private var db: BlazeDBClient?
 

--- a/BlazeDBTests/Tier1Core/Query/QueryBuilderEdgeCaseTests.swift
+++ b/BlazeDBTests/Tier1Core/Query/QueryBuilderEdgeCaseTests.swift
@@ -10,10 +10,52 @@ import XCTest
 @testable import BlazeDB
 #endif
 
-final class QueryBuilderEdgeCaseTests: XCTestCase {
+final class QueryBuilderEdgeCaseTests: LinuxTier1NonCryptoKDFHarness {
     
     private var tempURL: URL?
     private var db: BlazeDBClient?
+    
+    // Linux-only boundary datasets for Tier1 runtime control.
+    // Keep macOS fixture sizes unchanged to avoid behavior drift there.
+    private var largeDatasetQueryRecordCount: Int {
+        #if os(Linux)
+        return 1001
+        #else
+        return 2000
+        #endif
+    }
+    
+    private var largeDatasetLimitRecordCount: Int {
+        #if os(Linux)
+        return 101
+        #else
+        return 2000
+        #endif
+    }
+    
+    private var heavyJoinPrefilterRecordCount: Int {
+        #if os(Linux)
+        return 101
+        #else
+        return 1000
+        #endif
+    }
+    
+    private var verySelectiveFilterRecordCount: Int {
+        #if os(Linux)
+        return 1001
+        #else
+        return 2000
+        #endif
+    }
+    
+    private var memoryEfficiencyRecordCount: Int {
+        #if os(Linux)
+        return 101
+        #else
+        return 2000
+        #endif
+    }
     
     override func setUpWithError() throws {
         try super.setUpWithError()
@@ -237,8 +279,8 @@ final class QueryBuilderEdgeCaseTests: XCTestCase {
     // MARK: - Large Dataset Edge Cases
     
     func testQueryOn10KRecords() throws {
-        // Keep this as a large-dataset correctness check without making Tier1 Linux nightly stall.
-        let recordCount = 2_000
+        // Boundary-focused on Linux, unchanged stress profile on macOS.
+        let recordCount = largeDatasetQueryRecordCount
         let records = (0..<recordCount).map { i in
             BlazeDataRecord([
                 "index": .int(i),
@@ -255,7 +297,8 @@ final class QueryBuilderEdgeCaseTests: XCTestCase {
     }
     
     func testLimitOn10KRecords() throws {
-        let recordCount = 2_000
+        // Limit correctness only needs a limit-boundary dataset on Linux.
+        let recordCount = largeDatasetLimitRecordCount
         let records = (0..<recordCount).map { i in
             BlazeDataRecord(["index": .int(i)])
         }
@@ -535,10 +578,10 @@ final class QueryBuilderEdgeCaseTests: XCTestCase {
         let userID = UUID()
         _ = try requireFixture(usersDB).insert(BlazeDataRecord(["id": .uuid(userID), "name": .string("Alice")]))
         
-        // Insert 1000 bugs (batch insert - 10x faster!), only 1 matches filter
-        let bugRecords = (0..<1000).map { i in
+        // Boundary-focused on Linux; unchanged fixture volume on macOS.
+        let bugRecords = (0..<heavyJoinPrefilterRecordCount).map { i in
             BlazeDataRecord([
-                "title": .string(i == 500 ? "Special Bug" : "Bug \(i)"),
+                "title": .string(i == (heavyJoinPrefilterRecordCount / 2) ? "Special Bug" : "Bug \(i)"),
                 "status": .string("open"),
                 "author_id": .uuid(userID)
             ])
@@ -579,8 +622,8 @@ final class QueryBuilderEdgeCaseTests: XCTestCase {
     // MARK: - Stress Tests
     
     func testVerySelectiveFilter() throws {
-        // Large selective-filter correctness check with CI-safe dataset size.
-        let recordCount = 2_000
+        // Selective filter boundary on Linux, unchanged stress profile on macOS.
+        let recordCount = verySelectiveFilterRecordCount
         let specialIndex = recordCount / 2
         let records = (0..<recordCount).map { i in
             BlazeDataRecord([
@@ -601,7 +644,7 @@ final class QueryBuilderEdgeCaseTests: XCTestCase {
     
     func testQueryBuilderMemoryEfficiency() throws {
         // This validates limit behavior; it does not require a 5k insert to be meaningful.
-        let recordCount = 2_000
+        let recordCount = memoryEfficiencyRecordCount
         let records = (0..<recordCount).map { i in
             BlazeDataRecord([
                 "index": .int(i),

--- a/BlazeDBTests/Tier1Core/Query/QueryErgonomicsTests.swift
+++ b/BlazeDBTests/Tier1Core/Query/QueryErgonomicsTests.swift
@@ -14,7 +14,7 @@ import XCTest
 @testable import BlazeDB
 #endif
 
-final class QueryErgonomicsTests: XCTestCase {
+final class QueryErgonomicsTests: LinuxTier1NonCryptoKDFHarness {
     
     private var tempURL: URL?
     private var db: BlazeDBClient?

--- a/BlazeDBTests/Tier1Core/Query/QueryProfilingTests.swift
+++ b/BlazeDBTests/Tier1Core/Query/QueryProfilingTests.swift
@@ -12,7 +12,7 @@ import XCTest
 @testable import BlazeDB
 #endif
 
-final class QueryProfilingTests: XCTestCase {
+final class QueryProfilingTests: LinuxTier1NonCryptoKDFHarness {
     
     private var dbURL: URL?
     private var db: BlazeDBClient?

--- a/BlazeDBTests/Tier1Core/Query/QueryResultConversionTests.swift
+++ b/BlazeDBTests/Tier1Core/Query/QueryResultConversionTests.swift
@@ -15,7 +15,7 @@ import XCTest
 @testable import BlazeDB
 #endif
 
-final class QueryResultConversionTests: XCTestCase {
+final class QueryResultConversionTests: LinuxTier1NonCryptoKDFHarness {
     private var tempURL: URL?
     private var db: BlazeDBClient?
     


### PR DESCRIPTION
## Summary
- add a **Linux-only, test-only** non-crypto KDF harness (`LinuxTier1NonCryptoKDFHarness`) for Tier1 query suites
- keep crypto/security behavior untouched by making the harness opt-in and only applying it to non-crypto query suites
- apply one additional hotspot cleanup in `QueryBuilderEdgeCaseTests` using **Linux boundary-focused fixtures** (macOS fixture sizes remain unchanged)

## Runtime-cost reduction
- query suites now avoid repeated high-cost KDF setup on Linux Tier1 where KDF hardness is not the behavior under test
- `QueryBuilderEdgeCaseTests` heavy Linux fixture volumes are reduced to boundary-focused counts to remove brute-force runtime cost

## Correctness preservation
- crypto/security suites do not inherit from this harness and continue to exercise real KDF behavior
- macOS behavior/profile is unchanged by this PR
- query semantics and assertions are preserved; only Linux fixture volumes for the hotspot suite are adjusted

## Scope constraints honored
- no workflow changes
- no test-plan changes
- no product/runtime code changes
- no macOS behavior drift

## Test plan
- [x] Verify harness is opt-in and only used by non-crypto query suites
- [x] Verify no security/crypto Tier1 test classes inherit from the harness
- [ ] Re-run Nightly confidence Linux Tier1 and compare wall time after merge