### PR TITLE
fix(tier1): consolidate Linux runtime relief + index hotspot boundary tuning

### DIFF
--- a/BlazeDBTests/Tier1Core/Helpers/LinuxTier1NonCryptoKDFHarness.swift
+++ b/BlazeDBTests/Tier1Core/Helpers/LinuxTier1NonCryptoKDFHarness.swift
@@ -1,0 +1,36 @@
+//  LinuxTier1NonCryptoKDFHarness.swift
+//  BlazeDBTests
+//
+//  WARNING: TEST-ONLY CI RUNTIME HARNESS.
+//  This is intentionally loud so it is not mistaken for product behavior.
+
+import XCTest
+#if canImport(BlazeDBCore)
+@testable import BlazeDBCore
+#else
+@testable import BlazeDB
+#endif
+
+/// Linux-only runtime relief harness for non-crypto Tier1 suites.
+///
+/// Why this exists:
+/// - Tier1 query/CRUD suites validate behavior, not PBKDF2 cost tuning.
+/// - Linux Tier1 wall time is dominated by repeated DB init KDF overhead.
+///
+/// Guardrail:
+/// - Crypto/security suites must NOT inherit from this class.
+open class LinuxTier1NonCryptoKDFHarness: XCTestCase {
+    override open class func setUp() {
+        super.setUp()
+        #if os(Linux)
+        KeyManager.setTestPBKDF2IterationsOverride(10_000)
+        #endif
+    }
+
+    override open class func tearDown() {
+        #if os(Linux)
+        KeyManager.setTestPBKDF2IterationsOverride(nil)
+        #endif
+        super.tearDown()
+    }
+}

--- a/BlazeDBTests/Tier1Core/Indexes/BlazeIndexStressTests.swift
+++ b/BlazeDBTests/Tier1Core/Indexes/BlazeIndexStressTests.swift
@@ -22,6 +22,64 @@ final class BlazeIndexStressTests: XCTestCase {
     private var tempURL: URL?
     private var db: BlazeDBClient?
     
+    // Linux Tier1 uses boundary-focused fixture sizes to preserve correctness signal
+    // without carrying heavy-lane stress runtime cost.
+    private var linuxBoundaryRebuildCount: Int {
+        #if os(Linux)
+        return 1_001
+        #else
+        return 1_000
+        #endif
+    }
+    
+    private var linuxBoundaryHighCardinalityCount: Int {
+        #if os(Linux)
+        return 101
+        #else
+        return 500
+        #endif
+    }
+    
+    private var linuxBoundaryCompoundCount: Int {
+        #if os(Linux)
+        return 101
+        #else
+        return 500
+        #endif
+    }
+    
+    private var linuxBoundaryMaintenanceCount: Int {
+        #if os(Linux)
+        return 101
+        #else
+        return 1_000
+        #endif
+    }
+    
+    private var linuxBoundaryMaintenanceRounds: Int {
+        #if os(Linux)
+        return 2
+        #else
+        return 5
+        #endif
+    }
+    
+    private var linuxBoundaryScanVsIndexCount: Int {
+        #if os(Linux)
+        return 1_001
+        #else
+        return 500
+        #endif
+    }
+    
+    private var linuxBoundaryPersistenceCount: Int {
+        #if os(Linux)
+        return 101
+        #else
+        return 500
+        #endif
+    }
+    
     override func setUpWithError() throws {
         tempURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("BlazeIndexStress-\(UUID().uuidString).blazedb")
@@ -40,7 +98,7 @@ final class BlazeIndexStressTests: XCTestCase {
     /// Test index rebuild on large dataset
     /// Note: Set RUN_HEAVY_STRESS=1 to use 10k records, otherwise uses 1k
     func testIndexRebuildOn10kRecords() throws {
-        let count = ProcessInfo.processInfo.environment["RUN_HEAVY_STRESS"] == "1" ? 10_000 : 1_000
+        let count = ProcessInfo.processInfo.environment["RUN_HEAVY_STRESS"] == "1" ? 10_000 : linuxBoundaryRebuildCount
         
         print("📊 Inserting \(count) records...")
         for i in 0..<count {
@@ -84,7 +142,7 @@ final class BlazeIndexStressTests: XCTestCase {
     /// Test high cardinality index (many unique values)
     /// Note: Set RUN_HEAVY_STRESS=1 to use 5k records, otherwise uses 500
     func testHighCardinalityIndex() throws {
-        let count = ProcessInfo.processInfo.environment["RUN_HEAVY_STRESS"] == "1" ? 5_000 : 500
+        let count = ProcessInfo.processInfo.environment["RUN_HEAVY_STRESS"] == "1" ? 5_000 : linuxBoundaryHighCardinalityCount
         
         print("📊 Creating high cardinality index with \(count) unique values...")
         
@@ -126,7 +184,7 @@ final class BlazeIndexStressTests: XCTestCase {
     /// Test compound index with 3+ fields on large dataset
     /// Note: Set RUN_HEAVY_STRESS=1 to use 5k records, otherwise uses 500
     func testCompoundIndex3FieldsOn5kRecords() throws {
-        let count = ProcessInfo.processInfo.environment["RUN_HEAVY_STRESS"] == "1" ? 5_000 : 500
+        let count = ProcessInfo.processInfo.environment["RUN_HEAVY_STRESS"] == "1" ? 5_000 : linuxBoundaryCompoundCount
         
         print("📊 Testing compound index with 3 fields on \(count) records...")
         
@@ -171,8 +229,8 @@ final class BlazeIndexStressTests: XCTestCase {
     
     /// Test index maintenance during heavy updates
     func testIndexMaintenanceDuringUpdates() throws {
-        let count = 1_000
-        let updateRounds = 5
+        let count = linuxBoundaryMaintenanceCount
+        let updateRounds = linuxBoundaryMaintenanceRounds
         
         print("📊 Testing index maintenance with \(count) records x \(updateRounds) update rounds...")
         
@@ -227,7 +285,7 @@ final class BlazeIndexStressTests: XCTestCase {
     /// Test index performance vs full scan
     /// Note: Set RUN_HEAVY_STRESS=1 to use 5k records, otherwise uses 500
     func testIndexedVsFullScanPerformance() throws {
-        let count = ProcessInfo.processInfo.environment["RUN_HEAVY_STRESS"] == "1" ? 5_000 : 500
+        let count = ProcessInfo.processInfo.environment["RUN_HEAVY_STRESS"] == "1" ? 5_000 : linuxBoundaryScanVsIndexCount
         let searchValue = "target_value"
         
         print("📊 Comparing indexed vs full scan performance on \(count) records...")
@@ -278,7 +336,7 @@ final class BlazeIndexStressTests: XCTestCase {
     /// Test index survives restart with large dataset
     /// Note: Set RUN_HEAVY_STRESS=1 to use 5k records, otherwise uses 500
     func testIndexPersistenceWith5kRecords() throws {
-        let count = ProcessInfo.processInfo.environment["RUN_HEAVY_STRESS"] == "1" ? 5_000 : 500
+        let count = ProcessInfo.processInfo.environment["RUN_HEAVY_STRESS"] == "1" ? 5_000 : linuxBoundaryPersistenceCount
         
         print("📊 Testing index persistence with \(count) records...")
         

--- a/BlazeDBTests/Tier1Core/Query/BlazeQueryObservationIntegrationTests.swift
+++ b/BlazeDBTests/Tier1Core/Query/BlazeQueryObservationIntegrationTests.swift
@@ -10,7 +10,7 @@ import SwiftUI
 import Combine
 
 @MainActor
-final class BlazeQueryObservationIntegrationTests: XCTestCase {
+final class BlazeQueryObservationIntegrationTests: LinuxTier1NonCryptoKDFHarness {
     private var db: BlazeDBClient?
     private var dbURL: URL?
 

--- a/BlazeDBTests/Tier1Core/Query/BlazeQueryTests.swift
+++ b/BlazeDBTests/Tier1Core/Query/BlazeQueryTests.swift
@@ -12,7 +12,7 @@ import XCTest
 @testable import BlazeDB
 #endif
 
-final class BlazeQueryTests: XCTestCase {
+final class BlazeQueryTests: LinuxTier1NonCryptoKDFHarness {
     private var db: BlazeDBClient?
     private var tempURL: URL?
 

--- a/BlazeDBTests/Tier1Core/Query/GraphQueryAPITests.swift
+++ b/BlazeDBTests/Tier1Core/Query/GraphQueryAPITests.swift
@@ -5,7 +5,7 @@ import XCTest
 @testable import BlazeDB
 #endif
 
-final class GraphQueryAPITests: XCTestCase {
+final class GraphQueryAPITests: LinuxTier1NonCryptoKDFHarness {
     private var dbURL: URL?
     private var db: BlazeDBClient?
 

--- a/BlazeDBTests/Tier1Core/Query/QueryBuilderEdgeCaseTests.swift
+++ b/BlazeDBTests/Tier1Core/Query/QueryBuilderEdgeCaseTests.swift
@@ -10,10 +10,52 @@ import XCTest
 @testable import BlazeDB
 #endif
 
-final class QueryBuilderEdgeCaseTests: XCTestCase {
+final class QueryBuilderEdgeCaseTests: LinuxTier1NonCryptoKDFHarness {
     
     private var tempURL: URL?
     private var db: BlazeDBClient?
+    
+    // Linux-only boundary datasets for Tier1 runtime control.
+    // Keep macOS fixture sizes unchanged to avoid behavior drift there.
+    private var largeDatasetQueryRecordCount: Int {
+        #if os(Linux)
+        return 1001
+        #else
+        return 2000
+        #endif
+    }
+    
+    private var largeDatasetLimitRecordCount: Int {
+        #if os(Linux)
+        return 101
+        #else
+        return 2000
+        #endif
+    }
+    
+    private var heavyJoinPrefilterRecordCount: Int {
+        #if os(Linux)
+        return 101
+        #else
+        return 1000
+        #endif
+    }
+    
+    private var verySelectiveFilterRecordCount: Int {
+        #if os(Linux)
+        return 1001
+        #else
+        return 2000
+        #endif
+    }
+    
+    private var memoryEfficiencyRecordCount: Int {
+        #if os(Linux)
+        return 101
+        #else
+        return 2000
+        #endif
+    }
     
     override func setUpWithError() throws {
         try super.setUpWithError()
@@ -237,8 +279,8 @@ final class QueryBuilderEdgeCaseTests: XCTestCase {
     // MARK: - Large Dataset Edge Cases
     
     func testQueryOn10KRecords() throws {
-        // Keep this as a large-dataset correctness check without making Tier1 Linux nightly stall.
-        let recordCount = 2_000
+        // Boundary-focused on Linux, unchanged stress profile on macOS.
+        let recordCount = largeDatasetQueryRecordCount
         let records = (0..<recordCount).map { i in
             BlazeDataRecord([
                 "index": .int(i),
@@ -255,7 +297,8 @@ final class QueryBuilderEdgeCaseTests: XCTestCase {
     }
     
     func testLimitOn10KRecords() throws {
-        let recordCount = 2_000
+        // Limit correctness only needs a limit-boundary dataset on Linux.
+        let recordCount = largeDatasetLimitRecordCount
         let records = (0..<recordCount).map { i in
             BlazeDataRecord(["index": .int(i)])
         }
@@ -535,10 +578,10 @@ final class QueryBuilderEdgeCaseTests: XCTestCase {
         let userID = UUID()
         _ = try requireFixture(usersDB).insert(BlazeDataRecord(["id": .uuid(userID), "name": .string("Alice")]))
         
-        // Insert 1000 bugs (batch insert - 10x faster!), only 1 matches filter
-        let bugRecords = (0..<1000).map { i in
+        // Boundary-focused on Linux; unchanged fixture volume on macOS.
+        let bugRecords = (0..<heavyJoinPrefilterRecordCount).map { i in
             BlazeDataRecord([
-                "title": .string(i == 500 ? "Special Bug" : "Bug \(i)"),
+                "title": .string(i == (heavyJoinPrefilterRecordCount / 2) ? "Special Bug" : "Bug \(i)"),
                 "status": .string("open"),
                 "author_id": .uuid(userID)
             ])
@@ -579,8 +622,8 @@ final class QueryBuilderEdgeCaseTests: XCTestCase {
     // MARK: - Stress Tests
     
     func testVerySelectiveFilter() throws {
-        // Large selective-filter correctness check with CI-safe dataset size.
-        let recordCount = 2_000
+        // Selective filter boundary on Linux, unchanged stress profile on macOS.
+        let recordCount = verySelectiveFilterRecordCount
         let specialIndex = recordCount / 2
         let records = (0..<recordCount).map { i in
             BlazeDataRecord([
@@ -601,7 +644,7 @@ final class QueryBuilderEdgeCaseTests: XCTestCase {
     
     func testQueryBuilderMemoryEfficiency() throws {
         // This validates limit behavior; it does not require a 5k insert to be meaningful.
-        let recordCount = 2_000
+        let recordCount = memoryEfficiencyRecordCount
         let records = (0..<recordCount).map { i in
             BlazeDataRecord([
                 "index": .int(i),

--- a/BlazeDBTests/Tier1Core/Query/QueryErgonomicsTests.swift
+++ b/BlazeDBTests/Tier1Core/Query/QueryErgonomicsTests.swift
@@ -14,7 +14,7 @@ import XCTest
 @testable import BlazeDB
 #endif
 
-final class QueryErgonomicsTests: XCTestCase {
+final class QueryErgonomicsTests: LinuxTier1NonCryptoKDFHarness {
     
     private var tempURL: URL?
     private var db: BlazeDBClient?

--- a/BlazeDBTests/Tier1Core/Query/QueryExplainTests.swift
+++ b/BlazeDBTests/Tier1Core/Query/QueryExplainTests.swift
@@ -15,6 +15,40 @@ final class QueryExplainTests: XCTestCase {
     private var tempURL: URL?
     private var db: BlazeDBClient?
     
+    // Linux CI is currently the bottleneck lane for Tier1 wall time.
+    // Keep macOS stress sizes unchanged; use threshold-focused fixture sizes on Linux.
+    private var largeTableScanRecordCount: Int {
+        #if os(Linux)
+        return 1001
+        #else
+        return 15000
+        #endif
+    }
+    
+    private var largeSortRecordCount: Int {
+        #if os(Linux)
+        return 10001
+        #else
+        return 20000
+        #endif
+    }
+    
+    private var groupedAggregationRecordCount: Int {
+        #if os(Linux)
+        return 1200
+        #else
+        return 5000
+        #endif
+    }
+    
+    private var groupedAggregationFilterThreshold: Int {
+        #if os(Linux)
+        return 600
+        #else
+        return 2500
+        #endif
+    }
+    
     override func setUpWithError() throws {
         try super.setUpWithError()
         BlazeDBClient.clearCachedKey()
@@ -129,8 +163,7 @@ final class QueryExplainTests: XCTestCase {
     // MARK: - Warnings
     
     func testExplainWarnsLargeTableScan() throws {
-        // Batch insert 15k records (20x faster!)
-        let records = (0..<15000).map { i in
+        let records = (0..<largeTableScanRecordCount).map { i in
             BlazeDataRecord(["value": .int(i)])
         }
         _ = try requireFixture(db).insertMany(records)
@@ -138,7 +171,7 @@ final class QueryExplainTests: XCTestCase {
         let plan = try requireFixture(db).query().explain()
         
         // Should warn about large dataset
-        XCTAssertGreaterThan(plan.warnings.count, 0)
+        XCTAssertTrue(plan.warnings.contains { $0.contains("Large dataset") })
     }
     
     func testExplainWarnsManyFilters() throws {
@@ -158,8 +191,7 @@ final class QueryExplainTests: XCTestCase {
     }
     
     func testExplainWarnsLargeSort() throws {
-        // Batch insert 20k records (20x faster!)
-        let records = (0..<20000).map { i in
+        let records = (0..<largeSortRecordCount).map { i in
             BlazeDataRecord(["value": .int(i)])
         }
         _ = try requireFixture(db).insertMany(records)
@@ -169,7 +201,7 @@ final class QueryExplainTests: XCTestCase {
             .explain()
         
         // Should warn about sorting many records
-        XCTAssertGreaterThan(plan.warnings.count, 0)
+        XCTAssertTrue(plan.warnings.contains { $0.contains("Sorting") })
     }
     
     // MARK: - Estimation Accuracy
@@ -271,8 +303,7 @@ final class QueryExplainTests: XCTestCase {
     }
     
     func testExplainGroupedAggregation() throws {
-        // Batch insert 5000 records (15x faster!)
-        let records = (0..<5000).map { i in
+        let records = (0..<groupedAggregationRecordCount).map { i in
             BlazeDataRecord([
                 "team": .string("team_\(i % 10)"),
                 "value": .int(i)
@@ -281,7 +312,7 @@ final class QueryExplainTests: XCTestCase {
         _ = try requireFixture(db).insertMany(records)
         
         let plan = try requireFixture(db).query()
-            .where("value", greaterThan: .int(2500))
+            .where("value", greaterThan: .int(groupedAggregationFilterThreshold))
             .groupBy("team")
             .count()
             .sum("value")

--- a/BlazeDBTests/Tier1Core/Query/QueryProfilingTests.swift
+++ b/BlazeDBTests/Tier1Core/Query/QueryProfilingTests.swift
@@ -12,7 +12,7 @@ import XCTest
 @testable import BlazeDB
 #endif
 
-final class QueryProfilingTests: XCTestCase {
+final class QueryProfilingTests: LinuxTier1NonCryptoKDFHarness {
     
     private var dbURL: URL?
     private var db: BlazeDBClient?

--- a/BlazeDBTests/Tier1Core/Query/QueryResultConversionTests.swift
+++ b/BlazeDBTests/Tier1Core/Query/QueryResultConversionTests.swift
@@ -15,7 +15,7 @@ import XCTest
 @testable import BlazeDB
 #endif
 
-final class QueryResultConversionTests: XCTestCase {
+final class QueryResultConversionTests: LinuxTier1NonCryptoKDFHarness {
     private var tempURL: URL?
     private var db: BlazeDBClient?
     


### PR DESCRIPTION
## Summary
This PR consolidates the Linux Tier1 runtime fixes from this thread into one branch:

1. Linux-only `QueryExplainTests` fixture boundary tuning
2. Linux-only non-crypto Tier1 KDF override harness (opt-in query suites only)
3. One additional single-suite hotspot fix: Linux boundary-focused fixture tuning in `BlazeIndexStressTests`

No workflow/test-plan changes are included.

## Before timing (latest available nightly #22, Linux Tier1)
- `QueryBuilderEdgeCaseTests`: **629.152s**
- `QueryExplainTests`: **479.711s**
- `BlazeIndexStressTests`: **188.712s**
  - `testHighCardinalityIndex`: 52.697s
  - `testIndexMaintenanceDuringUpdates`: 42.623s
  - `testIndexRebuildOn10kRecords`: 31.824s
  - `testIndexPersistenceWith5kRecords`: 27.330s

## After expected timing
Conservative expected Linux Tier1 reduction from this full pack:
- `QueryExplainTests`: major reduction (removed multi-minute grouped/sort hotspots)
- query-suite fixed overhead reduction via Linux-only non-crypto KDF harness
- `BlazeIndexStressTests`: expected drop from ~189s to ~70-100s

Overall expected net improvement: meaningful nightly Linux Tier1 wall-time drop without reducing Tier1 semantic guarantees.

## Why Tier1 does not need larger dataset here
Tier1 for these suites is intended to validate:
- index correctness
- index persistence correctness after reopen
- indexed vs scan result parity
- index maintenance correctness after updates

It is **not** intended to serve as a medium-scale throughput benchmark.

## Where stress profile remains
Large-volume stress behavior remains available in heavier lanes via existing controls (for example `RUN_HEAVY_STRESS=1`) and deep/heavy validation lanes.

## Correctness preservation and scope controls
- Linux-only runtime relief
- macOS fixture profiles unchanged
- crypto/security suites do not use KDF override harness
- assertions retained (and in some places made more specific)
- no workflow churn, no test-plan churn