### PR TITLE
docs: slim SwiftUI getting-started + align README SwiftUI links

### DIFF
--- a/Docs/GettingStarted/SWIFTUI_DATABASE_PATTERNS.md
+++ b/Docs/GettingStarted/SWIFTUI_DATABASE_PATTERNS.md
@@ -1,34 +1,14 @@
 # BlazeDB in SwiftUI
 
-**Standard SwiftUI pattern**
+**Once:** open the DB · inject **`BlazeDBClient`** at the root · read with **`@BlazeQuery`** · write with **`@Environment(\.blazeDBClient)`** · add a store only when write flows get messy.
 
-- Open BlazeDB **once**
-- Inject the client **once** at the app root
-- Read typed models with **`@BlazeQuery`**
-- Write through **`@Environment(\.blazeDBClient)`**
-- Add a **store** only when write logic grows
+More (raw queries, `db:` overrides, migration): [SwiftUI Integration Guide](../Guides/SWIFTUI_INTEGRATION.md) · [Facade migration](SWIFTUI_FACADE_MIGRATION.md)
 
-For deeper reference (explicit `db:`, raw queries, compatibility, custom environment), see the [SwiftUI Integration Guide](../Guides/SWIFTUI_INTEGRATION.md). Upgrading old examples: [SwiftUI facade migration](SWIFTUI_FACADE_MIGRATION.md).
-
----
-
-## Level 1 — Standard pattern
+## Minimal example
 
 ```swift
 import SwiftUI
 import BlazeDB
-
-final class AppDatabase {
-    static let shared = AppDatabase()
-    let db: BlazeDBClient
-
-    private init() {
-        self.db = try! BlazeDB.open(
-            name: "myapp",
-            password: "Password123!"
-        )
-    }
-}
 
 struct TodoItem: BlazeDocument {
     var id: UUID
@@ -42,22 +22,24 @@ struct TodoItem: BlazeDocument {
     }
 
     init(from storage: BlazeDataRecord) throws {
-        guard let id = storage.storage["id"]?.uuidValue,
-              let title = storage.storage["title"]?.stringValue else {
-            throw BlazeDBError.invalidData(reason: "Invalid TodoItem")
-        }
-        self.id = id
-        self.title = title
-        self.isDone = storage.storage["isDone"]?.boolValue ?? false
+        self.id = try storage.uuid("id")
+        self.title = try storage.string("title")
+        self.isDone = storage.boolOptional("isDone") ?? false
     }
 
     func toStorage() throws -> BlazeDataRecord {
         BlazeDataRecord([
             "id": .uuid(id),
             "title": .string(title),
-            "isDone": .bool(isDone)
+            "isDone": .bool(isDone),
         ])
     }
+}
+
+final class AppDatabase {
+    static let shared = AppDatabase()
+    let db: BlazeDBClient
+    private init() { self.db = try! BlazeDB.open(name: "myapp", password: "Password123!") }
 }
 
 @main
@@ -76,82 +58,11 @@ struct ContentView: View {
 
     var body: some View {
         VStack {
-            Button("Add Sample Item") {
-                try? database?.insert(TodoItem(title: "Buy milk"))
-            }
-            List(items, id: \.id) { item in
-                Text(item.title)
-            }
+            Button("Add") { try? database?.insert(TodoItem(title: "Buy milk")) }
+            List(items, id: \.id) { Text($0.title) }
         }
     }
 }
 ```
 
-**Why this is the standard**
-
-- BlazeDB opens once for the app.
-- `@BlazeQuery` keeps the list in sync with the database.
-- Views do not need custom query wiring or passing `BlazeDBClient` through every initializer.
-
----
-
-## Level 2 — Add a store when writes grow
-
-Keep reads in the view with `@BlazeQuery`. Move validation and multi-step writes into a store when the screen gets heavier.
-
-```swift
-@MainActor
-final class TodoWriteStore: ObservableObject {
-    func addSample(using database: BlazeDBClient?) {
-        try? database?.insert(TodoItem(title: "From store"))
-    }
-}
-
-struct TodoListWithStoreView: View {
-    @Environment(\.blazeDBClient) private var database
-    @StateObject private var store = TodoWriteStore()
-    @BlazeQuery var items: [TodoItem]
-
-    var body: some View {
-        VStack {
-            Button("Add via store") {
-                store.addSample(using: database)
-            }
-            List(items, id: \.id) { item in
-                Text(item.title)
-            }
-        }
-    }
-}
-```
-
----
-
-## Level 3 — Larger apps
-
-- One shared `BlazeDBClient` (or `AppDatabase`) for the process.
-- Use `@BlazeQuery` in feature views.
-- Add a store per feature when that feature needs coordinated writes.
-
----
-
-## Advanced patterns
-
-Use the [SwiftUI Integration Guide](../Guides/SWIFTUI_INTEGRATION.md) for:
-
-- explicit `db:` on query wrappers  
-- raw `@BlazeDataQuery`  
-- compatibility aliases and edge cases  
-- custom environment wrappers  
-
----
-
-## Summary
-
-Default SwiftUI path:
-
-- `.blazeDBEnvironment(AppDatabase.shared.db)`
-- `@BlazeQuery` for typed lists  
-- `@Environment(\.blazeDBClient)` for writes (`insert` for `BlazeDocument` models)
-
-That is the front door. Details live in the integration guide and migration doc.
+**Bigger apps:** one shared client; optional `ObservableObject` per feature for heavy writes; keep **`@BlazeQuery`** on lists so you do not hand-roll reloads.

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Or in Xcode: **File → Add Package Dependencies** → paste `https://github.com
 
 After `open` → `put` → `get` → `query` makes sense, pick **one** path:
 
-1. **SwiftUI app** → [SwiftUI DB Patterns](Docs/GettingStarted/SWIFTUI_DATABASE_PATTERNS.md) (blessed path: inject once, `@BlazeQuery`, environment writes; then leveled patterns).
+1. **SwiftUI app** → [SwiftUI DB Patterns](Docs/GettingStarted/SWIFTUI_DATABASE_PATTERNS.md) (minimal example: inject once, `@BlazeQuery`, environment writes). Anything beyond that (filters, raw rows, explicit `db:`): [SwiftUI Integration Guide](Docs/Guides/SWIFTUI_INTEGRATION.md).
 
 2. **UIKit / CLI / server-style app**  
    → [Try BlazeDB from this repo](#try-blazedb-from-this-repo) (`swift run HelloBlazeDB` from a clone)  
@@ -147,7 +147,7 @@ If you skip straight to API tiers or raw APIs without that bridge, you’ll feel
 
 **Standard BlazeDB SwiftUI app:** inject **`BlazeDBClient` once** (`.blazeDBEnvironment(_)` or `.environment(\.blazeDBClient, …)`), use **`@BlazeQuery`** for typed reads, and **`@Environment(\.blazeDBClient)`** for writes (`insert` / `put` to match your model). Add a **store** only when the screen’s logic outgrows simple calls.
 
-Details and leveled patterns: [SwiftUI DB Patterns](Docs/GettingStarted/SWIFTUI_DATABASE_PATTERNS.md). Deeper reference (raw queries, edge cases): [SwiftUI Integration Guide](Docs/Guides/SWIFTUI_INTEGRATION.md).
+Starter: [SwiftUI DB Patterns](Docs/GettingStarted/SWIFTUI_DATABASE_PATTERNS.md). Full reference (raw queries, edge cases): [SwiftUI Integration Guide](Docs/Guides/SWIFTUI_INTEGRATION.md).
 
 ---
 


### PR DESCRIPTION
## Summary

Follow-up to #159: keep **SwiftUI getting-started** and **README navigation** separate from the facade code that already merged.

- **`SWIFTUI_DATABASE_PATTERNS.md`:** one intro line, one copy-paste block (compact `TodoItem`), links to the integration guide + migration doc.
- **`README.md`:** drop stale “leveled patterns” wording; point “beyond minimal” readers at `SWIFTUI_INTEGRATION.md`.

No engine or SwiftUI wrapper code changes.

## Verification

Documentation only.