### PR TITLE
fix linux Tier1 nightly false failures

### DIFF
--- a/BlazeDBTests/Tier1Core/API/TriggerPersistenceAPITests.swift
+++ b/BlazeDBTests/Tier1Core/API/TriggerPersistenceAPITests.swift
@@ -19,6 +19,7 @@ final class TriggerPersistenceAPITests: XCTestCase {
         try? FileManager.default.removeItem(at: try requireFixture(metaURL))
     }
 
+    #if !BLAZEDB_LINUX_CORE
     func testOnInsertTriggerDefinitionIsPersistedToLayoutMetadata() throws {
         let db = try BlazeDBClient(name: "trigger-persist", fileURL: try requireFixture(dbURL), password: "TriggerPass-123!")
         defer { try? requireFixture(db).close() }
@@ -48,4 +49,9 @@ final class TriggerPersistenceAPITests: XCTestCase {
             "Registering onInsert trigger should persist trigger metadata"
         )
     }
+    #else
+    func testOnInsertTriggerDefinitionIsPersistedToLayoutMetadata() throws {
+        throw XCTSkip("Trigger metadata persistence is disabled under BLAZEDB_LINUX_CORE")
+    }
+    #endif
 }

--- a/BlazeDBTests/Tier1Core/Query/QueryBuilderEdgeCaseTests.swift
+++ b/BlazeDBTests/Tier1Core/Query/QueryBuilderEdgeCaseTests.swift
@@ -293,7 +293,9 @@ final class QueryBuilderEdgeCaseTests: LinuxTier1NonCryptoKDFHarness {
             .where("status", equals: .string("open"))
             .execute()
         
-        XCTAssertEqual(results.count, recordCount / 2)
+        // Sequence starts at 0, so odd dataset sizes have one extra even/open record.
+        let expectedOpenCount = (recordCount + 1) / 2
+        XCTAssertEqual(results.count, expectedOpenCount)
     }
     
     func testLimitOn10KRecords() throws {


### PR DESCRIPTION
## Summary
- Skip `TriggerPersistenceAPITests.testOnInsertTriggerDefinitionIsPersistedToLayoutMetadata` on Linux where trigger metadata persistence is compiled out via `BLAZEDB_LINUX_CORE`.
- Fix `QueryBuilderEdgeCaseTests.testQueryOn10KRecords` expected count for odd Linux boundary dataset sizes (`1001` records => `501` open records).
- Keep scope limited to Tier1 test logic only; no production code or workflow changes.

## Test plan
- [x] `TMPDIR=/home/mikeld37/tmp swift test --filter QueryBuilderEdgeCaseTests.testQueryOn10KRecords`
- [x] `TMPDIR=/home/mikeld37/tmp swift test --filter TriggerPersistenceAPITests.testOnInsertTriggerDefinitionIsPersistedToLayoutMetadata`