### PR TITLE
harden test harness temp lifecycle cleanup

### DIFF
--- a/Scripts/lib/temp_lifecycle.sh
+++ b/Scripts/lib/temp_lifecycle.sh
@@ -19,11 +19,12 @@ blazedb_temp_setup() {
   mkdir -p "$BLAZEDB_TEMP_ROOT"
   export TMPDIR="$BLAZEDB_TEMP_ROOT"
 
-  echo "[temp] created run temp root: $BLAZEDB_TEMP_ROOT"
-  echo "[temp] TMPDIR set to: $TMPDIR"
+  echo "[temp] root=$BLAZEDB_TEMP_ROOT"
 
-  blazedb_reap_stale_tmpdirs "/tmp" "$threshold_minutes"
-  blazedb_reap_stale_tmpdirs "$base_dir" "$threshold_minutes"
+  local reaped_total=0
+  reaped_total=$(( reaped_total + $(blazedb_reap_stale_tmpdirs "/tmp" "$threshold_minutes") ))
+  reaped_total=$(( reaped_total + $(blazedb_reap_stale_tmpdirs "$base_dir" "$threshold_minutes") ))
+  echo "[temp] reaped_stale=${reaped_total}"
 
   trap 'blazedb_temp_teardown $?' EXIT INT TERM
 }
@@ -34,8 +35,10 @@ blazedb_reap_stale_tmpdirs() {
   local now
   now="$(date +%s)"
   local removed=0
+  local skipped_live=0
 
   if [[ ! -d "$parent" ]]; then
+    echo 0
     return
   fi
 
@@ -48,6 +51,14 @@ blazedb_reap_stale_tmpdirs() {
     mtime="$(stat -c %Y "$d" 2>/dev/null || echo 0)"
     age_min=$(( (now - mtime) / 60 ))
     if (( age_min > threshold_minutes )); then
+      # Name format: blazedb-<purpose>-<pid>-<timestamp>; skip live PIDs when parseable.
+      local base pid
+      base="$(basename "$d")"
+      pid="$(echo "$base" | sed -nE 's/^blazedb-[^-]+-([0-9]+)-[0-9]{8}-[0-9]{6}$/\1/p')"
+      if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+        skipped_live=$((skipped_live + 1))
+        continue
+      fi
       if rm -rf "$d"; then
         removed=$((removed + 1))
       fi
@@ -55,9 +66,10 @@ blazedb_reap_stale_tmpdirs() {
   done
   shopt -u nullglob
 
-  if (( removed > 0 )); then
-    echo "[temp] reaped $removed stale blazedb-* dir(s) in $parent (>${threshold_minutes}m old)"
+  if (( skipped_live > 0 )); then
+    echo "[temp] skipped_live_pid=${skipped_live} parent=${parent}" >&2
   fi
+  echo "$removed"
 }
 
 blazedb_temp_teardown() {
@@ -71,13 +83,15 @@ blazedb_temp_teardown() {
   if [[ -n "${BLAZEDB_TEMP_ROOT:-}" && -d "${BLAZEDB_TEMP_ROOT}" ]]; then
     rm -rf "${BLAZEDB_TEMP_ROOT}" || true
     if [[ -d "${BLAZEDB_TEMP_ROOT}" ]]; then
-      echo "[temp] ERROR: leaked temp root still exists: ${BLAZEDB_TEMP_ROOT}"
+      echo "[temp] teardown=failed root=${BLAZEDB_TEMP_ROOT}"
       if [[ "$status" -eq 0 ]]; then
         status=99
       fi
     else
-      echo "[temp] removed run temp root: ${BLAZEDB_TEMP_ROOT}"
+      echo "[temp] teardown=ok root=${BLAZEDB_TEMP_ROOT}"
     fi
+  else
+    echo "[temp] teardown=ok root_missing_or_already_removed"
   fi
 
   trap - EXIT INT TERM

--- a/Scripts/lib/temp_lifecycle.sh
+++ b/Scripts/lib/temp_lifecycle.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+# Shared temp lifecycle management for local/CI harness scripts.
+# - Creates a per-run TMPDIR under .artifacts/tmp
+# - Reaps stale BlazeDB-owned temp roots
+# - Removes the run temp root on exit and fails loudly on leaks
+
+blazedb_temp_setup() {
+  local purpose="${1:-run}"
+  local base_dir="${2:-$(pwd)/.artifacts/tmp}"
+  local threshold_minutes="${BLAZEDB_TMP_REAP_MINUTES:-60}"
+  local ts
+  ts="$(date +%Y%m%d-%H%M%S)"
+
+  mkdir -p "$base_dir"
+
+  BLAZEDB_TEMP_ROOT="${base_dir}/blazedb-${purpose}-$$-${ts}"
+  export BLAZEDB_TEMP_ROOT
+  mkdir -p "$BLAZEDB_TEMP_ROOT"
+  export TMPDIR="$BLAZEDB_TEMP_ROOT"
+
+  echo "[temp] created run temp root: $BLAZEDB_TEMP_ROOT"
+  echo "[temp] TMPDIR set to: $TMPDIR"
+
+  blazedb_reap_stale_tmpdirs "/tmp" "$threshold_minutes"
+  blazedb_reap_stale_tmpdirs "$base_dir" "$threshold_minutes"
+
+  trap 'blazedb_temp_teardown $?' EXIT INT TERM
+}
+
+blazedb_reap_stale_tmpdirs() {
+  local parent="$1"
+  local threshold_minutes="$2"
+  local now
+  now="$(date +%s)"
+  local removed=0
+
+  if [[ ! -d "$parent" ]]; then
+    return
+  fi
+
+  shopt -s nullglob
+  for d in "$parent"/blazedb-*; do
+    [[ -d "$d" ]] || continue
+    [[ -n "${BLAZEDB_TEMP_ROOT:-}" && "$d" == "$BLAZEDB_TEMP_ROOT" ]] && continue
+
+    local mtime age_min
+    mtime="$(stat -c %Y "$d" 2>/dev/null || echo 0)"
+    age_min=$(( (now - mtime) / 60 ))
+    if (( age_min > threshold_minutes )); then
+      if rm -rf "$d"; then
+        removed=$((removed + 1))
+      fi
+    fi
+  done
+  shopt -u nullglob
+
+  if (( removed > 0 )); then
+    echo "[temp] reaped $removed stale blazedb-* dir(s) in $parent (>${threshold_minutes}m old)"
+  fi
+}
+
+blazedb_temp_teardown() {
+  local status="${1:-$?}"
+  if [[ "${BLAZEDB_TEMP_TEARDOWN_DONE:-0}" == "1" ]]; then
+    return
+  fi
+  BLAZEDB_TEMP_TEARDOWN_DONE=1
+  export BLAZEDB_TEMP_TEARDOWN_DONE
+
+  if [[ -n "${BLAZEDB_TEMP_ROOT:-}" && -d "${BLAZEDB_TEMP_ROOT}" ]]; then
+    rm -rf "${BLAZEDB_TEMP_ROOT}" || true
+    if [[ -d "${BLAZEDB_TEMP_ROOT}" ]]; then
+      echo "[temp] ERROR: leaked temp root still exists: ${BLAZEDB_TEMP_ROOT}"
+      if [[ "$status" -eq 0 ]]; then
+        status=99
+      fi
+    else
+      echo "[temp] removed run temp root: ${BLAZEDB_TEMP_ROOT}"
+    fi
+  fi
+
+  trap - EXIT INT TERM
+  exit "$status"
+}

--- a/Scripts/oss-readiness-local.sh
+++ b/Scripts/oss-readiness-local.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 set -euo pipefail
+. "$(dirname "$0")/lib/temp_lifecycle.sh"
+blazedb_temp_setup "oss-readiness"
 
 LOG_DIR="${TMPDIR:-/tmp}/blazedb-oss-readiness-$(date +%s)"
 mkdir -p "$LOG_DIR"

--- a/Scripts/run-core-integration.sh
+++ b/Scripts/run-core-integration.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # Pre-release confidence lane: Tier 0 + Tier 1 + Tier 2.
 set -e
+. "$(dirname "$0")/lib/temp_lifecycle.sh"
+blazedb_temp_setup "core-integration"
 echo "=== Core+Integration (pre-release) ==="
 RUN_ID="$(date +%Y%m%d-%H%M%S)"
 ARTIFACT_DIR=".artifacts/core-integration/${RUN_ID}"

--- a/Scripts/run-tier0.sh
+++ b/Scripts/run-tier0.sh
@@ -2,12 +2,12 @@
 # Tier 0: Always-on (local + PR). Fast, deterministic, must pass.
 # See Docs/Testing/TEST_EXECUTION_MODEL.md
 set -e
+. "$(dirname "$0")/lib/temp_lifecycle.sh"
+blazedb_temp_setup "tier0"
 echo "=== Tier 0: Always-on deterministic gate ==="
 RUN_ID="$(date +%Y%m%d-%H%M%S)"
 ARTIFACT_DIR=".artifacts/quick/${RUN_ID}"
-TMP_BASE=".artifacts/tmp/${RUN_ID}"
-mkdir -p "$ARTIFACT_DIR" "$TMP_BASE"
-export TMPDIR="$(pwd)/$TMP_BASE"
+mkdir -p "$ARTIFACT_DIR"
 # Fail fast if Tier-2-only env is set (would change test behavior; Tier 0 must stay light)
 if [ -n "${RUN_HEAVY_STRESS}" ] && [ "${RUN_HEAVY_STRESS}" != "0" ]; then
   echo "ERROR: RUN_HEAVY_STRESS must not be set for Tier 0. Unset it or use run-tier2.sh for heavy stress."

--- a/Scripts/run-tier1-depth.sh
+++ b/Scripts/run-tier1-depth.sh
@@ -2,6 +2,8 @@
 # Tier2/Tier3 heavy depth lane.
 # See Docs/Testing/CI_AND_TEST_TIERS.md
 set -e
+. "$(dirname "$0")/lib/temp_lifecycle.sh"
+blazedb_temp_setup "tier1-depth"
 echo "=== Tier2/Tier3 heavy depth ==="
 RUN_ID="$(date +%Y%m%d-%H%M%S)"
 ARTIFACT_DIR=".artifacts/tier1-depth/${RUN_ID}"

--- a/Scripts/run-tier1-strict.sh
+++ b/Scripts/run-tier1-strict.sh
@@ -2,6 +2,8 @@
 # Strict deterministic run for Tier 0 + Tier 1 only.
 # With tiered targets, strict mode now maps to target-level execution.
 set -e
+. "$(dirname "$0")/lib/temp_lifecycle.sh"
+blazedb_temp_setup "tier1-strict"
 echo "=== Tier 1 (strict): Tier 0 + Tier 1 deterministic ==="
 # Fail fast if Tier-2-only env is set
 if [ -n "${RUN_HEAVY_STRESS}" ] && [ "${RUN_HEAVY_STRESS}" != "0" ]; then

--- a/Scripts/run-tier1.sh
+++ b/Scripts/run-tier1.sh
@@ -2,6 +2,8 @@
 # Tier 1: CI gate. Tier 0 + Tier 1 deterministic lanes.
 # See Docs/Testing/TEST_EXECUTION_MODEL.md
 set -e
+. "$(dirname "$0")/lib/temp_lifecycle.sh"
+blazedb_temp_setup "tier1"
 echo "=== Tier 1: CI gate (Tier 0 + Tier1) ==="
 RUN_ID="$(date +%Y%m%d-%H%M%S)"
 ARTIFACT_DIR=".artifacts/core/${RUN_ID}"

--- a/Scripts/run-tier2.sh
+++ b/Scripts/run-tier2.sh
@@ -4,6 +4,8 @@
 # Use --strict (or BLAZEDB_TIER2_STRICT=1) to make failures fail the caller workflow.
 # See Docs/Testing/TEST_EXECUTION_MODEL.md
 set -euo pipefail
+. "$(dirname "$0")/lib/temp_lifecycle.sh"
+blazedb_temp_setup "tier2"
 STRICT_MODE="${BLAZEDB_TIER2_STRICT:-0}"
 case "${1:-}" in
   --strict)

--- a/Scripts/run-tier3.sh
+++ b/Scripts/run-tier3.sh
@@ -3,6 +3,8 @@
 # NEVER run in CI or on PR. Require explicit invocation.
 # See Docs/Testing/TEST_EXECUTION_MODEL.md and TEST_EXECUTION_TIERS.md §4.
 set -euo pipefail
+. "$(dirname "$0")/lib/temp_lifecycle.sh"
+blazedb_temp_setup "tier3"
 echo "=== Tier 3: Manual only (destructive / I/O fault injection) ==="
 echo "These tests must be run explicitly. They are excluded from all automation."
 echo "  >> BlazeDB_Tier3_Destructive (root package)"


### PR DESCRIPTION
## Summary
- Add `Scripts/lib/temp_lifecycle.sh` to centralize runner temp-root setup under `.artifacts/tmp/blazedb-<purpose>-<pid>-<timestamp>`.
- Reap stale `blazedb-*` temp directories at runner startup (conservative age threshold via `BLAZEDB_TMP_REAP_MINUTES`, default 60).
- Wire temp lifecycle setup/teardown into tier and harness entry scripts: `run-tier0.sh`, `run-tier1.sh`, `run-tier1-strict.sh`, `run-tier2.sh`, `run-tier1-depth.sh`, `run-tier3.sh`, `run-core-integration.sh`, and `oss-readiness-local.sh`.
- Add teardown leak guard: if a runner cannot remove its own temp root, the run fails loudly.

## Test plan
- [x] `bash -n Scripts/lib/temp_lifecycle.sh Scripts/run-tier0.sh Scripts/run-tier1.sh Scripts/run-tier1-strict.sh Scripts/run-tier2.sh Scripts/run-tier1-depth.sh Scripts/run-tier3.sh Scripts/run-core-integration.sh Scripts/oss-readiness-local.sh`
- [x] `mkdir -p /tmp/blazedb-temp-selftest-old && touch -d '2 hours ago' /tmp/blazedb-temp-selftest-old && bash -lc '. ./Scripts/lib/temp_lifecycle.sh; blazedb_temp_setup selftest; echo "inside TMPDIR=$TMPDIR"'`
- [x] Verified logs show stale reap + run temp root creation + cleanup