### PR TITLE
docs(swiftui): wiring-first getting-started (defer BlazeDocument mapping)

### DIFF
--- a/Docs/GettingStarted/SWIFTUI_DATABASE_PATTERNS.md
+++ b/Docs/GettingStarted/SWIFTUI_DATABASE_PATTERNS.md
@@ -1,45 +1,45 @@
 # BlazeDB in SwiftUI
 
-**Once:** open the DB · inject **`BlazeDBClient`** at the root · read with **`@BlazeQuery`** · write with **`@Environment(\.blazeDBClient)`** · add a store only when write flows get messy.
+**Standard SwiftUI pattern**
 
-More (raw queries, `db:` overrides, migration): [SwiftUI Integration Guide](../Guides/SWIFTUI_INTEGRATION.md) · [Facade migration](SWIFTUI_FACADE_MIGRATION.md)
+- Open BlazeDB **once**
+- Inject the client **once** at the app root
+- Read typed models with **`@BlazeQuery`**
+- Write through **`@Environment(\.blazeDBClient)`**
+- Add a **store** only when write logic grows
 
-## Minimal example
+For deeper reference, raw queries, compatibility notes, and full `BlazeDocument` model examples, see the [SwiftUI Integration Guide](../Guides/SWIFTUI_INTEGRATION.md). Upgrading old examples: [SwiftUI facade migration](SWIFTUI_FACADE_MIGRATION.md).
+
+---
+
+## Level 1 — Standard app wiring
+
+Define a `BlazeDocument` model once, then wire the app like this.
+
+This page focuses on **where the database opens**, **how it is injected**, **how reads work**, and **how writes work**. It does **not** walk through full `toStorage()` / `init(from:)` mapping—see the integration guide or [`Examples/TypeSafeModels.swift`](../../Examples/TypeSafeModels.swift) for that.
+
+> **`BlazeDocument` requires `init(from:)` and `toStorage()`.** The `TodoItem` sketch below shows fields and usage only. Before you build, add those two methods (copy a template from [`TypeSafeModels.swift`](../../Examples/TypeSafeModels.swift) or the [integration guide](../Guides/SWIFTUI_INTEGRATION.md)).
 
 ```swift
 import SwiftUI
 import BlazeDB
 
-struct TodoItem: BlazeDocument {
-    var id: UUID
-    var title: String
-    var isDone: Bool
-
-    init(id: UUID = UUID(), title: String, isDone: Bool = false) {
-        self.id = id
-        self.title = title
-        self.isDone = isDone
-    }
-
-    init(from storage: BlazeDataRecord) throws {
-        self.id = try storage.uuid("id")
-        self.title = try storage.string("title")
-        self.isDone = storage.boolOptional("isDone") ?? false
-    }
-
-    func toStorage() throws -> BlazeDataRecord {
-        BlazeDataRecord([
-            "id": .uuid(id),
-            "title": .string(title),
-            "isDone": .bool(isDone),
-        ])
-    }
-}
-
 final class AppDatabase {
     static let shared = AppDatabase()
     let db: BlazeDBClient
-    private init() { self.db = try! BlazeDB.open(name: "myapp", password: "Password123!") }
+
+    private init() {
+        self.db = try! BlazeDB.open(
+            name: "myapp",
+            password: "Password123!"
+        )
+    }
+}
+
+struct TodoItem: BlazeDocument {
+    var id: UUID = UUID()
+    var title: String
+    var isDone: Bool = false
 }
 
 @main
@@ -58,11 +58,100 @@ struct ContentView: View {
 
     var body: some View {
         VStack {
-            Button("Add") { try? database?.insert(TodoItem(title: "Buy milk")) }
-            List(items, id: \.id) { Text($0.title) }
+            Button("Add Sample Item") {
+                try? database?.insert(TodoItem(title: "Buy milk"))
+            }
+
+            List(items, id: \.id) { item in
+                Text(item.title)
+            }
         }
     }
 }
 ```
 
-**Bigger apps:** one shared client; optional `ObservableObject` per feature for heavy writes; keep **`@BlazeQuery`** on lists so you do not hand-roll reloads.
+### Why this is the standard
+
+- BlazeDB opens once for the app.
+- `@BlazeQuery` keeps the list in sync.
+- Views do not need custom query setup.
+- The database does not need to be passed through every initializer.
+
+---
+
+## Level 2 — Add a store when writes grow
+
+Keep reads in the view with `@BlazeQuery`. Move validation and multi-step writes into a store when the screen gets heavier.
+
+```swift
+import SwiftUI
+import Combine
+import BlazeDB
+
+@MainActor
+final class TodoWriteStore: ObservableObject {
+    func addSample(using database: BlazeDBClient?) {
+        try? database?.insert(TodoItem(title: "From store"))
+    }
+}
+
+struct TodoListWithStoreView: View {
+    @Environment(\.blazeDBClient) private var database
+    @StateObject private var store = TodoWriteStore()
+    @BlazeQuery var items: [TodoItem]
+
+    var body: some View {
+        VStack {
+            Button("Add via store") {
+                store.addSample(using: database)
+            }
+
+            List(items, id: \.id) { item in
+                Text(item.title)
+            }
+        }
+    }
+}
+```
+
+---
+
+## Level 3 — Larger apps
+
+- One shared `BlazeDBClient` for the process
+- Use `@BlazeQuery` in feature views
+- Add a store per feature when coordinated writes are needed
+
+---
+
+## Advanced patterns
+
+Use the [SwiftUI Integration Guide](../Guides/SWIFTUI_INTEGRATION.md) for:
+
+- explicit `db:` on query wrappers
+- raw `@BlazeDataQuery`
+- compatibility aliases and edge cases
+- full `BlazeDocument` model mapping
+- custom environment wrappers
+
+---
+
+## Summary
+
+Default SwiftUI path:
+
+- `.blazeDBEnvironment(AppDatabase.shared.db)`
+- `@BlazeQuery`
+- `@Environment(\.blazeDBClient)` for writes
+
+That is the front door.
+
+---
+
+## Why this page is split this way
+
+SwiftUI integration (environment, queries, writes) and **document serialization** (`BlazeDocument` field mapping) are separate learning steps. Mixing them on one getting-started page makes BlazeDB feel heavier than it needs to.
+
+## Product note
+
+`BlazeDocument` is a manual mapping protocol—you still have to implement `init(from:)` and `toStorage()` somewhere before typed queries and `insert` work. This doc defers that to the integration guide and examples so the first read stays about app shape, not serialization.

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Or in Xcode: **File → Add Package Dependencies** → paste `https://github.com
 
 After `open` → `put` → `get` → `query` makes sense, pick **one** path:
 
-1. **SwiftUI app** → [SwiftUI DB Patterns](Docs/GettingStarted/SWIFTUI_DATABASE_PATTERNS.md) (minimal example: inject once, `@BlazeQuery`, environment writes). Anything beyond that (filters, raw rows, explicit `db:`): [SwiftUI Integration Guide](Docs/Guides/SWIFTUI_INTEGRATION.md).
+1. **SwiftUI app** → [SwiftUI DB Patterns](Docs/GettingStarted/SWIFTUI_DATABASE_PATTERNS.md) (app wiring: inject once, `@BlazeQuery`, environment writes; full `BlazeDocument` mapping lives in the integration guide). Anything beyond that (filters, raw rows, explicit `db:`): [SwiftUI Integration Guide](Docs/Guides/SWIFTUI_INTEGRATION.md).
 
 2. **UIKit / CLI / server-style app**  
    → [Try BlazeDB from this repo](#try-blazedb-from-this-repo) (`swift run HelloBlazeDB` from a clone)  
@@ -147,7 +147,7 @@ If you skip straight to API tiers or raw APIs without that bridge, you’ll feel
 
 **Standard BlazeDB SwiftUI app:** inject **`BlazeDBClient` once** (`.blazeDBEnvironment(_)` or `.environment(\.blazeDBClient, …)`), use **`@BlazeQuery`** for typed reads, and **`@Environment(\.blazeDBClient)`** for writes (`insert` / `put` to match your model). Add a **store** only when the screen’s logic outgrows simple calls.
 
-Starter: [SwiftUI DB Patterns](Docs/GettingStarted/SWIFTUI_DATABASE_PATTERNS.md). Full reference (raw queries, edge cases): [SwiftUI Integration Guide](Docs/Guides/SWIFTUI_INTEGRATION.md).
+SwiftUI wiring: [SwiftUI DB Patterns](Docs/GettingStarted/SWIFTUI_DATABASE_PATTERNS.md). Full reference (raw queries, `BlazeDocument` mapping, edge cases): [SwiftUI Integration Guide](Docs/Guides/SWIFTUI_INTEGRATION.md).
 
 ---
 


### PR DESCRIPTION
## Summary

The getting-started page mixed **SwiftUI wiring** with a full `BlazeDocument` sample, which made BlazeDB feel heavier than the SwiftUI story warrants.

This PR:

- Puts **open / inject / `@BlazeQuery` / env writes** (and optional store) front and center.
- **Defers** `init(from:)` / `toStorage()` to the [SwiftUI Integration Guide](Docs/Guides/SWIFTUI_INTEGRATION.md) and [`Examples/TypeSafeModels.swift`](Examples/TypeSafeModels.swift), with an explicit blockquote so readers know the `TodoItem` sketch is incomplete until mapping is added.
- Adds short sections on **why** wiring and serialization are split, and an honest **product note** that `BlazeDocument` still requires manual mapping somewhere.
- Tweaks **README** lines so “SwiftUI DB Patterns” is described as **app wiring**, not the full mapping reference.

No code or API changes.

Made with [Cursor](https://cursor.com)