### PR TITLE
fix(tests): observability concurrent test — CI deadline vs deadlock semantics

### DIFF
--- a/BlazeDBTests/Tier1Extended/Observability/ObservabilityTests.swift
+++ b/BlazeDBTests/Tier1Extended/Observability/ObservabilityTests.swift
@@ -170,11 +170,26 @@ final class ObservabilityTests: XCTestCase {
     }
     
     func testObservability_DoesNotDeadlock() throws {
-        // Concurrent operations with observability
+        // Concurrent operations with observability.
+        //
+        // Wall-clock budget, not a deadlock oracle: `DispatchGroup.wait(timeout:)` only checks
+        // that work finishes before a deadline. `.timedOut` means one or more tasks did not
+        // complete in time — consistent with queued access behind serialized writes, contention,
+        // filesystem latency, or CI scheduler variance — not proof of an AB–BA lock cycle.
+        //
+        // Why budgets must be generous on CI:
+        // - Writes serialize through `performSafeWrite` (client write lock) and legacy insert’s
+        //   barrier on the collection queue; under contention, end-to-end time can approach the
+        //   cumulative cost of those critical sections, not a single insert in isolation.
+        // - `observe()` is not free: it routes through `health()` / `stats()` / monitoring paths
+        //   with additional synchronous queue work, stacking with concurrent `fetchAll()`.
         let group = DispatchGroup()
         let errors = ObservabilityLockedErrors()
         let client = try XCTUnwrap(db)
-        
+        let isCI = ProcessInfo.processInfo.environment["CI"] == "true"
+            || ProcessInfo.processInfo.environment["GITHUB_ACTIONS"] == "true"
+        let deadlineSeconds: TimeInterval = isCI ? 45.0 : 15.0
+
         for _ in 0..<10 {
             group.enter()
             DispatchQueue.global().async { [client] in
@@ -189,10 +204,14 @@ final class ObservabilityTests: XCTestCase {
                 group.leave()
             }
         }
-        
-        let result = group.wait(timeout: .now() + 5.0)
+
+        let result = group.wait(timeout: .now() + deadlineSeconds)
         let allErrors = errors.snapshot()
-        XCTAssertEqual(result, .success, "Operations should complete without deadlock")
+        XCTAssertEqual(
+            result,
+            .success,
+            "All concurrent lanes should finish within \(deadlineSeconds)s (deadline miss ≠ proven deadlock)"
+        )
         XCTAssertTrue(allErrors.isEmpty || allErrors.allSatisfy { $0.localizedDescription.contains("locked") },
                       "Only expected errors should occur")
     }

--- a/Docs/Testing/TEST_STABILITY_FIXES.md
+++ b/Docs/Testing/TEST_STABILITY_FIXES.md
@@ -80,6 +80,26 @@ if results.count >= 3 {
 
 ---
 
+### 6. **Observability concurrent stress — deadline vs deadlock (Tier 2)**
+
+**Problem:** `testObservability_DoesNotDeadlock` failed on macOS CI with `DispatchGroup.wait` returning `.timedOut` against a 5s budget. That only proves a **deadline miss**, not a lock cycle in the engine.
+
+**Interpretation (defensible):**
+
+- Inserts serialize through `performSafeWrite` and the collection queue’s barrier path; under contention, completion time can approach the **cumulative** cost of those sections.
+- `observe()` pulls in `health()` / `stats()` / monitoring snapshot work — synchronous queue and filesystem activity — and stacks with concurrent `fetchAll()`.
+- Loaded CI runners add wall-clock variance (scheduling, disk, fsync). Forward progress can still be happening when a short stopwatch fires.
+
+**Fix:** Larger timeout on CI (`CI` / `GITHUB_ACTIONS`: 45s; local: 15s) and in-test documentation that the assertion is a **wall-clock bound**, not deadlock detection. A real deadlock-focused test would need different design (lock-order instrumentation, progress probes, or diagnostics that distinguish stall from slow completion).
+
+**If this flakes again:** Prefer adding **observability** (per-phase timing, progress checks, contention signals) over repeatedly widening the budget. The test should stay forgiving of scheduler noise but still fail on meaningful regressions — avoid turning it into “pass unless the machine is on fire.”
+
+**File:** `BlazeDBTests/Tier1Extended/Observability/ObservabilityTests.swift`
+
+**Added:** 2026-04-12
+
+---
+
 ## Test Execution Improvements
 
 ### Before Fixes:


### PR DESCRIPTION
## Summary

Nightly macOS Tier2 (strict) failed on `testObservability_DoesNotDeadlock` with `DispatchGroup.wait` returning `.timedOut` after **5s**. That only shows a **wall-clock deadline miss**, not a demonstrated AB–BA deadlock in the engine.

## Changes

- **`ObservabilityTests.swift`**: Document what the test actually measures; use **CI-aware timeouts** (`CI` / `GITHUB_ACTIONS`: 45s, local: 15s); assertion text no longer implies a proven deadlock.
- **`Docs/Testing/TEST_STABILITY_FIXES.md`**: Add §6 with a defensible interpretation, mitigation, and guidance to prefer observability over repeatedly stretching budgets if this flakes again.

## Why it passed other runs

Intermittent by nature:

- **Same code, different wall time**: Ten concurrent lanes do serialized writes plus `observe()` → `stats()` / monitoring paths and `fetchAll()`; total time varies with **runner load**, **disk/fsync**, and **queue scheduling**.
- **5s was a tight budget** on shared `macos-15` hosts; a pass only means that run finished under the stopwatch, not that the previous failure was impossible.
- **Different triggers**: Manual workflow runs vs scheduled nightly can hit different queue contention and `main` SHAs.

So earlier greens were consistent with **timing variance**, not proof the old budget was always safe.


Made with [Cursor](https://cursor.com)