### PR TITLE
ci(nightly): remove redundant Linux pre-build steps

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -448,9 +448,6 @@ jobs:
       - name: Swift version
         run: swift --version
 
-      - name: Build core
-        run: swift build --target BlazeDBCore
-
       - name: Prepare CI log directories
         run: mkdir -p .logs .artifacts
 
@@ -506,9 +503,6 @@ jobs:
 
       - name: Swift version
         run: swift --version
-
-      - name: Build core
-        run: swift build --target BlazeDBCore
 
       - name: Prepare CI log directories
         run: mkdir -p .logs .artifacts
@@ -575,9 +569,6 @@ jobs:
       - name: Swift version
         run: swift --version
 
-      - name: Build core
-        run: swift build --target BlazeDBCore
-
       - name: Prepare CI log directories
         run: mkdir -p .logs .artifacts
 
@@ -641,9 +632,6 @@ jobs:
 
       - name: Swift version
         run: swift --version
-
-      - name: Build core
-        run: swift build --target BlazeDBCore
 
       - name: Prepare CI log directories
         run: mkdir -p .logs .artifacts
@@ -710,9 +698,6 @@ jobs:
       - name: Swift version
         run: swift --version
 
-      - name: Build core
-        run: swift build --target BlazeDBCore
-
       - name: Prepare CI log directories
         run: mkdir -p .logs .artifacts
 
@@ -776,9 +761,6 @@ jobs:
 
       - name: Swift version
         run: swift --version
-
-      - name: Build core
-        run: swift build --target BlazeDBCore
 
       - name: Prepare CI log directories
         run: mkdir -p .logs .artifacts

--- a/Docs/Testing/CI_AND_TEST_TIERS.md
+++ b/Docs/Testing/CI_AND_TEST_TIERS.md
@@ -65,6 +65,7 @@ Use this table for day-to-day expectations.
   - `Linux (Swift 6.2) — Tier3 (heavy)`: `BlazeDB_Tier3_Heavy` (Linux-only nightly split job)
   - `Linux (Swift 6.2) — Tier3 (perf)`: `BlazeDB_Tier3_Heavy_Perf` (Linux-only nightly split job)
 - Linux Tier labels are grouping vocabulary, **not execution stages**: `linux-tier0`, `linux-tier1`, `linux-tier2-core`, `linux-tier2-extended`, `linux-tier3-heavy`, and `linux-tier3-perf` are independent sibling jobs in `nightly.yml` (no `needs` chain between Linux lanes).
+- Linux sibling jobs are intentionally `swift test`-first (no explicit `swift build --target BlazeDBCore` pre-step) to avoid redundant per-lane pre-build overhead.
 - Nightly confidence lanes are root-owned and do not depend on `BlazeDBExtraTests`.
 - Temporary quarantine policy (current): `macOS 15 — Tier3 (heavy, non-blocking)` is non-blocking in nightly so Tier1/Tier2 gates stay authoritative; Tier3 remains monitored with post-failure diagnostics.
 - **Operational policy:** nightly failures are triaged within 24–48 hours.


### PR DESCRIPTION
## Summary
This PR is a narrow nightly-runtime optimization pass.

- remove redundant `swift build --target BlazeDBCore` steps from Linux nightly sibling lanes
- keep test policy, tier structure, job independence, and coverage semantics unchanged
- add a small docs note clarifying Linux nightly runs `swift test` directly by design

## Why
Linux nightly lanes are independent sibling jobs and each lane already runs `swift test`, which builds required test products. Keeping a separate `swift build --target BlazeDBCore` in every lane adds duplicated pre-build time.

## Test plan
- [ ] Run `nightly.yml` manually
- [ ] Verify Linux Tier0/Tier1/Tier2-core/Tier2-extended/Tier3-heavy/Tier3-perf jobs execute normally
- [ ] Compare Linux lane runtimes against recent baseline runs to confirm reduced setup time
- [ ] Confirm no test policy or lane dependency semantics changed

Made with [Cursor](https://cursor.com)