### PR TITLE
docs(ci): tighten snapshot and tiered-lane guidance

### DIFF
--- a/Docs/Testing/CI_AND_TEST_TIERS.md
+++ b/Docs/Testing/CI_AND_TEST_TIERS.md
@@ -13,6 +13,8 @@ Use this table for day-to-day expectations.
 | Lane | Goal | Trigger | Blocking | Current workflow(s) |
 | ---- | ---- | ------- | -------- | ------------------- |
 | PR fast gate | Catch obvious breakage quickly | `pull_request`, `push` | Yes | `ci.yml` |
+| Nightly confidence | Broad daily cross-platform confidence with independent lanes | Daily + manual | Mixed (macOS Tier3 non-blocking; most lanes blocking) | `nightly.yml` |
+| Deep validation | Longer-running soak/depth validation sweep | Weekly + manual | No | `deep-validation.yml` |
 | Tier1 depth | Broader Tier1 confidence | Weekly + manual | No | `tier1-depth.yml` |
 | Release validation | Validate tagged releases | `v*` tag + manual | Release-only | `release.yml` |
 | Tag probe | Check older tags still build | Manual | No | `tag-probe.yml` |
@@ -26,6 +28,28 @@ Use this table for day-to-day expectations.
 - In rollout:
   - deep soak lane (`deep-validation.yml`)
 
+## CI Philosophy: Tiered, Not Sequential
+
+BlazeDB uses a tiered testing model where tiers represent signal class and runtime cost, **not** promotion order.
+
+- Tiers are classification labels, not execution stages.
+- Linux nightly lanes run as independent sibling jobs.
+- There is no Linux Tier1 -> Tier2 -> Tier3 dependency chain.
+
+**Important:** Linux nightly tiers are parallel classification lanes, not staged promotion gates.
+
+This is intentional:
+
+- Tier surfaces validate different behavior classes and do not consume each other's artifacts.
+- Sequential staging would add wall-clock without adding correctness.
+- Parallel sibling lanes maximize nightly signal by exposing failures across all surfaces in the same run.
+
+Design tradeoff (intentional):
+
+- Favor: broader signal per run + faster critical-path completion.
+- Accept: higher runner concurrency consumption versus staged early-exit gating.
+
+In short: nightly confidence optimizes for coverage visibility and time-to-signal, not strict tier promotion.
 ## Workflow Inventory
 
 - `.github/workflows/ci.yml`
@@ -47,7 +71,7 @@ Use this table for day-to-day expectations.
 
 - `.github/workflows/tier1-depth.yml`
 - Trigger: **weekly schedule** and **manual** (`workflow_dispatch`)
-- Runs `BlazeDB_Tier2` + `BlazeDB_Tier2_Extended` and `BlazeDB_Tier3_Heavy` + `BlazeDB_Tier3_Heavy_Perf` (legacy workflow name retained pending PR4 cleanup).
+- Runs `BlazeDB_Tier2` + `BlazeDB_Tier2_Extended` and `BlazeDB_Tier3_Heavy` + `BlazeDB_Tier3_Heavy_Perf` (legacy workflow name retained pending PR4 cleanup; filename intentionally lags behavior).
 
 - `.github/workflows/nightly.yml`
 - Trigger: **daily schedule** and **manual** (`workflow_dispatch`)


### PR DESCRIPTION
## Summary
- add `Nightly confidence` and `Deep validation` entries to the CI lane snapshot for day-to-day completeness
- restore and emphasize the `CI Philosophy: Tiered, Not Sequential` section with an explicit callout that Linux nightly tiers are classification lanes, not staged promotion gates
- keep the `tier1-depth.yml` naming mismatch note explicit (`filename intentionally lags behavior`)

## Test plan
- [ ] Render and skim `Docs/Testing/CI_AND_TEST_TIERS.md` for readability
- [ ] Confirm lane snapshot, philosophy, and workflow inventory sections are mutually consistent

Made with [Cursor](https://cursor.com)