### PR TITLE
docs: README onboarding (Path A/B, Start Here first)

### DIFF
--- a/Docs/GettingStarted/FEATURE_ROADMAP.md
+++ b/Docs/GettingStarted/FEATURE_ROADMAP.md
@@ -58,7 +58,7 @@ extension BlazeDBClient {
 - Uses existing recovery code paths
 - No core changes needed
 
-### 4. README “Try the demo” / Start Here sections
+### 4. README “Try BlazeDB from this repo” / Start Here sections
 **Goal:** 3 copy-paste examples that work immediately
 
 **Examples:**

--- a/Docs/GettingStarted/FEATURE_ROADMAP.md
+++ b/Docs/GettingStarted/FEATURE_ROADMAP.md
@@ -58,7 +58,7 @@ extension BlazeDBClient {
 - Uses existing recovery code paths
 - No core changes needed
 
-### 4. README Quick Start Section
+### 4. README “Try the demo” / Start Here sections
 **Goal:** 3 copy-paste examples that work immediately
 
 **Examples:**

--- a/Docs/GettingStarted/README.md
+++ b/Docs/GettingStarted/README.md
@@ -44,29 +44,21 @@ If you see "Success!", BlazeDB is working.
 
 ## Step 3: Starter Code
 
-Copy this into your project:
+Copy into your project. Same flow as [README Start Here](../../README.md#start-here-new-users): one file, structs, save → load → query.
 
 ```swift
 import BlazeDB
 
-// 1. Define your model
 struct Bug: BlazeStorable {
     var id: UUID = UUID()
     var title: String
     var status: String
 }
 
-// 2. Open database (creates if needed, always encrypted)
 let db = try BlazeDB.open(name: "myapp", password: "My-Secure-Password-2026!")
-
-// 3. Put
 let bug = Bug(title: "Crash", status: "open")
 try db.put(bug)
-
-// 4. Get by key (UUID or namespace:UUID)
 let loaded: Bug? = try db.get("bug:\(bug.id.uuidString)")
-
-// 5. Query by namespace
 let openBugs: [Bug] = try db.query("bug")
     .where("status", equals: "open")
     .all()

--- a/Docs/README.md
+++ b/Docs/README.md
@@ -26,7 +26,7 @@ Internal analysis material lives under [`Docs/Internal/`](Internal/README.md) an
 *Map of the folders: what to trust for “how does it work today.”* BlazeDB documentation is organized into:
 
 - **Canonical docs (current, maintained)** — Use these first for behavior and APIs:
-  - [Repository README](../README.md) (install, quickstart, product summary)
+  - [Repository README](../README.md) (Start Here, try from repo / add to app, product summary)
   - [Getting Started](GettingStarted/) (first run, HOW_TO_USE, Linux notes)
   - [Testing / CI](Testing/) (tiers, test layout, execution model)
   - [Release](Release/) (release-facing checklists and notes)

--- a/Docs/README.md
+++ b/Docs/README.md
@@ -1,10 +1,10 @@
 # BlazeDB Documentation
 
-This index separates the main public documentation path from maintainer-only or historical material.
+This index separates the main public documentation path from maintainer-only or historical material. *Skim the headings to see where you are; you don’t have to read this file top to bottom.*
 
 ## Support-State Framing
 
-Use this quick framing before diving into detailed docs:
+*Quick mental model so you don’t assume sync/telemetry are in the default box.* Use this quick framing before diving into detailed docs:
 
 - **Default shipped core:** embedded encrypted engine, typed/raw APIs, durability, import/export, health/stats, CLI tooling.
 - **Advanced but supported:** migrations, schema validation, indexing/search tuning, manual mapping.
@@ -12,6 +12,8 @@ Use this quick framing before diving into detailed docs:
 - **Historical/internal:** archive and project-management docs are non-authoritative for first-time adopters.
 
 ## Audience Segmentation
+
+*Who each pile of docs is for—helps you ignore the wrong shelf.*
 
 - **Public product docs:** what BlazeDB is, how to use it, what is supported now.
 - **Public maintainer docs:** release/testing/CI operations for contributors.
@@ -21,7 +23,7 @@ Internal analysis material lives under [`Docs/Internal/`](Internal/README.md) an
 
 ## Documentation guide
 
-BlazeDB documentation is organized into:
+*Map of the folders: what to trust for “how does it work today.”* BlazeDB documentation is organized into:
 
 - **Canonical docs (current, maintained)** — Use these first for behavior and APIs:
   - [Repository README](../README.md) (install, quickstart, product summary)
@@ -36,12 +38,16 @@ BlazeDB documentation is organized into:
 
 ## Start Here
 
-- [Getting Started](GettingStarted/README.md) for first install, first run, and starter code.
-- [Developer Guide](DEVELOPER_GUIDE.md) for the main public API walkthrough.
-- [API Reference](API/API_REFERENCE.md) for reference-style documentation.
-- [Examples](../Examples/) for runnable usage patterns.
+*If you’re new, hit these in roughly this order—you’ll stay on the happy path.*
+
+- [Getting Started](GettingStarted/README.md) — install the package, run `HelloBlazeDB`, paste the tiny starter snippet; the “I just want it working” path.
+- [Developer Guide](DEVELOPER_GUIDE.md) — longer walkthrough of the public API in prose (CRUD, queries, patterns); read after you’ve run something once.
+- [API Reference](API/API_REFERENCE.md) — lookup tables and signatures when you already know what you’re trying to call.
+- [Examples](../Examples/) — copy-paste runnable projects and patterns when docs need a concrete file to stare at.
 
 ## Core Product Docs
+
+*Stuff you’ll want when something “should work on my OS” or “what happens on crash / upgrade.”*
 
 - [Compatibility](COMPATIBILITY.md) for supported platforms and release expectations.
 - [Security](../SECURITY.md) for vulnerability reporting and disclosure expectations.
@@ -53,17 +59,23 @@ BlazeDB documentation is organized into:
 
 ## Advanced Features (Supported)
 
+*Still supported, just not the first day’s reading.*
+
 - [Developer Guide](DEVELOPER_GUIDE.md) (advanced API sections)
 - [API Reference](API/API_REFERENCE.md) (full reference; includes advanced and conditional surfaces)
 - [Performance](Performance/README.md) (benchmark and tuning guidance)
 
 ## Conditional / Deferred Features
 
+*May exist in the repo or docs but isn’t the default OSS story—read so you don’t cargo-cult sync/transport.*
+
 - [Distributed Transport Deferred Status](Status/DISTRIBUTED_TRANSPORT_DEFERRED.md)
 - [Sync Docs](Sync/README.md) - design and deferred transport context; not default OSS onboarding
 - Telemetry and staging-related surfaces in source are conditional and should be treated as non-default runtime behavior
 
 ## Contributing And Project Policies
+
+*Legal/social/process: how to contribute, behave, report issues, and what stability means.*
 
 - [Contributing Guide](../CONTRIBUTING.md)
 - [Code of Conduct](../CODE_OF_CONDUCT.md)
@@ -73,6 +85,8 @@ BlazeDB documentation is organized into:
 - [Third-Party Notices](../THIRD_PARTY_NOTICES.md)
 
 ## Maintainer Docs
+
+*CI lanes, releases, checklists—for people merging PRs or cutting releases.*
 
 - [CI and Test Tiers](Testing/CI_AND_TEST_TIERS.md)
 - [Testing Guide](TESTING_GUIDE.md)
@@ -84,10 +98,14 @@ BlazeDB documentation is organized into:
 
 ## Internal Analysis Docs
 
+*Deep dives and positioning notes; interesting for maintainers, not required reading for app devs.*
+
 - [Internal Docs Index](Internal/README.md)
 - Analysis-style status artifacts are maintainer-facing and intentionally separated from user onboarding flow.
 
 ## Historical And Internal Material
+
+*Old milestones, superseded designs, audits—useful for archaeology, not “current truth” unless linked from a maintained doc.*
 
 - [Archive](Archive/) for historical release and design records (see [Archive README](Archive/README.md)).
 - [Meta](Meta/README.md) for internal project-management documentation.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # BlazeDB
 
-**Version:** 2.7.5 &nbsp;|&nbsp; **License:** MIT &nbsp;|&nbsp; **Swift 6 strict concurrency compliant**
-
-An encrypted, embedded document database for Swift. Single-process, zero external dependencies. Production runtime is always encrypted at rest.
+An encrypted, embedded document database for Swift. Single-process, zero external dependencies. Production runtime is always encrypted at rest. *MIT · Swift 6+ · current release **2.7.5** (add the package under [Install](#install)).*
 
 [![Swift](https://img.shields.io/badge/Swift-6.0+-orange.svg)](https://swift.org)
 [![Platforms](https://img.shields.io/badge/Platforms-macOS%20%7C%20iOS%20%7C%20watchOS%20%7C%20tvOS%20%7C%20visionOS%20%7C%20Linux%20%7C%20Android-lightgrey.svg)](Docs/COMPATIBILITY.md)
@@ -12,41 +10,74 @@ An encrypted, embedded document database for Swift. Single-process, zero externa
 
 ## Quick Navigation
 
-- [Start Here (New Users)](#start-here-new-users)
-- [SwiftUI Path (Start Here)](#swiftui-path-start-here)
-- [Quick Start](#quick-start)
-- [Install](#install)
-- [Example: Lists and List Items](#example-lists-and-list-items)
-- [API Overview](#api-overview)
-- [Current Limitations](#current-limitations)
+*Primary links—everything else (Install, examples, API details) is further down.*
+
+- [Start Here](#start-here-new-users)
+- [What to do next](#what-to-do-next)
+- [SwiftUI path](#swiftui-path-start-here)
+- [Try the demo](#try-the-demo)
 - [Documentation](#documentation)
 
 ## Start Here (New Users)
 
 If you are new, use this path first and ignore the advanced sections until you need them.
 
+**No database experience needed.** BlazeDB stores everything in **one encrypted file** per app name (`"demo"` here)—like a save slot on disk, not a separate server. You describe data with ordinary Swift structs: **`put`** saves a value, **`get`** loads one item when you know its id string, **`query`** returns a list you can filter (e.g. only open bugs). Nothing is sent over the network.
+
+Read the sample **top to bottom**: `open` → `put` → `get` → `query`.
+
 ```swift
 import BlazeDB
 
+// One Bug’s shape in Swift
 struct Bug: BlazeStorable {
     var id: UUID = UUID()
     var title: String
     var status: String
 }
 
+// Open or create the file (password encrypts it; nothing leaves your machine)
 let db = try BlazeDB.open(name: "demo", password: "DemoPass123!")
 let bug = Bug(title: "Crash on launch", status: "open")
-try db.put(bug)
+try db.put(bug)  // save
 
+// Load by id: "bug" + this bug’s uuid
 let loaded: Bug? = try db.get("bug:\(bug.id.uuidString)")
+// All bugs with status "open"
 let openBugs: [Bug] = try db.query("bug")
     .where("status", equals: "open")
     .all()
 ```
 
-That is the default beginner workflow: `open -> put -> get -> query(namespace)`.
+The `"bug"` in `query("bug")` is a **label for which kind of record** (bugs vs notes vs something else). It is **not** a separate table—every record still lives in **one** collection inside that file.
 
-Keys use the format `"type:UUID"` (for example, `"bug:123e4567-e89b-12d3-a456-426614174000"`). The prefix maps to the model type/namespace.
+**Think:** one file, one collection, many labeled records.
+
+**Recap**
+
+| Step | What it does |
+|------|----------------|
+| `open` | Opens your encrypted file |
+| `put` | Saves a struct |
+| `get("bug:…")` | Loads one bug by id |
+| `query("bug")…` | Lists or filters bugs |
+
+Id strings look like `"bug:<uuid>"`: `bug` = kind, uuid = which one.
+
+## What to do next
+
+After `open` → `put` → `get` → `query` makes sense, pick **one** path:
+
+1. **SwiftUI app** → [SwiftUI DB Patterns](Docs/GettingStarted/SWIFTUI_DATABASE_PATTERNS.md) (how to hold `BlazeDBClient` in an app and level-up patterns).
+
+2. **UIKit / CLI / server-style app**  
+   → [Try the demo](#try-the-demo) (`swift run HelloBlazeDB` from a clone)  
+   → [Install](#install) (add the package to your app)  
+   → [HOW_TO_USE_BLAZEDB.md](Docs/GettingStarted/HOW_TO_USE_BLAZEDB.md)
+
+3. **How storage actually works** (single file, single collection, why there’s no SQL) → [Core Concepts](#core-concepts) below.
+
+If you skip straight to API tiers or raw APIs without that bridge, you’ll feel lost—that’s normal; come back to step 1–3.
 
 ## SwiftUI Path (Start Here)
 
@@ -55,6 +86,8 @@ If you are building a SwiftUI app, start here next:
 - [SwiftUI DB Patterns](Docs/GettingStarted/SWIFTUI_DATABASE_PATTERNS.md) - beginner-first setup, then clear Level 1 to Level 4 progression.
 
 ## What BlazeDB Is
+
+> **Optional background** — read [What to do next](#what-to-do-next) first if you only care about getting code running. This section is the mental model (embedded, encrypted, no SQL).
 
 - An **embedded** database — runs in your process, no server required
 - **Encrypted at rest** in production — AES-256-GCM on every data page
@@ -73,6 +106,8 @@ If you are building a SwiftUI app, start here next:
 
 ### API tiers
 
+*Skip this table until the default `open` / `put` / `get` / `query` flow feels boring—you don’t need to pick a “tier” on day one.*
+
 | Tier | API | Use case |
 |------|-----|----------|
 | **Default API (recommended)** | `BlazeDB.open(...)` + `db.put` / `db.get` / `db.query(namespace)` | Fastest path for most app code |
@@ -82,15 +117,15 @@ If you are building a SwiftUI app, start here next:
 
 ---
 
-## Quick Start
+## Try the demo
 
-Run the included example directly from this repository:
+**From a clone of this repo** (no `Package.swift` edit needed), run:
 
 ```bash
 swift run HelloBlazeDB
 ```
 
-Or test a different minimal example in your own app:
+**Minimal sample** (after adding the package)—same idea as [Start Here](#start-here-new-users), shorter:
 
 ```swift
 import BlazeDB
@@ -101,9 +136,9 @@ struct Note: BlazeStorable {
 }
 
 let db = try BlazeDB.open(name: "quickstart", password: "DemoPass123!")
-try db.put(Note(text: "Ship first BlazeDB build"))
+try db.put(Note(text: "Ship first BlazeDB build"))  // save
 
-let notes: [Note] = try db.query("note").all()
+let notes: [Note] = try db.query("note").all()  // all notes (or [] if empty)
 ```
 
 For the full beginner walkthrough (`open -> put -> get -> query`), use **Start Here (New Users)**.
@@ -191,7 +226,7 @@ Later, BlazeDB can find all items with that ID and return the items for Grocerie
 
 ## Advanced Usage (Optional)
 
-If you're new, the sections above are enough to get started. The rest of this README covers deeper architecture, advanced APIs, and operational details.
+If you're new, [What to do next](#what-to-do-next) + [Start Here](#start-here-new-users) are enough to ship something. Everything from **Core Concepts** downward is deeper architecture, alternate APIs, and ops—read when you need it, not in order.
 
 ## Core Concepts
 
@@ -219,6 +254,8 @@ The production runtime is always encrypted at rest. Every data page is sealed wi
 ---
 
 ## API Overview
+
+*Same idea as the [API tiers](#api-tiers) table above, with code—skip until the default API feels limiting.*
 
 ### Default API (recommended)
 
@@ -351,7 +388,8 @@ See [Compatibility Matrix](Docs/COMPATIBILITY.md) for details.
 
 ## Testing And CI
 
-- PR/release validation on macOS runs `BlazeDB_Tier0`, `BlazeDB_Tier1`, and `BlazeDB_Tier2` as the main gate.
+- **PR gate** (macOS): `BlazeDB_Tier0` and `BlazeDB_Tier1` on every push/PR; Linux runs `BlazeDB_Tier0`. See `Docs/Testing/CI_AND_TEST_TIERS.md` for the full matrix.
+- **Release validation** (tagged releases): macOS runs Tier0–Tier2 (+ extended companion targets as defined in the release workflow)—not the same cadence as the PR gate.
 - **Nightly Confidence (daily)** runs macOS Tier2 strict, clean checkout, README quickstart, Tier0 TSan, and Linux Tier1/Tier2 core lanes (see `Docs/Testing/CI_AND_TEST_TIERS.md`).
 - **Deep Validation (weekly)** runs broader coverage: macOS Tier0/1/2/3 + destructive + TSan, and Linux Tier0/1/2 (+ extended companion).
 - Additional nightly checks verify clean checkout and README quickstart scripts.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BlazeDB
 
-An encrypted, embedded document database for Swift. Single-process, zero external dependencies. Production runtime is always encrypted at rest. *MIT · Swift 6+ · current release **2.7.5** (add the package under [Install](#install)).*
+An encrypted, embedded document database for Swift. Single-process, zero external dependencies. Production runtime is always encrypted at rest. *MIT · Swift 6+ · current release **2.7.5** (add the package under [Add BlazeDB to your app](#add-blazedb-to-your-app)).*
 
 [![Swift](https://img.shields.io/badge/Swift-6.0+-orange.svg)](https://swift.org)
 [![Platforms](https://img.shields.io/badge/Platforms-macOS%20%7C%20iOS%20%7C%20watchOS%20%7C%20tvOS%20%7C%20visionOS%20%7C%20Linux%20%7C%20Android-lightgrey.svg)](Docs/COMPATIBILITY.md)
@@ -10,12 +10,18 @@ An encrypted, embedded document database for Swift. Single-process, zero externa
 
 ## Quick Navigation
 
-*Primary links—everything else (Install, examples, API details) is further down.*
+*Primary links—everything else (examples, API details, deeper sections) is further down.*
+
+This README is **onboarding-first**: most people start with [Start Here](#start-here-new-users) to get a mental model and copy-paste sample. Two explicit paths branch from there:
+
+- **Path A — try BlazeDB from this repo:** clone, then [Try BlazeDB from this repo](#try-blazedb-from-this-repo) (`swift run HelloBlazeDB`).
+- **Path B — add BlazeDB to your app:** [Add BlazeDB to your app](#add-blazedb-to-your-app) (SwiftPM or Xcode), then wire up code using Start Here, [SwiftUI path](#swiftui-path-start-here), or the full guide.
 
 - [Start Here](#start-here-new-users)
+- [Try BlazeDB from this repo](#try-blazedb-from-this-repo)
+- [Add BlazeDB to your app](#add-blazedb-to-your-app)
 - [What to do next](#what-to-do-next)
 - [SwiftUI path](#swiftui-path-start-here)
-- [Try the demo](#try-the-demo)
 - [Documentation](#documentation)
 
 ## Start Here (New Users)
@@ -64,6 +70,56 @@ The `"bug"` in `query("bug")` is a **label for which kind of record** (bugs vs n
 
 Id strings look like `"bug:<uuid>"`: `bug` = kind, uuid = which one.
 
+---
+
+## Try BlazeDB from this repo
+
+**Path A — repo demo.** From a clone of this repo (no `Package.swift` edit needed), run:
+
+```bash
+swift run HelloBlazeDB
+```
+
+**Minimal sample** (after adding the package)—same idea as [Start Here](#start-here-new-users), shorter:
+
+```swift
+import BlazeDB
+
+struct Note: BlazeStorable {
+    var id: UUID = UUID()
+    var text: String
+}
+
+let db = try BlazeDB.open(name: "quickstart", password: "DemoPass123!")
+try db.put(Note(text: "Ship first BlazeDB build"))  // save
+
+let notes: [Note] = try db.query("note").all()  // all notes (or [] if empty)
+```
+
+For the full beginner walkthrough (`open -> put -> get -> query`), use **Start Here (New Users)**.
+For deeper coverage, see [HOW_TO_USE_BLAZEDB.md](Docs/GettingStarted/HOW_TO_USE_BLAZEDB.md).
+
+## Add BlazeDB to your app
+
+**Path B — consumer integration.** Add the package to your project, then use the snippets in [Start Here](#start-here-new-users) or [Try BlazeDB from this repo](#try-blazedb-from-this-repo) (minimal sample).
+
+Add to your `Package.swift`:
+
+```swift
+dependencies: [
+    .package(url: "https://github.com/Mikedan37/BlazeDB.git", from: "2.7.5")
+],
+targets: [
+    .target(name: "YourApp", dependencies: ["BlazeDB"])
+]
+```
+
+Or in Xcode: **File → Add Package Dependencies** → paste `https://github.com/Mikedan37/BlazeDB.git`.
+
+**Requirements:** Swift 6.0+, macOS 15+ / iOS 15+ / watchOS 8+ / tvOS 15+ / visionOS 1+ / Linux / Android
+
+---
+
 ## What to do next
 
 After `open` → `put` → `get` → `query` makes sense, pick **one** path:
@@ -71,8 +127,8 @@ After `open` → `put` → `get` → `query` makes sense, pick **one** path:
 1. **SwiftUI app** → [SwiftUI DB Patterns](Docs/GettingStarted/SWIFTUI_DATABASE_PATTERNS.md) (how to hold `BlazeDBClient` in an app and level-up patterns).
 
 2. **UIKit / CLI / server-style app**  
-   → [Try the demo](#try-the-demo) (`swift run HelloBlazeDB` from a clone)  
-   → [Install](#install) (add the package to your app)  
+   → [Try BlazeDB from this repo](#try-blazedb-from-this-repo) (`swift run HelloBlazeDB` from a clone)  
+   → [Add BlazeDB to your app](#add-blazedb-to-your-app) (SwiftPM or Xcode)  
    → [HOW_TO_USE_BLAZEDB.md](Docs/GettingStarted/HOW_TO_USE_BLAZEDB.md)
 
 3. **How storage actually works** (single file, single collection, why there’s no SQL) → [Core Concepts](#core-concepts) below.
@@ -114,52 +170,6 @@ If you are building a SwiftUI app, start here next:
 | **TypedStore (secondary)** | `db.typed(T.self)` → scoped handle | View models or service layers that want a bound store |
 | **Raw (advanced)** | `BlazeDataRecord` + `db.insert(record)` | Dynamic schemas, migrations |
 | **Manual mapping (advanced)** | `BlazeDocument` | Custom storage control and manual serialization |
-
----
-
-## Try the demo
-
-**From a clone of this repo** (no `Package.swift` edit needed), run:
-
-```bash
-swift run HelloBlazeDB
-```
-
-**Minimal sample** (after adding the package)—same idea as [Start Here](#start-here-new-users), shorter:
-
-```swift
-import BlazeDB
-
-struct Note: BlazeStorable {
-    var id: UUID = UUID()
-    var text: String
-}
-
-let db = try BlazeDB.open(name: "quickstart", password: "DemoPass123!")
-try db.put(Note(text: "Ship first BlazeDB build"))  // save
-
-let notes: [Note] = try db.query("note").all()  // all notes (or [] if empty)
-```
-
-For the full beginner walkthrough (`open -> put -> get -> query`), use **Start Here (New Users)**.
-For deeper coverage, see [HOW_TO_USE_BLAZEDB.md](Docs/GettingStarted/HOW_TO_USE_BLAZEDB.md).
-
-## Install
-
-Add to your `Package.swift`:
-
-```swift
-dependencies: [
-    .package(url: "https://github.com/Mikedan37/BlazeDB.git", from: "2.7.5")
-],
-targets: [
-    .target(name: "YourApp", dependencies: ["BlazeDB"])
-]
-```
-
-Or in Xcode: **File → Add Package Dependencies** → paste `https://github.com/Mikedan37/BlazeDB.git`.
-
-**Requirements:** Swift 6.0+, macOS 15+ / iOS 15+ / watchOS 8+ / tvOS 15+ / visionOS 1+ / Linux / Android
 
 ---
 


### PR DESCRIPTION
## Summary

Onboarding-first README with two explicit paths after **Start Here**:

- **Path A — Try BlazeDB from this repo** (`swift run HelloBlazeDB` from a clone)
- **Path B — Add BlazeDB to your app** (SwiftPM / Xcode; replaces a vague "Install" heading)

Also aligns `Docs/README.md` and `FEATURE_ROADMAP.md` headings with the new section names.

## Why

Separates "evaluate from the repo" vs "integrate into an app" without leading with setup-heavy steps, so GitHub visitors get a mental model first.

No runtime or CI behavior changes.