### PR TITLE
ci(nightly): split Linux Tier2/Tier3 jobs for parallel fan-out

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -544,11 +544,12 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
-  # Linux-only: deeper suites (moved from long Tier1 runs) — not duplicated on macOS nightly jobs.
-  nightly-linux-tier2:
-    name: Linux (Swift 6.2) — Tier2 (+ extended)
+  # Linux-only: deeper suites (moved from long Tier1 runs) — split so core/extended run in parallel.
+  nightly-linux-tier2-core:
+    name: Linux (Swift 6.2) — Tier2 (core)
     runs-on: ubuntu-22.04
     timeout-minutes: 240
+    needs: nightly-linux-tier1
 
     steps:
       - name: Checkout
@@ -579,19 +580,85 @@ jobs:
       - name: Prepare CI log directories
         run: mkdir -p .logs .artifacts
 
-      - name: Test Tier 2 (+ extended companion)
+      - name: Test Tier 2 (core)
         run: |
           set -euo pipefail
           mkdir -p .logs
           (
             while sleep 60; do
-              echo "[tier2-heartbeat] $(date -u '+%Y-%m-%dT%H:%M:%SZ') swift-test still running"
+              echo "[tier2-core-heartbeat] $(date -u '+%Y-%m-%dT%H:%M:%SZ') swift-test still running"
             done
           ) &
           _hb=$!
           trap 'kill "$_hb" 2>/dev/null || true' EXIT
           stdbuf -oL -eL swift test --disable-swift-testing --filter 'BlazeDB_Tier2\.' 2>&1 \
-            | stdbuf -oL -eL tee .logs/tier2.log
+            | stdbuf -oL -eL tee .logs/tier2-core.log
+
+      - name: Dump diagnostics on failure
+        if: failure()
+        run: |
+          mkdir -p .logs
+          ps aux > .logs/ps.txt || true
+          df -h > .logs/disk.txt || true
+          swift --version > .logs/swift-version.txt 2>&1 || true
+
+      - name: Upload nightly Linux Tier2 core logs
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: nightly-linux-tier2-core-logs
+          path: |
+            .logs/
+            .artifacts/
+          if-no-files-found: ignore
+          retention-days: 7
+
+  nightly-linux-tier2-extended:
+    name: Linux (Swift 6.2) — Tier2 (extended)
+    runs-on: ubuntu-22.04
+    timeout-minutes: 240
+    needs: nightly-linux-tier1
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Cache SwiftPM build
+        uses: actions/cache@v5
+        with:
+          path: .build
+          key: nightly-${{ runner.os }}-spm-${{ hashFiles('Package.swift', 'Package.resolved') }}
+          restore-keys: |
+            nightly-${{ runner.os }}-spm-
+            ${{ runner.os }}-spm-
+
+      - name: Setup Swift 6.2
+        uses: swift-actions/setup-swift@v2
+        with:
+          swift-version: "6.2"
+
+      - name: Swift version
+        run: swift --version
+
+      - name: Build core
+        run: swift build --target BlazeDBCore
+
+      - name: Prepare CI log directories
+        run: mkdir -p .logs .artifacts
+
+      - name: Test Tier 2 (extended)
+        run: |
+          set -euo pipefail
+          mkdir -p .logs
+          (
+            while sleep 60; do
+              echo "[tier2-extended-heartbeat] $(date -u '+%Y-%m-%dT%H:%M:%SZ') swift-test still running"
+            done
+          ) &
+          _hb=$!
+          trap 'kill "$_hb" 2>/dev/null || true' EXIT
           stdbuf -oL -eL swift test --disable-swift-testing --filter BlazeDB_Tier2_Extended 2>&1 \
             | stdbuf -oL -eL tee .logs/tier2-extended.log
 
@@ -603,11 +670,11 @@ jobs:
           df -h > .logs/disk.txt || true
           swift --version > .logs/swift-version.txt 2>&1 || true
 
-      - name: Upload nightly Linux Tier2 logs
+      - name: Upload nightly Linux Tier2 extended logs
         if: always()
         uses: actions/upload-artifact@v5
         with:
-          name: nightly-linux-tier2-logs
+          name: nightly-linux-tier2-extended-logs
           path: |
             .logs/
             .artifacts/
@@ -615,10 +682,13 @@ jobs:
           retention-days: 7
 
   # Linux Tier3 nightly is blocking (unlike macOS Tier3 quarantine above).
-  nightly-linux-tier3-heavy:
-    name: Linux (Swift 6.2) — Tier3 heavy (+ perf companion)
+  nightly-linux-tier3-heavy-core:
+    name: Linux (Swift 6.2) — Tier3 heavy
     runs-on: ubuntu-22.04
     timeout-minutes: 240
+    needs:
+      - nightly-linux-tier2-core
+      - nightly-linux-tier2-extended
 
     steps:
       - name: Checkout
@@ -649,21 +719,19 @@ jobs:
       - name: Prepare CI log directories
         run: mkdir -p .logs .artifacts
 
-      - name: Test Tier 3 heavy (+ transitional perf companion)
+      - name: Test Tier 3 heavy
         run: |
           set -euo pipefail
           mkdir -p .logs
           (
             while sleep 120; do
-              echo "[tier3-linux-heartbeat] $(date -u '+%Y-%m-%dT%H:%M:%SZ') swift-test still running"
+              echo "[tier3-linux-heavy-heartbeat] $(date -u '+%Y-%m-%dT%H:%M:%SZ') swift-test still running"
             done
           ) &
           _hb=$!
           trap 'kill "$_hb" 2>/dev/null || true' EXIT
           stdbuf -oL -eL swift test --disable-swift-testing --filter 'BlazeDB_Tier3_Heavy\.' 2>&1 \
             | stdbuf -oL -eL tee .logs/tier3-heavy.log
-          stdbuf -oL -eL swift test --disable-swift-testing --filter BlazeDB_Tier3_Heavy_Perf 2>&1 \
-            | stdbuf -oL -eL tee .logs/tier3-heavy-perf.log
 
       - name: Dump diagnostics on failure
         if: failure()
@@ -677,7 +745,77 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v5
         with:
-          name: nightly-linux-tier3-heavy-logs
+          name: nightly-linux-tier3-heavy-core-logs
+          path: |
+            .logs/
+            .artifacts/
+          if-no-files-found: ignore
+          retention-days: 7
+
+  nightly-linux-tier3-perf:
+    name: Linux (Swift 6.2) — Tier3 perf companion
+    runs-on: ubuntu-22.04
+    timeout-minutes: 240
+    needs:
+      - nightly-linux-tier2-core
+      - nightly-linux-tier2-extended
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Cache SwiftPM build
+        uses: actions/cache@v5
+        with:
+          path: .build
+          key: nightly-${{ runner.os }}-spm-${{ hashFiles('Package.swift', 'Package.resolved') }}
+          restore-keys: |
+            nightly-${{ runner.os }}-spm-
+            ${{ runner.os }}-spm-
+
+      - name: Setup Swift 6.2
+        uses: swift-actions/setup-swift@v2
+        with:
+          swift-version: "6.2"
+
+      - name: Swift version
+        run: swift --version
+
+      - name: Build core
+        run: swift build --target BlazeDBCore
+
+      - name: Prepare CI log directories
+        run: mkdir -p .logs .artifacts
+
+      - name: Test Tier 3 perf companion
+        run: |
+          set -euo pipefail
+          mkdir -p .logs
+          (
+            while sleep 120; do
+              echo "[tier3-linux-perf-heartbeat] $(date -u '+%Y-%m-%dT%H:%M:%SZ') swift-test still running"
+            done
+          ) &
+          _hb=$!
+          trap 'kill "$_hb" 2>/dev/null || true' EXIT
+          stdbuf -oL -eL swift test --disable-swift-testing --filter BlazeDB_Tier3_Heavy_Perf 2>&1 \
+            | stdbuf -oL -eL tee .logs/tier3-heavy-perf.log
+
+      - name: Dump diagnostics on failure
+        if: failure()
+        run: |
+          mkdir -p .logs
+          ps aux > .logs/ps.txt || true
+          df -h > .logs/disk.txt || true
+          swift --version > .logs/swift-version.txt 2>&1 || true
+
+      - name: Upload nightly Linux Tier3 perf logs
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: nightly-linux-tier3-perf-logs
           path: |
             .logs/
             .artifacts/

--- a/Docs/Testing/CI_AND_TEST_TIERS.md
+++ b/Docs/Testing/CI_AND_TEST_TIERS.md
@@ -60,8 +60,10 @@ Use this table for day-to-day expectations.
   - `macOS 15 — Tier0 ThreadSanitizer`: `swift test --sanitize thread --filter BlazeDB_Tier0`
   - `Linux (Swift 6.2) — Tier0`: `BlazeDB_Tier0`
   - `Linux (Swift 6.2) — Tier1 (canonical)`: `BlazeDB_Tier1` via filter `'BlazeDB_Tier1\.'` (fast nightly signal)
-  - `Linux (Swift 6.2) — Tier2 (+ extended)`: `BlazeDB_Tier2` + `BlazeDB_Tier2_Extended` (Linux-only nightly job; deeper suites)
-  - `Linux (Swift 6.2) — Tier3 heavy (+ perf)`: `BlazeDB_Tier3_Heavy` + `BlazeDB_Tier3_Heavy_Perf` (Linux-only nightly job)
+  - `Linux (Swift 6.2) — Tier2 (core)`: `BlazeDB_Tier2` (Linux-only nightly split job; deeper suites)
+  - `Linux (Swift 6.2) — Tier2 (extended)`: `BlazeDB_Tier2_Extended` (Linux-only nightly split job; deeper suites)
+  - `Linux (Swift 6.2) — Tier3 heavy`: `BlazeDB_Tier3_Heavy` (Linux-only nightly split job)
+  - `Linux (Swift 6.2) — Tier3 perf companion`: `BlazeDB_Tier3_Heavy_Perf` (Linux-only nightly split job)
 - Nightly confidence lanes are root-owned and do not depend on `BlazeDBExtraTests`.
 - Temporary quarantine policy (current): `macOS 15 — Tier3 Heavy` is non-blocking in nightly due to cumulative profiling-load instability; lane remains monitored and includes automated post-failure diagnostics.
 - **Operational policy:** nightly failures are triaged within 24–48 hours.
@@ -69,7 +71,7 @@ Use this table for day-to-day expectations.
 ### Nightly Tier3 policy
 
 - **`nightly-macos-tier3-heavy`:** quarantined — `continue-on-error: true` in `nightly.yml`; a red Tier3 step does **not** fail the overall nightly workflow; logs and diagnostics still upload.
-- **`nightly-linux-tier3-heavy`:** blocking — a red step fails the workflow (Linux depth lane).
+- **`nightly-linux-tier3-heavy-core`** and **`nightly-linux-tier3-perf`**: blocking — a red step fails the workflow (Linux depth lane).
 - Any change to either policy should update **this file** and **`nightly.yml`** together so the two stay aligned.
 
 ### Nightly stability trade-offs (documented)
@@ -219,7 +221,7 @@ Use precise language so status and dashboards do not blur the PR gate with deepe
 | **Canonical tiers** | `BlazeDB_Tier0`, `BlazeDB_Tier1`, `BlazeDB_Tier2`, `BlazeDB_Tier3_Heavy`, `BlazeDB_Tier3_Destructive` (end-state model). |
 | **PR3 transitional companions** | `BlazeDB_Tier2_Extended`, `BlazeDB_Tier3_Heavy_Perf`; temporary bridge targets slated for PR4 filesystem/target normalization. |
 | **Depth lane** | `tier1-depth.yml` currently runs `BlazeDB_Tier2` + `BlazeDB_Tier2_Extended` + `BlazeDB_Tier3_Heavy` + `BlazeDB_Tier3_Heavy_Perf` (workflow filename kept for compatibility until PR4). |
-| **Nightly confidence lane** | `nightly.yml`: macOS Tier1, Tier2 strict, **Tier3 heavy (quarantined: does not fail the workflow)**; **Linux** adds separate blocking jobs for canonical Tier1, Tier2 (+ extended), Tier3 heavy (+ perf). |
+| **Nightly confidence lane** | `nightly.yml`: macOS Tier1, Tier2 strict, **Tier3 heavy (quarantined: does not fail the workflow)**; **Linux** adds separate blocking jobs for canonical Tier1, Tier2 (core), Tier2 (extended), Tier3 heavy, and Tier3 perf companion. |
 | **Nightly macOS Tier3 heavy** | Job `nightly-macos-tier3-heavy`: `continue-on-error: true` — red tests are monitored (logs/artifacts/diagnostics) but **do not** turn the nightly run red. Not the same as Linux Tier3 nightly (blocking). |
 | **Deep validation lane** | `deep-validation.yml`: macOS full stack; **Linux extended** runs Tier0 → canonical Tier1 → Tier2/Tier2_Extended → Tier3 heavy/perf (see workflow). |
 | **Canonical Tier1** | `BlazeDB_Tier1` (single canonical Tier1 target). |
@@ -228,19 +230,19 @@ Inventory/bootstrap code may still bucket all three SwiftPM modules under a sing
 
 ### Suites relocated off canonical Tier1 (inventory)
 
-These used to inflate Linux Tier1 wall-clock; they now live in **`BlazeDB_Tier2`** or **`BlazeDB_Tier3_Heavy`** and are exercised on **Linux** by `nightly-linux-tier2`, `nightly-linux-tier3-heavy`, and `deep-validation` → `deep-linux-extended`. macOS release/nightly still runs the same SPM targets—only Linux splits jobs for scheduling.
+These used to inflate Linux Tier1 wall-clock; they now live in **`BlazeDB_Tier2`** or **`BlazeDB_Tier3_Heavy`** and are exercised on **Linux** by `nightly-linux-tier2-core`, `nightly-linux-tier2-extended`, `nightly-linux-tier3-heavy-core`, `nightly-linux-tier3-perf`, and `deep-validation` → `deep-linux-extended`. macOS release/nightly still runs the same SPM targets—only Linux splits jobs for scheduling.
 
 | Logical area | File under `BlazeDBTests/…` | SPM module | Linux nightly |
 | ------------ | --------------------------- | ---------- | ------------- |
-| Type-safety edge cases | `Tier2Integration/BlazeDBIntegrationTests/EdgeCases/TypeSafetyEdgeCaseTests.swift` | `BlazeDB_Tier2` | `nightly-linux-tier2` |
-| Codable integration | `…/Integration/CodableIntegrationTests.swift` | `BlazeDB_Tier2` | `nightly-linux-tier2` |
-| Client API (`BlazeDBClientTests`) | `…/Core/BlazeDBTests.swift` | `BlazeDB_Tier2` | `nightly-linux-tier2` |
-| Persist API | `…/Persistence/BlazeDBPersistAPITests.swift` | `BlazeDB_Tier2` | `nightly-linux-tier2` |
-| Data seeding | `…/DataSeedingTests.swift` | `BlazeDB_Tier2` | `nightly-linux-tier2` |
-| Subqueries | `…/SQL/SubqueryTests.swift` | `BlazeDB_Tier2` | `nightly-linux-tier2` |
-| Filesystem errors | `…/Core/BlazeFileSystemErrorTests.swift` | `BlazeDB_Tier2` | `nightly-linux-tier2` |
-| Key-path query | `…/Features/KeyPathQueryTests.swift` | `BlazeDB_Tier2` | `nightly-linux-tier2` |
-| Query EXPLAIN (scale-heavy) | `Tier3Heavy/Query/QueryExplainTests.swift` | `BlazeDB_Tier3_Heavy` | `nightly-linux-tier3-heavy` |
+| Type-safety edge cases | `Tier2Integration/BlazeDBIntegrationTests/EdgeCases/TypeSafetyEdgeCaseTests.swift` | `BlazeDB_Tier2` | `nightly-linux-tier2-core` |
+| Codable integration | `…/Integration/CodableIntegrationTests.swift` | `BlazeDB_Tier2` | `nightly-linux-tier2-core` |
+| Client API (`BlazeDBClientTests`) | `…/Core/BlazeDBTests.swift` | `BlazeDB_Tier2` | `nightly-linux-tier2-core` |
+| Persist API | `…/Persistence/BlazeDBPersistAPITests.swift` | `BlazeDB_Tier2` | `nightly-linux-tier2-core` |
+| Data seeding | `…/DataSeedingTests.swift` | `BlazeDB_Tier2` | `nightly-linux-tier2-core` |
+| Subqueries | `…/SQL/SubqueryTests.swift` | `BlazeDB_Tier2` | `nightly-linux-tier2-core` |
+| Filesystem errors | `…/Core/BlazeFileSystemErrorTests.swift` | `BlazeDB_Tier2` | `nightly-linux-tier2-core` |
+| Key-path query | `…/Features/KeyPathQueryTests.swift` | `BlazeDB_Tier2` | `nightly-linux-tier2-core` |
+| Query EXPLAIN (scale-heavy) | `Tier3Heavy/Query/QueryExplainTests.swift` | `BlazeDB_Tier3_Heavy` | `nightly-linux-tier3-heavy-core` |
 
 `Tier1Core/DXQueryExplainTests.swift` remains in **`BlazeDB_Tier1`** (different, lighter DX coverage)—do not confuse with `QueryExplainTests` in Tier3.
 


### PR DESCRIPTION
## Summary
- split Linux nightly Tier2 into `nightly-linux-tier2-core` and `nightly-linux-tier2-extended` jobs with shared upstream dependency on Linux Tier1
- split Linux nightly Tier3 into `nightly-linux-tier3-heavy-core` and `nightly-linux-tier3-perf` jobs that fan out in parallel after both Tier2 jobs complete
- update `Docs/Testing/CI_AND_TEST_TIERS.md` to match the new Linux nightly job IDs, naming, and blocking policy wording

## Test plan
- [ ] Trigger `nightly.yml` manually and verify Linux graph stages: Tier1 -> (Tier2 core + Tier2 extended) -> (Tier3 heavy + Tier3 perf)
- [ ] Confirm the four split jobs each run exactly one target filter and upload distinct artifacts
- [ ] Compare critical-path runtime against recent baseline runs to validate wall-clock reduction

Made with [Cursor](https://cursor.com)