### PR TITLE
test(tier3): reduce CPU profiling fixture size for CI stability

### DIFF
--- a/BlazeDBTests/Performance/PerformanceProfilingTests.swift
+++ b/BlazeDBTests/Performance/PerformanceProfilingTests.swift
@@ -399,14 +399,13 @@ final class PerformanceProfilingTests: XCTestCase {
     
     /// PROFILE: CPU-intensive query (complex filters)
     func testProfile_CPUIntensiveQuery() throws {
-        // Keep CI runtime bounded while preserving query-shape coverage.
+        // CI uses a smaller fixture to avoid nightly runtime spikes; local keeps more volume.
         let runningOnCI = ProcessInfo.processInfo.environment["GITHUB_ACTIONS"] == "true"
         let recordCount = runningOnCI ? 1_000 : 2_000
         let lowerBound = recordCount / 4
         let upperBound = (recordCount * 3) / 4
-        let expectedCount = (lowerBound + 1..<upperBound).reduce(0) { partial, value in
-            partial + (value.isMultiple(of: 2) ? 1 : 0)
-        }
+        let matchingRange = (lowerBound + 1)..<upperBound
+        let expectedCount = matchingRange.filter { $0.isMultiple(of: 2) }.count
 
         // Setup
         for i in 0..<recordCount {

--- a/BlazeDBTests/Performance/PerformanceProfilingTests.swift
+++ b/BlazeDBTests/Performance/PerformanceProfilingTests.swift
@@ -399,8 +399,17 @@ final class PerformanceProfilingTests: XCTestCase {
     
     /// PROFILE: CPU-intensive query (complex filters)
     func testProfile_CPUIntensiveQuery() throws {
+        // Keep CI runtime bounded while preserving query-shape coverage.
+        let runningOnCI = ProcessInfo.processInfo.environment["GITHUB_ACTIONS"] == "true"
+        let recordCount = runningOnCI ? 1_000 : 2_000
+        let lowerBound = recordCount / 4
+        let upperBound = (recordCount * 3) / 4
+        let expectedCount = (lowerBound + 1..<upperBound).reduce(0) { partial, value in
+            partial + (value.isMultiple(of: 2) ? 1 : 0)
+        }
+
         // Setup
-        for i in 0..<20_000 {
+        for i in 0..<recordCount {
             try! db.insert(BlazeDataRecord([
                 "a": .int(i),
                 "b": .string("value\(i)"),
@@ -411,11 +420,11 @@ final class PerformanceProfilingTests: XCTestCase {
         
         try profileWithMetrics(name: "CPU Intensive Query") {
             let results = try db.query()
-                .where("a", greaterThan: .int(5000))
-                .where("a", lessThan: .int(15000))
+                .where("a", greaterThan: .int(lowerBound))
+                .where("a", lessThan: .int(upperBound))
                 .where("d", equals: .bool(true))
                 .execute()
-            XCTAssertGreaterThan(results.count, 0)
+            XCTAssertEqual(results.count, expectedCount)
         }
     }
 }

--- a/BlazeDBTests/Tier3Heavy/Performance/PerformanceProfilingTests.swift
+++ b/BlazeDBTests/Tier3Heavy/Performance/PerformanceProfilingTests.swift
@@ -412,8 +412,17 @@ final class PerformanceProfilingTests: XCTestCase {
     
     /// PROFILE: CPU-intensive query (complex filters)
     func testProfile_CPUIntensiveQuery() throws {
+        // Keep CI runtime bounded while preserving query-shape coverage.
+        let runningOnCI = ProcessInfo.processInfo.environment["GITHUB_ACTIONS"] == "true"
+        let recordCount = runningOnCI ? 1_000 : 2_000
+        let lowerBound = recordCount / 4
+        let upperBound = (recordCount * 3) / 4
+        let expectedCount = (lowerBound + 1..<upperBound).reduce(0) { partial, value in
+            partial + (value.isMultiple(of: 2) ? 1 : 0)
+        }
+
         // Setup
-        for i in 0..<20_000 {
+        for i in 0..<recordCount {
             try! db.insert(BlazeDataRecord([
                 "a": .int(i),
                 "b": .string("value\(i)"),
@@ -424,11 +433,11 @@ final class PerformanceProfilingTests: XCTestCase {
         
         try profileWithMetrics(name: "CPU Intensive Query") {
             let results = try db.query()
-                .where("a", greaterThan: .int(5000))
-                .where("a", lessThan: .int(15000))
+                .where("a", greaterThan: .int(lowerBound))
+                .where("a", lessThan: .int(upperBound))
                 .where("d", equals: .bool(true))
                 .execute()
-            XCTAssertGreaterThan(results.count, 0)
+            XCTAssertEqual(results.count, expectedCount)
         }
     }
 }

--- a/BlazeDBTests/Tier3Heavy/Performance/PerformanceProfilingTests.swift
+++ b/BlazeDBTests/Tier3Heavy/Performance/PerformanceProfilingTests.swift
@@ -412,14 +412,13 @@ final class PerformanceProfilingTests: XCTestCase {
     
     /// PROFILE: CPU-intensive query (complex filters)
     func testProfile_CPUIntensiveQuery() throws {
-        // Keep CI runtime bounded while preserving query-shape coverage.
+        // CI uses a smaller fixture to avoid nightly runtime spikes; local keeps more volume.
         let runningOnCI = ProcessInfo.processInfo.environment["GITHUB_ACTIONS"] == "true"
         let recordCount = runningOnCI ? 1_000 : 2_000
         let lowerBound = recordCount / 4
         let upperBound = (recordCount * 3) / 4
-        let expectedCount = (lowerBound + 1..<upperBound).reduce(0) { partial, value in
-            partial + (value.isMultiple(of: 2) ? 1 : 0)
-        }
+        let matchingRange = (lowerBound + 1)..<upperBound
+        let expectedCount = matchingRange.filter { $0.isMultiple(of: 2) }.count
 
         // Setup
         for i in 0..<recordCount {

--- a/Tests/BlazeDBTests/Performance/PerformanceProfilingTests.swift
+++ b/Tests/BlazeDBTests/Performance/PerformanceProfilingTests.swift
@@ -409,14 +409,13 @@ final class PerformanceProfilingTests: XCTestCase {
     
     /// PROFILE: CPU-intensive query (complex filters)
     func testProfile_CPUIntensiveQuery() throws {
-        // Keep CI runtime bounded while preserving query-shape coverage.
+        // CI uses a smaller fixture to avoid nightly runtime spikes; local keeps more volume.
         let runningOnCI = ProcessInfo.processInfo.environment["GITHUB_ACTIONS"] == "true"
         let recordCount = runningOnCI ? 1_000 : 2_000
         let lowerBound = recordCount / 4
         let upperBound = (recordCount * 3) / 4
-        let expectedCount = (lowerBound + 1..<upperBound).reduce(0) { partial, value in
-            partial + (value.isMultiple(of: 2) ? 1 : 0)
-        }
+        let matchingRange = (lowerBound + 1)..<upperBound
+        let expectedCount = matchingRange.filter { $0.isMultiple(of: 2) }.count
 
         // Setup
         for i in 0..<recordCount {

--- a/Tests/BlazeDBTests/Performance/PerformanceProfilingTests.swift
+++ b/Tests/BlazeDBTests/Performance/PerformanceProfilingTests.swift
@@ -409,8 +409,17 @@ final class PerformanceProfilingTests: XCTestCase {
     
     /// PROFILE: CPU-intensive query (complex filters)
     func testProfile_CPUIntensiveQuery() throws {
+        // Keep CI runtime bounded while preserving query-shape coverage.
+        let runningOnCI = ProcessInfo.processInfo.environment["GITHUB_ACTIONS"] == "true"
+        let recordCount = runningOnCI ? 1_000 : 2_000
+        let lowerBound = recordCount / 4
+        let upperBound = (recordCount * 3) / 4
+        let expectedCount = (lowerBound + 1..<upperBound).reduce(0) { partial, value in
+            partial + (value.isMultiple(of: 2) ? 1 : 0)
+        }
+
         // Setup
-        for i in 0..<20_000 {
+        for i in 0..<recordCount {
             try! db.insert(BlazeDataRecord([
                 "a": .int(i),
                 "b": .string("value\(i)"),
@@ -421,11 +430,11 @@ final class PerformanceProfilingTests: XCTestCase {
         
         try profileWithMetrics(name: "CPU Intensive Query") {
             let results = try db.query()
-                .where("a", greaterThan: .int(5000))
-                .where("a", lessThan: .int(15000))
+                .where("a", greaterThan: .int(lowerBound))
+                .where("a", lessThan: .int(upperBound))
                 .where("d", equals: .bool(true))
                 .execute()
-            XCTAssertGreaterThan(results.count, 0)
+            XCTAssertEqual(results.count, expectedCount)
         }
     }
 }


### PR DESCRIPTION
## Summary
- Reduce `testProfile_CPUIntensiveQuery` setup volume to environment-aware sizes (`1000` on CI, `2000` locally) to prevent Tier3-heavy runtime spikes.
- Preserve query-shape coverage while replacing a weak non-zero assertion with an exact expected-cardinality assertion.
- Apply the same fix to all mirrored profiling test files to keep suites behaviorally aligned.

## Test plan
- [x] `swift test --disable-swift-testing --filter 'BlazeDB_Tier3_Heavy.PerformanceProfilingTests/testProfile_CPUIntensiveQuery'`
- [ ] Run nightly confidence workflow and confirm `macOS 15 — Tier3 Heavy (+ perf companion, transitional)` completes successfully