### PR TITLE
SwiftUI: @BlazeStorableQuery uses environment; docs single front door

### DIFF
--- a/BlazeDB/SwiftUI/BlazeStorableLiveQuery.swift
+++ b/BlazeDB/SwiftUI/BlazeStorableLiveQuery.swift
@@ -3,6 +3,30 @@ import Foundation
 #if canImport(SwiftUI) && canImport(Combine) && (os(macOS) || os(iOS) || os(watchOS) || os(tvOS))
 import SwiftUI
 
+// MARK: - Change notification (same pattern as ``BlazeQueryTypedObserver``)
+
+@MainActor
+fileprivate protocol BlazeStorableQueryRefreshable: AnyObject {
+    func refresh()
+}
+
+extension BlazeStorableQueryObserver: BlazeStorableQueryRefreshable {}
+
+private final class BlazeStorableQueryRefreshSink: @unchecked Sendable {
+    private weak var target: (any BlazeStorableQueryRefreshable)?
+
+    func attach(_ o: any BlazeStorableQueryRefreshable) {
+        target = o
+    }
+
+    func notifyChange() {
+        guard let t = target else { return }
+        Task { @MainActor in
+            t.refresh()
+        }
+    }
+}
+
 /// SwiftUI live-query wrapper for a ``BlazeStorable`` model (namespace-filtered decode).
 ///
 /// **Relationship to other wrappers:** Prefer ``BlazeQuery`` when your model conforms to
@@ -10,26 +34,35 @@ import SwiftUI
 /// ``BlazeStorable`` / Codable only and do not want ``BlazeDocument``. For raw
 /// ``BlazeDataRecord`` rows, use ``BlazeDataQuery``.
 ///
-/// Use this when your UI should stay in sync with database writes for one model type.
+/// Pass ``BlazeDBClient`` with `db:` **or** inject ``EnvironmentValues/blazeDBClient`` from an ancestor
+/// (same as ``BlazeQuery``). If `db` is omitted, results stay empty until the environment provides a client.
 ///
 /// ```swift
-/// @BlazeStorableQuery(
-///     db: db,
-///     kind: Bug.self,
-///     where: "status",
-///     equals: .string("open")
-/// )
-/// var bugs: [Bug]
+/// RootView().blazeDBEnvironment(app.db)
+///
+/// @BlazeStorableQuery(kind: Bug.self) var bugs: [Bug]
 /// ```
 @propertyWrapper
 @MainActor
 public struct BlazeStorableQuery<T: BlazeStorable>: DynamicProperty {
+    private let explicitDB: BlazeDBClient?
+
+    @Environment(\.blazeDBClient) private var environmentDB
     @StateObject private var observer: BlazeStorableQueryObserver<T>
 
-    public var wrappedValue: [T] { observer.results }
-    public var projectedValue: BlazeStorableQueryObserver<T> { observer }
+    public var wrappedValue: [T] {
+        observer.bindDatabaseIfNeeded(explicitDB ?? environmentDB)
+        return observer.results
+    }
 
-    public init(db: BlazeDBClient, kind: T.Type) {
+    public var projectedValue: BlazeStorableQueryObserver<T> {
+        observer.bindDatabaseIfNeeded(explicitDB ?? environmentDB)
+        return observer
+    }
+
+    /// - Parameter db: Pass `nil` (default) to resolve the client from ``EnvironmentValues/blazeDBClient``.
+    public init(db: BlazeDBClient? = nil, kind: T.Type) {
+        self.explicitDB = db
         _observer = StateObject(wrappedValue: BlazeStorableQueryObserver(
             db: db,
             filters: [],
@@ -39,8 +72,9 @@ public struct BlazeStorableQuery<T: BlazeStorable>: DynamicProperty {
         ))
     }
 
+    /// - Parameter db: Pass `nil` (default) to resolve the client from ``EnvironmentValues/blazeDBClient``.
     public init(
-        db: BlazeDBClient,
+        db: BlazeDBClient? = nil,
         kind: T.Type,
         where field: String,
         equals value: BlazeDocumentField,
@@ -48,6 +82,7 @@ public struct BlazeStorableQuery<T: BlazeStorable>: DynamicProperty {
         descending: Bool = false,
         limit: Int? = nil
     ) {
+        self.explicitDB = db
         _observer = StateObject(wrappedValue: BlazeStorableQueryObserver(
             db: db,
             filters: [(field, .equals, value)],
@@ -58,22 +93,26 @@ public struct BlazeStorableQuery<T: BlazeStorable>: DynamicProperty {
     }
 }
 
+/// Alias for ``BlazeStorableQuery`` when you want a name that signals environment-driven resolution.
+public typealias BlazeStorableEnvironmentQuery<T: BlazeStorable> = BlazeStorableQuery<T>
+
 @MainActor
 public final class BlazeStorableQueryObserver<T: BlazeStorable>: ObservableObject {
     @Published public private(set) var results: [T] = []
     @Published public private(set) var isLoading: Bool = false
     @Published public private(set) var error: Error?
 
-    private let db: BlazeDBClient
+    private var db: BlazeDBClient?
     private let filters: [(field: String, comparison: BlazeQueryComparison, value: BlazeDocumentField)]
     private let sortField: String?
     private let sortDescending: Bool
     private let limitCount: Int?
     private var refreshTask: Task<Void, Never>?
     private var changeObserverToken: ObserverToken?
+    private let refreshSink = BlazeStorableQueryRefreshSink()
 
     fileprivate init(
-        db: BlazeDBClient,
+        db: BlazeDBClient?,
         filters: [(field: String, comparison: BlazeQueryComparison, value: BlazeDocumentField)],
         sortField: String?,
         sortDescending: Bool,
@@ -85,14 +124,37 @@ public final class BlazeStorableQueryObserver<T: BlazeStorable>: ObservableObjec
         self.sortField = sortField
         self.sortDescending = sortDescending
         self.limitCount = limitCount
+
+        refreshSink.attach(self)
+
+        if let db {
+            subscribeToChanges(db: db)
+            refresh()
+        }
+    }
+
+    /// Binds a ``BlazeDBClient`` from SwiftUI environment (or explicit injection) the first time it becomes available.
+    internal func bindDatabaseIfNeeded(_ client: BlazeDBClient?) {
+        guard db == nil, let client else { return }
+        db = client
+        subscribeToChanges(db: client)
         refresh()
-        self.changeObserverToken = db.observe { [weak self] _ in
-            Task { @MainActor in self?.refresh() }
+    }
+
+    private func subscribeToChanges(db: BlazeDBClient) {
+        changeObserverToken = db.observe { [refreshSink] _ in
+            refreshSink.notifyChange()
         }
     }
 
     public func refresh() {
         refreshTask?.cancel()
+
+        guard let db else {
+            isLoading = false
+            return
+        }
+
         refreshTask = Task { @MainActor in
             isLoading = true
             error = nil

--- a/Docs/AGENTS_GUIDE.md
+++ b/Docs/AGENTS_GUIDE.md
@@ -645,107 +645,81 @@ let bugs = try result.records(as: Bug.self) // Converts to [Bug]
 
 ---
 
-## SwiftUI Integration
+## SwiftUI integration
 
-**Design Intent:** Property wrappers provide automatic reactivity and eliminate manual state management for database queries.
+**Documentation principle:** One **default** path for normal apps; **advanced** paths are labeled, not presented as equal choices. See [SwiftUI Integration Guide](Guides/SWIFTUI_INTEGRATION.md) and [Internal: SwiftUI path note](Internal/SWIFTUI_PATH_MAINTAINER_NOTE.md).
 
-### Basic @BlazeQuery
+**Default (most apps):** `BlazeStorable` + `@BlazeStorableQuery(kind:)` + `.blazeDBEnvironment(_)` + `@Environment(\.blazeDBClient)` for writes.
+
+**Advanced:** `BlazeDocument` + `@BlazeQuery` + manual `toStorage()` / `init(from:)`.
+
+**Raw rows:** `@BlazeDataQuery` (always `db:`).
+
+### Default: Storable + environment
 
 ```swift
-struct BugListView: View {
- @BlazeQuery(
- db: AppDatabase.shared.db,
- where: "status", equals:.string("open"),
- sortBy: "priority", descending: true
- )
- var openBugs
+@main
+struct MyApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ItemListView()
+                .blazeDBEnvironment(AppDatabase.shared.db)
+        }
+    }
+}
 
- var body: some View {
- List(openBugs, id: \.id) { bug in
- Text(bug["title"]?.stringValue?? "")
- }
- }
+struct Item: BlazeStorable {
+    var id: UUID = UUID()
+    var title: String
+}
+
+struct ItemListView: View {
+    @Environment(\.blazeDBClient) private var db
+    @BlazeStorableQuery(kind: Item.self) private var items: [Item]
+
+    var body: some View {
+        List(items, id: \.id) { Text($0.title) }
+    }
 }
 ```
 
-### Type-Safe @BlazeQueryTyped
+### Advanced: BlazeDocument + @BlazeQuery
 
 ```swift
-struct BugListView: View {
- @BlazeQueryTyped(
- db: AppDatabase.shared.db,
- type: Bug.self,
- where: "status", equals:.string("open"),
- sortBy: "priority", descending: true
- )
- var openBugs: [Bug] // Type-safe!
+// TodoItem must conform to BlazeDocument with toStorage() and init(from:).
+struct DocListView: View {
+    @BlazeQuery(where: "status", equals: "open", sortBy: "priority", descending: true)
+    var openItems: [TodoItem]
 
- var body: some View {
- List(openBugs) { bug in
- Text(bug.title) // Direct access, no optional unwrapping
- }
- }
+    var body: some View {
+        List(openItems, id: \.id) { Text($0.title) }
+    }
 }
 ```
 
-### Auto-Refresh
+### Raw records: @BlazeDataQuery
 
 ```swift
-struct BugListView: View {
- @BlazeQuery(db: AppDatabase.shared.db)
- var allBugs
+struct RawBugListView: View {
+    @BlazeDataQuery(
+        db: AppDatabase.shared.db,
+        where: "status", equals: .string("open"),
+        sortBy: "priority", descending: true
+    )
+    var openBugs: [BlazeDataRecord]
 
- var body: some View {
- List(allBugs, id: \.id) { bug in
- BugRowView(bug: bug)
- }
-.refreshable(query: $allBugs) // Pull to refresh
-.onAppear {
- $allBugs.enableAutoRefresh(interval: 10) // Auto-refresh every 10s
- }
-.onDisappear {
- $allBugs.disableAutoRefresh()
- }
- }
+    var body: some View {
+        List(openBugs, id: \.id) { bug in
+            Text(bug["title"]?.stringValue ?? "")
+        }
+        .refreshable(query: $openBugs)
+    }
 }
 ```
 
-### Form with Database Updates
+### Legacy naming
 
-```swift
-struct CreateBugView: View {
- @Environment(\.dismiss) var dismiss
- let db = AppDatabase.shared.db
-
- @State private var title = ""
- @State private var priority = 5
-
- @BlazeQuery(
- db: AppDatabase.shared.db,
- where: "status", equals:.string("open")
- )
- var openBugs // Auto-updates after insert!
-
- var body: some View {
- Form {
- TextField("Title", text: $title)
- Stepper("Priority: \(priority)", value: $priority, in: 1...10)
-
- Button("Create") {
- Task {
- let bug = BlazeDataRecord([
- "title":.string(title),
- "priority":.int(priority),
- "status":.string("open")
- ])
- try? await db.insert(bug)
- dismiss() // @BlazeQuery auto-refreshes
- }
- }
- }
- }
-}
-```
+`BlazeQueryTyped` is a typealias for `BlazeQuery`; do not use in new examples.
 
 ---
 
@@ -1349,23 +1323,26 @@ let bugs = try db.query() // Blocks UI
 .execute()
 ```
 
-### 8. Use @BlazeQuery for SwiftUI
+### 8. SwiftUI reactive lists
 
 ```swift
-// Good: Reactive queries
-@BlazeQuery(db: db, where: "status", equals:.string("open"))
-var openBugs
+// Good (default path): BlazeStorable + @BlazeStorableQuery
+@BlazeStorableQuery(kind: Item.self) var items: [Item]
 
-// Avoid: Manual state management
+// Good (advanced): BlazeDocument + @BlazeQuery
+@BlazeQuery(db: db, where: "status", equals: .string("open"))
+var openBugs: [Bug] // Bug: BlazeDocument
+
+// Avoid: Manual @State + onAppear for data that should track DB changes
 @State private var bugs: [BlazeDataRecord] = []
-.onAppear {
- bugs = try db.query()...
-}
+.onAppear { bugs = try db.query()... }
 ```
 
 ---
 
 ## Complete Example: Bug Tracker App
+
+**Advanced path** (`BlazeDocument` + manual mapping). For a minimal SwiftUI app, prefer **`BlazeStorable`** + **`@BlazeStorableQuery`** (see [SwiftUI DB Patterns](GettingStarted/SWIFTUI_DATABASE_PATTERNS.md)).
 
 ```swift
 import SwiftUI

--- a/Docs/API/API_REFERENCE.md
+++ b/Docs/API/API_REFERENCE.md
@@ -729,22 +729,28 @@ func performSecurityAudit() -> SecurityAuditReport
 
 ---
 
-## ** SwiftUI Integration**
+## ** SwiftUI integration**
 
-For app-local SwiftUI usage, these wrappers can refresh query results after BlazeDB change notifications.
-They are refresh-on-change wrappers (query re-execution), not a generalized incremental diff engine.
+On Apple platforms, property wrappers re-run queries when BlazeDB posts change notifications (refresh-on-change, not incremental diff).
 
-### **Property Wrappers:**
+**Recommended (most apps):** **`BlazeStorable`** + **`@BlazeStorableQuery(kind: Self.self)`** + root **`.blazeDBEnvironment(BlazeDBClient)`**; omit **`db:`** to use **`EnvironmentValues.blazeDBClient`**.
+
+**Advanced (manual record mapping):** **`BlazeDocument`** + **`@BlazeQuery`**. Legacy alias **`BlazeQueryTyped`** = **`BlazeQuery`**.
+
+**Raw rows:** **`@BlazeDataQuery`**, always with **`db:`** (no environment shortcut).
 
 ```swift
-// Query property wrapper
-@BlazeQuery(db: BlazeDBClient, where: "status", equals:.string("open"))
-var records: [BlazeDataRecord]
+// Default: Codable models
+@BlazeStorableQuery(kind: Item.self) var items: [Item]
 
-// Typed query property wrapper
-@BlazeQueryTyped(db: BlazeDBClient, type: User.self, where: \.status, equals: "active")
-var users: [User]
+// Advanced: BlazeDocument + manual toStorage / init(from:)
+@BlazeQuery(where: "status", equals: "open") var bugs: [Bug]
+
+// Raw BlazeDataRecord rows
+@BlazeDataQuery(db: client, where: "status", equals: .string("open")) var rows: [BlazeDataRecord]
 ```
+
+See [SwiftUI Integration Guide](../Guides/SWIFTUI_INTEGRATION.md).
 
 ---
 

--- a/Docs/DEVELOPER_GUIDE.md
+++ b/Docs/DEVELOPER_GUIDE.md
@@ -49,7 +49,7 @@ import BlazeDB // Database functionality
 
 // SwiftUI integration (macOS/iOS/watchOS/tvOS only)
 #if canImport(SwiftUI)
-import SwiftUI // @BlazeQuery is automatically available
+import SwiftUI // @BlazeStorableQuery, @BlazeQuery, @BlazeDataQuery on Apple platforms
 #endif
 ```
 
@@ -785,97 +785,17 @@ let tags = tagsArray.stringValues // ["swift", "database"]
 
 ---
 
-## SwiftUI Integration
+## SwiftUI integration
 
-### @BlazeQuery (Dynamic)
+Authoritative, user-facing docs: [SwiftUI Integration Guide](Guides/SWIFTUI_INTEGRATION.md), [SwiftUI DB Patterns](GettingStarted/SWIFTUI_DATABASE_PATTERNS.md). Maintainer rationale: [Internal/SWIFTUI_PATH_MAINTAINER_NOTE.md](Internal/SWIFTUI_PATH_MAINTAINER_NOTE.md).
 
-Reactive property wrapper for database queries.
-BlazeDB change notifications can trigger query refreshes for SwiftUI-bound results.
+**Default:** `BlazeStorable` + `@BlazeStorableQuery(kind:)` + `.blazeDBEnvironment` + `@Environment(\.blazeDBClient)` for writes.
 
-```swift
-struct BugListView: View {
- @BlazeQuery(
- db: AppDatabase.shared.db,
- where: "status", equals: .string("open"),
- sortBy: "priority", descending: true
- )
- var openBugs
+**Advanced:** `BlazeDocument` + `@BlazeQuery` (manual `BlazeDataRecord` mapping). **`BlazeQueryTyped`** is a legacy alias for **`BlazeQuery`**.
 
- var body: some View {
- List(openBugs, id: \.id) { bug in
- Text(bug["title"]?.stringValue ?? "")
- }
- }
-}
-```
+**Raw:** `@BlazeDataQuery` with explicit `db:`.
 
-### @BlazeQueryTyped (Type-Safe)
-
-Type-safe variant for compile-time safety.
-
-```swift
-struct BugListView: View {
- @BlazeQueryTyped(
- db: AppDatabase.shared.db,
- type: Bug.self,
- where: "status", equals: .string("open"),
- sortBy: "priority", descending: true
- )
- var openBugs: [Bug]
-
- var body: some View {
- List(openBugs) { bug in
- Text(bug.title) // Direct access!
- Text("P\(bug.priority)") // No .intValue!
- }
- }
-}
-```
-
-### Auto-Refresh
-
-```swift
-struct BugListView: View {
- @BlazeQuery(db: AppDatabase.shared.db)
- var allBugs
-
- var body: some View {
- List(allBugs, id: \.id) { bug in
- BugRowView(bug: bug)
- }
- .refreshable(query: $allBugs) // Pull to refresh
- .onAppear {
- $allBugs.enableAutoRefresh(interval: 10) // Auto-refresh every 10s
- }
- .onDisappear {
- $allBugs.disableAutoRefresh()
- }
- }
-}
-```
-
-`enableAutoRefresh(interval:)` is optional polling on top of notification-driven refresh.
-Use it when you want periodic safety refreshes; rely on default change observation for normal app-local writes.
-
-### Manual Refresh
-
-```swift
-struct BugListView: View {
- @BlazeQuery(db: AppDatabase.shared.db)
- var allBugs
-
- var body: some View {
- List(allBugs, id: \.id) { bug in
- BugRowView(bug: bug)
- }
- .toolbar {
- Button("Refresh") {
- $allBugs.refresh() // Manual refresh
- }
- }
- }
-}
-```
+`enableAutoRefresh(interval:)` on **`BlazeQueryTypedObserver`** is optional polling on top of change notifications; prefer notification-driven refresh for normal app writes.
 
 ---
 
@@ -1242,10 +1162,12 @@ let bugs = try db.query() // Blocks UI
  .execute()
 ```
 
-### 8. Use @BlazeQuery for SwiftUI
+### 8. SwiftUI reactive queries
+
+**Default app path:** `@BlazeStorableQuery(kind:)` with `BlazeStorable` models (see [SwiftUI Integration Guide](Guides/SWIFTUI_INTEGRATION.md)). **`@BlazeQuery`** is for **`BlazeDocument`** (manual `BlazeDataRecord` mapping).
 
 ```swift
-// Good: Reactive queries
+// Good: Reactive queries (BlazeDocument example)
 @BlazeQuery(db: db, where: "status", equals: .string("open"))
 var openBugs
 

--- a/Docs/Features/REACTIVE_QUERIES_EXPLAINED.md
+++ b/Docs/Features/REACTIVE_QUERIES_EXPLAINED.md
@@ -1,5 +1,7 @@
 # Reactive Live Queries: How They Work & Performance Impact
 
+The same change-notification idea applies to **`@BlazeStorableQuery`**, **`@BlazeQuery`**, and **`@BlazeDataQuery`** (each uses an observer subscribed via **`db.observe`**). This doc uses **`@BlazeQuery`** in diagrams for historical reasons; see [SwiftUI Integration Guide](../Guides/SWIFTUI_INTEGRATION.md) for which wrapper matches which model protocol.
+
 ## **How Reactive Queries Work**
 
 ### **Architecture Overview**

--- a/Docs/GettingStarted/HOW_TO_USE_BLAZEDB.md
+++ b/Docs/GettingStarted/HOW_TO_USE_BLAZEDB.md
@@ -221,16 +221,15 @@ let results = try query.execute().records
 
 A slow query scans all records because there's no index. If you filter by `user_id` without an index, BlazeDB reads every record. For small datasets, this is fine. For large datasets, add indexes (see API docs).
 
-### SwiftUI Query Observation
+### SwiftUI query observation
 
-For app-local UI integration, BlazeDB exposes:
+**Default:** **`@BlazeStorableQuery(kind:)`** with **`BlazeStorable`** models, plus root **`.blazeDBEnvironment(_)`** and **`@Environment(\.blazeDBClient)`** for writes.
 
-- `@BlazeQuery` for dynamic record views
-- `@BlazeQueryTyped` for typed SwiftUI views
+**Advanced:** **`@BlazeQuery`** with **`BlazeDocument`** (manual **`toStorage()`** / **`init(from:)`**). Legacy alias **`@BlazeQueryTyped`** = **`@BlazeQuery`**.
 
-These wrappers can re-run queries when BlazeDB emits change notifications after writes.
-They are useful for keeping SwiftUI lists current without relying only on timer polling.
-Manual refresh and pull-to-refresh remain available when you want explicit refresh behavior.
+**Raw rows:** **`@BlazeDataQuery`** (always pass **`db:`**).
+
+These wrappers re-run queries when BlazeDB emits change notifications after writes. Full detail: [SWIFTUI_DATABASE_PATTERNS.md](SWIFTUI_DATABASE_PATTERNS.md), [SWIFTUI_INTEGRATION.md](../Guides/SWIFTUI_INTEGRATION.md).
 
 ---
 

--- a/Docs/GettingStarted/README.md
+++ b/Docs/GettingStarted/README.md
@@ -120,10 +120,9 @@ try db.update(t)
 try db.delete(t)
 ```
 
-### SwiftUI Query Observation (App Dev DX)
+### SwiftUI (default path)
 
-If you are building a SwiftUI app, BlazeDB provides `@BlazeQuery` (typed `BlazeDocument` lists; legacy alias `@BlazeQueryTyped`) and `@BlazeDataQuery` (raw ``BlazeDataRecord`` rows).
-These wrappers use BlazeDB change observation to refresh query results after DB writes, so UI lists can stay in sync without relying only on timers. See [SWIFTUI_DATABASE_PATTERNS.md](SWIFTUI_DATABASE_PATTERNS.md) and [SWIFTUI_INTEGRATION.md](../Guides/SWIFTUI_INTEGRATION.md).
+For **most** SwiftUI apps: **`BlazeStorable`** models, **`.blazeDBEnvironment(_)`** once at the root, **`@BlazeStorableQuery(kind:)`** for lists, **`@Environment(\.blazeDBClient)`** for writes. **`@BlazeQuery`** is **only** for **`BlazeDocument`** (manual **`BlazeDataRecord`** mapping). **`@BlazeDataQuery`** is for raw rows (advanced). Wrappers refresh from change notifications. Start at [SWIFTUI_DATABASE_PATTERNS.md](SWIFTUI_DATABASE_PATTERNS.md) and [SWIFTUI_INTEGRATION.md](../Guides/SWIFTUI_INTEGRATION.md).
 
 ### Raw Explicit API (Advanced)
 
@@ -200,7 +199,7 @@ Yes, by default. AES-256-GCM encryption is enabled automatically.
 Committed data survives. BlazeDB uses write-ahead logging for crash safety.
 
 **Can I use this with SwiftUI?**
-Yes. See `Examples/SwiftUIExample.swift` for `@BlazeDataQuery` (raw rows) and typed `@BlazeQuery`. These wrappers refresh from DB change notifications and still support manual/pull refresh where useful.
+Yes. Default: **`BlazeStorable`** + **`@BlazeStorableQuery`** + **`.blazeDBEnvironment`** (see [SWIFTUI_DATABASE_PATTERNS.md](SWIFTUI_DATABASE_PATTERNS.md)). `Examples/SwiftUIExample.swift` focuses on **`@BlazeDataQuery`** (raw rows) and similar patterns; it is **not** the minimal default app shape.
 
 **Can I use this with Vapor?**
 Yes. See [HOW_TO_USE_BLAZEDB.md](HOW_TO_USE_BLAZEDB.md#8-using-blazedb-in-a-server-vapor-example).

--- a/Docs/GettingStarted/SWIFTUI_DATABASE_PATTERNS.md
+++ b/Docs/GettingStarted/SWIFTUI_DATABASE_PATTERNS.md
@@ -1,24 +1,30 @@
 # BlazeDB in SwiftUI
 
-**Standard SwiftUI pattern**
+## Default path (most apps)
 
 - Open BlazeDB **once**
-- Inject the client **once** at the app root
-- Read typed models with **`@BlazeQuery`**
-- Write through **`@Environment(\.blazeDBClient)`**
+- Inject **`BlazeDBClient`** **once** at the root: **`.blazeDBEnvironment(_)`**
+- Model conforms to **`BlazeStorable`**
+- Read: **`@BlazeStorableQuery(kind:)`**
+- Write: **`@Environment(\.blazeDBClient)`** (e.g. **`put`**, **`insert`**)
 - Add a **store** only when write logic grows
 
-For deeper reference, raw queries, compatibility notes, and full `BlazeDocument` model examples, see the [SwiftUI Integration Guide](../Guides/SWIFTUI_INTEGRATION.md). Upgrading old examples: [SwiftUI facade migration](SWIFTUI_FACADE_MIGRATION.md).
+## Advanced path (manual storage)
+
+Use only when you need full control over **`BlazeDataRecord`** fields:
+
+- Model conforms to **`BlazeDocument`**
+- Implement **`toStorage()`** and **`init(from storage:)`**
+- Read: **`@BlazeQuery`**
+
+## Where to read more
+
+- **Reference (filters, raw rows, explicit `db:`, troubleshooting):** [SwiftUI Integration Guide](../Guides/SWIFTUI_INTEGRATION.md)
+- **Older API names / migration:** [SwiftUI facade migration](SWIFTUI_FACADE_MIGRATION.md)
 
 ---
 
 ## Level 1 — Standard app wiring
-
-Define a `BlazeDocument` model once, then wire the app like this.
-
-This page focuses on **where the database opens**, **how it is injected**, **how reads work**, and **how writes work**. It does **not** walk through full `toStorage()` / `init(from:)` mapping—see the integration guide or [`Examples/TypeSafeModels.swift`](../../Examples/TypeSafeModels.swift) for that.
-
-> **`BlazeDocument` requires `init(from:)` and `toStorage()`.** The `TodoItem` sketch below shows fields and usage only. Before you build, add those two methods (copy a template from [`TypeSafeModels.swift`](../../Examples/TypeSafeModels.swift) or the [integration guide](../Guides/SWIFTUI_INTEGRATION.md)).
 
 ```swift
 import SwiftUI
@@ -36,9 +42,11 @@ final class AppDatabase {
     }
 }
 
-struct TodoItem: BlazeDocument {
+struct ListItem: BlazeStorable {
     var id: UUID = UUID()
-    var title: String
+    var name: String
+    var description: String = ""
+    var createdAt: Date = Date()
     var isDone: Bool = false
 }
 
@@ -53,40 +61,45 @@ struct MyApp: App {
 }
 
 struct ContentView: View {
-    @Environment(\.blazeDBClient) private var database
-    @BlazeQuery var items: [TodoItem]
+    @Environment(\.blazeDBClient) private var db
+    @BlazeStorableQuery(kind: ListItem.self) private var items: [ListItem]
 
     var body: some View {
         VStack {
             Button("Add Sample Item") {
-                guard let database else { return }
-
+                guard let db else { return }
                 do {
-                    try database.insert(TodoItem(title: "Buy milk"))
+                    try db.put(ListItem(name: "Milk", description: "A carton of milk"))
                 } catch {
-                    print("Failed to insert item:", error)
+                    print("Failed to write item:", error)
                 }
             }
             List(items, id: \.id) { item in
-                Text(item.title)
+                VStack(alignment: .leading) {
+                    Text(item.name)
+                    Text(item.description)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
             }
         }
+        .padding()
     }
 }
 ```
 
 ### Why this is the standard
 
-- BlazeDB opens once for the app.
-- `@BlazeQuery` keeps the list in sync.
-- Views do not need custom query setup.
-- The database does not need to be passed through every initializer.
+- One **`BlazeDBClient`** for the app.
+- **`@BlazeStorableQuery`** stays in sync with writes; **no custom view `init`** just to pass **`db`** into the wrapper.
+- No manual **`BlazeDataRecord`** mapping for normal Codable models.
+- Child views inherit the client from the root; you do not pretend there are two databases.
 
 ---
 
 ## Level 2 — Add a store when writes grow
 
-Keep reads in the view with `@BlazeQuery`. Move validation and multi-step writes into a store when the screen gets heavier.
+Keep reads in the view with **`@BlazeStorableQuery`**. Move validation and multi-step writes into a store when the screen gets heavier.
 
 ```swift
 import SwiftUI
@@ -94,31 +107,29 @@ import Combine
 import BlazeDB
 
 @MainActor
-final class TodoWriteStore: ObservableObject {
+final class ListWriteStore: ObservableObject {
     func addSample(using database: BlazeDBClient?) {
-         guard let database else { return }
-
+        guard let database else { return }
         do {
-            try database.insert(TodoItem(title: "From store"))
+            try database.put(ListItem(name: "From store", description: ""))
         } catch {
-            print("Failed to insert item:", error)
+            print("Failed to write item:", error)
         }
     }
 }
 
-struct TodoListWithStoreView: View {
-    @Environment(\.blazeDBClient) private var database
-    @StateObject private var store = TodoWriteStore()
-    @BlazeQuery var items: [TodoItem]
+struct ListWithStoreView: View {
+    @Environment(\.blazeDBClient) private var db
+    @StateObject private var store = ListWriteStore()
+    @BlazeStorableQuery(kind: ListItem.self) private var items: [ListItem]
 
     var body: some View {
         VStack {
             Button("Add via store") {
-                store.addSample(using: database)
+                store.addSample(using: db)
             }
-
             List(items, id: \.id) { item in
-                Text(item.title)
+                Text(item.name)
             }
         }
     }
@@ -129,7 +140,7 @@ struct TodoListWithStoreView: View {
 
 ## Level 3 — Larger apps
 
-Keep **one** `BlazeDBClient` for the process (same `AppDatabase` + `.blazeDBEnvironment` as Level 1). Add tabs, navigation stacks, or feature modules as ordinary SwiftUI; each screen uses **`@BlazeQuery`** and, when needed, its own store—**do not** open a second database.
+Keep **one** **`BlazeDBClient`** for the process (same **`AppDatabase`** + **`.blazeDBEnvironment`** as Level 1). Add tabs, navigation stacks, or feature modules as ordinary SwiftUI; each screen uses **`@BlazeStorableQuery`** (or **`@BlazeQuery`** if you use **`BlazeDocument`**) and, when needed, its own store — **do not** open a second database.
 
 ```swift
 struct MainTabView: View {
@@ -145,16 +156,22 @@ struct MainTabView: View {
 }
 
 struct DoneItemsView: View {
-    @BlazeQuery(where: "isDone", equals: true, sortBy: "title", descending: false)
-    var items: [TodoItem]
+    @BlazeStorableQuery(
+        kind: ListItem.self,
+        where: "isDone",
+        equals: .bool(true),
+        sortBy: "name",
+        descending: false
+    )
+    var items: [ListItem]
 
     var body: some View {
-        List(items, id: \.id) { Text($0.title) }
+        List(items, id: \.id) { Text($0.name) }
     }
 }
 ```
 
-Use **`MyApp`** with **`MainTabView()`** instead of **`ContentView()`** in the `WindowGroup` when you adopt this shape—the injection line is unchanged:
+Use **`MainTabView()`** in the **`WindowGroup`** instead of **`ContentView()`** when you adopt this shape — the injection line is unchanged:
 
 ```swift
 WindowGroup {
@@ -163,49 +180,62 @@ WindowGroup {
 }
 ```
 
-- One shared client for the process.
-- Feature views only declare queries (and optional stores); they **inherit** the client from the root.
-- Add a **store per feature** when that feature’s writes are non-trivial (same idea as Level 2).
-
 ---
 
-## Level 4 — Advanced patterns
+## Level 4 — Advanced and legacy
 
-Details live in the [SwiftUI Integration Guide](../Guides/SWIFTUI_INTEGRATION.md) (raw **`@BlazeDataQuery`**, full **`BlazeDocument`** mapping, aliases, edge cases). One pattern people hit early: **explicit `db:`** on a wrapper for **previews** or **tests** when you want a specific client without rebuilding the full environment chain:
+### Manual **`BlazeDocument`** + **`@BlazeQuery`**
+
+When you need explicit **`BlazeDocumentField`** layout, conform to **`BlazeDocument`**, implement **`toStorage()`** and **`init(from storage:)`**, then use **`@BlazeQuery`**. Templates: [`Examples/TypeSafeModels.swift`](../../Examples/TypeSafeModels.swift).
 
 ```swift
-struct TodoRowPreview: View {
-    @BlazeQuery(db: AppDatabase.shared.db, where: "isDone", equals: false)
-    var active: [TodoItem]
+struct ContentViewDocumentExample: View {
+    @Environment(\.blazeDBClient) private var database
+    @BlazeQuery var items: [TodoItem]   // TodoItem: BlazeDocument
 
     var body: some View {
-        List(active, id: \.id) { Text($0.title) }
+        List(items, id: \.id) { Text($0.title) }
     }
 }
 ```
 
-For everything else in this bucket, use the integration guide:
+### Previews and tests: explicit **`db:`**
 
-- explicit `db:` on query wrappers (full matrix)
-- raw `@BlazeDataQuery`
-- compatibility aliases and edge cases
-- full `BlazeDocument` model mapping
-- custom environment wrappers
+When you want a specific client without the full environment chain:
+
+```swift
+struct ListPreview: View {
+    @BlazeStorableQuery(db: AppDatabase.shared.db, kind: ListItem.self)
+    var items: [ListItem]
+
+    var body: some View {
+        List(items, id: \.id) { Text($0.name) }
+    }
+}
+```
+
+### Raw rows
+
+**`@BlazeDataQuery`** returns **`[BlazeDataRecord]`** and always requires **`db:`**. See the [SwiftUI Integration Guide](../Guides/SWIFTUI_INTEGRATION.md).
+
+### Compatibility
+
+- **`BlazeQueryTyped`** = old name for **`BlazeQuery`**
+- Full migration notes: [SwiftUI facade migration](SWIFTUI_FACADE_MIGRATION.md)
 
 ---
 
 ## Summary
 
-Default SwiftUI path:
+| You want | Use |
+|----------|-----|
+| Normal SwiftUI app | **`BlazeStorable`** + **`.blazeDBEnvironment`** + **`@BlazeStorableQuery(kind:)`** + **`@Environment(\.blazeDBClient)`** for writes |
+| Manual record layout | **`BlazeDocument`** + **`@BlazeQuery`** + **`toStorage()`** / **`init(from:)`** |
+| Raw **`BlazeDataRecord`** lists | **`@BlazeDataQuery`** (see integration guide) |
 
-- `.blazeDBEnvironment(AppDatabase.shared.db)`
-- `@BlazeQuery`
-- `@Environment(\.blazeDBClient)` for writes
+That is the front door — not four equal options.
 
-That is the front door.
+### If you are stuck
 
----
-
-## Note on `BlazeDocument`
-
-`BlazeDocument` uses manual field mapping. You still need to implement `init(from:)` and `toStorage()` before typed queries and `insert` work. This page focuses on app shape and defers mapping details to the integration guide and examples.
+- **`@BlazeQuery`** ↔ **`BlazeDocument`** only (with manual mapping). For Codable-first models, use **`@BlazeStorableQuery`** instead.
+- **`put`** / typical app writes: **`BlazeStorable`**. Advanced **`BlazeDocument`** flows use typed **`insert`/`update`** from the **`BlazeDocument`** extensions (see [SwiftUI Integration Guide](../Guides/SWIFTUI_INTEGRATION.md)).

--- a/Docs/GettingStarted/SWIFTUI_FACADE_MIGRATION.md
+++ b/Docs/GettingStarted/SWIFTUI_FACADE_MIGRATION.md
@@ -1,6 +1,6 @@
 # SwiftUI facade migration (typed-default)
 
-The **current standard** for SwiftUI is: **inject `BlazeDBClient` once** → **`@BlazeQuery`** for typed reads → **writes via `@Environment(\.blazeDBClient)`** (or a store when logic grows). This page is the **short** migration guide for **existing** code that predates that shape.
+The **default** for **new** SwiftUI apps is: **inject `BlazeDBClient` once** → **`@BlazeStorableQuery(kind:)`** for **`BlazeStorable`** reads → **writes via `@Environment(\.blazeDBClient)`** (or a store when logic grows). Use **`@BlazeQuery`** only with **`BlazeDocument`** (manual `BlazeDataRecord` mapping). This page is the **short** migration guide for **existing** code that predates those names and shapes.
 
 ## What changed (naming)
 
@@ -9,7 +9,7 @@ The **current standard** for SwiftUI is: **inject `BlazeDBClient` once** → **`
 | `@BlazeQuery` with `wrappedValue: [BlazeDataRecord]` | **`@BlazeDataQuery`** (same behavior: raw rows) |
 | `@BlazeQueryTyped(..., type: T.self, ...)` | **`@BlazeQuery(...)`** — drop **`type:`**; `T` is inferred from **`[T]`** |
 
-**Why:** `@BlazeQuery` is now the obvious name for the API most SwiftUI apps want (typed lists). Raw rows keep a **more explicit** name: `@BlazeDataQuery`.
+**Why:** Typed **document** lists use **`@BlazeQuery`**; typed **Codable** lists use **`@BlazeStorableQuery`**. Raw rows use **`@BlazeDataQuery`**.
 
 Swift cannot overload one property-wrapper name for both `[BlazeDataRecord]` and `[T: BlazeDocument]` with a single type, so the old untyped **`@BlazeQuery`** spelling had to move.
 
@@ -49,6 +49,8 @@ var items: [MyModel]
 
 The **`BlazeQueryTyped`** name still exists as a **typealias** for **`BlazeQuery`**; you can migrate gradually. Deprecated **`type:`** initializers remain for compatibility.
 
+**`MyModel` is `BlazeStorable` only?** Prefer **`@BlazeStorableQuery(kind: MyModel.self)`** (optional **`db:`**; resolves **`\.blazeDBClient`** when omitted). You do not need **`BlazeDocument`** for Codable models.
+
 ## Environment injection
 
 Prefer injecting the client once:
@@ -56,10 +58,12 @@ Prefer injecting the client once:
 ```swift
 .environment(\.blazeDBClient, app.db)
 
-@BlazeQuery var items: [MyModel]
+@BlazeStorableQuery(kind: MyModel.self) var items: [MyModel]   // BlazeStorable
+
+@BlazeQuery var docs: [MyDoc]   // BlazeDocument only
 ```
 
-If **`blazeDBClient`** is unset, a query created **without** `db:` stays empty until the environment provides a client (see doc comments on **`BlazeQuery`**).
+If **`blazeDBClient`** is unset, a wrapper created **without** `db:` stays empty until the environment provides a client (see **`BlazeQuery`** / **`BlazeStorableQuery`** doc comments).
 
 ## Compatibility summary
 

--- a/Docs/Guides/SWIFTUI_INTEGRATION.md
+++ b/Docs/Guides/SWIFTUI_INTEGRATION.md
@@ -1,15 +1,39 @@
 # SwiftUI Integration Guide
 
-Quick reference for **`@BlazeQuery`** and **`@BlazeDataQuery`**.  
-Full app setup and **`BlazeDocument`** mapping → [SwiftUI DB Patterns](../GettingStarted/SWIFTUI_DATABASE_PATTERNS.md) · [`TypeSafeModels.swift`](../../Examples/TypeSafeModels.swift)
+## Recommended SwiftUI path
+
+For **most apps**, use **`BlazeStorable`** models, inject **`BlazeDBClient`** once with **`.blazeDBEnvironment(_)`**, read with **`@BlazeStorableQuery(kind:)`**, and write through **`@Environment(\.blazeDBClient)`** (for example **`put`**, **`insert`**, **`update`** on that client).
+
+Use **`BlazeDocument`** and **`@BlazeQuery`** only when you need **manual** **`BlazeDataRecord`** mapping (**`toStorage()`** / **`init(from:)`**).
+
+This guide is ordered that way: default first, advanced second, niche/legacy last.
 
 ---
 
-## Default recipe
+## When to use what
 
-- Open the DB **once**, inject **once** at the root (**`.blazeDBEnvironment`**).
-- Lists → **`@BlazeQuery`**. Writes → **`@Environment(\.blazeDBClient)`**.
-- Need raw rows instead of a typed model? → **`@BlazeDataQuery`** (below).
+| You have / need | Use |
+|-----------------|-----|
+| Normal Codable model (`struct` with `id: UUID`, etc.) | **`BlazeStorable`** |
+| Manual control of every `BlazeDocumentField` in a record | **`BlazeDocument`** + **`toStorage()`** / **`init(from storage:)`** |
+| Reactive typed list for a **`BlazeStorable`** model | **`@BlazeStorableQuery(kind: Model.self)`** |
+| Reactive typed list for a **`BlazeDocument`** model | **`@BlazeQuery`** |
+| Raw rows, dynamic keys, or debugging | **`@BlazeDataQuery`** (always pass **`db:`**) |
+| Writes from SwiftUI | **`@Environment(\.blazeDBClient)`** then **`put`** / **`insert`** / **`update`** on that client |
+
+**Writes and models:** **`put`** and **`insert(T: BlazeStorable)`** expect **`BlazeStorable`**. **`insert` / `update` / `upsert`** for **`BlazeDocument`** use **`toStorage()`**. Do not conform one model to **both** protocols unless you understand **`insert`/`upsert` ambiguity**; pick one primary path per type.
+
+---
+
+## Common mistakes (read this if something won’t compile)
+
+| Symptom | What went wrong | Fix |
+|---------|-----------------|-----|
+| **`@BlazeQuery` errors** on a **`BlazeStorable`**-only type | **`@BlazeQuery`** requires **`BlazeDocument`**. | Use **`@BlazeStorableQuery(kind:)`**, or add full **`BlazeDocument`** mapping (advanced). |
+| **`Type does not conform to BlazeDocument`** | Missing **`toStorage()`** or **`init(from storage:)`**. | Implement both, or switch model to **`BlazeStorable`** and **`@BlazeStorableQuery`**. |
+| **`insert` is ambiguous** | Type conforms to **both** **`BlazeDocument`** and **`BlazeStorable`**. | Prefer one protocol; or call **`insert(BlazeDataRecord)`** / **`insert`** with an explicit path after reading overload rules. |
+| List never populates | Environment not set. | Apply **`.blazeDBEnvironment(db)`** above the view, or pass **`db:`** on the wrapper. |
+| **`@BlazeDataQuery` and empty results** | Expecting environment like other wrappers. | **`@BlazeDataQuery`** always needs **`db:`**. |
 
 ---
 
@@ -36,14 +60,56 @@ struct MyApp: App {
 }
 ```
 
-Everything below assumes this. Don’t open the database again in child views.
+Do not open the database again in child views. One client per process, injected at the root.
 
 ---
 
-## `@BlazeQuery` (start here)
+## Default: `@BlazeStorableQuery` + `BlazeStorable`
 
-Typed **`[YourModel]`** — your model conforms to **`BlazeDocument`**.  
-Skip **`db:`** if you already used **`.blazeDBEnvironment`** above; the wrapper uses that client.
+Typed **`[YourModel]`** for **Codable** models. Omit **`db:`** when the root uses **`.blazeDBEnvironment`**; the wrapper resolves **`EnvironmentValues.blazeDBClient`** the same way **`@BlazeQuery`** does.
+
+```swift
+struct ListItem: BlazeStorable {
+    var id: UUID = UUID()
+    var name: String
+}
+
+struct RootView: View {
+    @Environment(\.blazeDBClient) private var db
+    @BlazeStorableQuery(kind: ListItem.self) private var items: [ListItem]
+
+    var body: some View {
+        List(items, id: \.id) { Text($0.name) }
+    }
+}
+```
+
+Filtered query:
+
+```swift
+@BlazeStorableQuery(kind: Task.self, where: "isComplete", equals: .bool(false))
+private var openTasks: [Task]
+```
+
+Alias (same type as **`@BlazeStorableQuery`**):
+
+```swift
+@BlazeStorableEnvironmentQuery(kind: ListItem.self) private var items: [ListItem]
+```
+
+Writes (typical):
+
+```swift
+guard let db else { return }
+try db.put(ListItem(name: "Milk"))
+// or: try db.insert(listItem)
+```
+
+---
+
+## Advanced: `@BlazeQuery` + `BlazeDocument`
+
+Use when you control **exact** **`BlazeDocumentField`** layout and implement **`toStorage()`** and **`init(from storage:)`** yourself. Skip **`db:`** when using **`.blazeDBEnvironment`**.
 
 ```swift
 @BlazeQuery var items: [TodoItem]
@@ -52,20 +118,11 @@ Skip **`db:`** if you already used **`.blazeDBEnvironment`** above; the wrapper 
 var openItems: [TodoItem]
 ```
 
-```swift
-struct RootView: View {
-    @Environment(\.blazeDBClient) private var database
-    @BlazeQuery var items: [TodoItem]
-
-    var body: some View {
-        List(items, id: \.id) { Text($0.title) }
-    }
-}
-```
+Full mapping examples: [`TypeSafeModels.swift`](../../Examples/TypeSafeModels.swift) · [SwiftUI DB Patterns](../GettingStarted/SWIFTUI_DATABASE_PATTERNS.md) (advanced section).
 
 ---
 
-## `@BlazeDataQuery` (raw rows only)
+## Raw rows: `@BlazeDataQuery`
 
 Returns **`[BlazeDataRecord]`**. You **always** pass **`db:`** (no environment shortcut).
 
@@ -80,34 +137,32 @@ var rows: [BlazeDataRecord]
 
 ---
 
-## `db:` on the wrapper
+## Explicit `db:` on a wrapper
 
-Use when you **aren’t** using the normal environment chain — e.g. **previews** or **tests** — and you already have a **`BlazeDBClient`** in hand.
+Use when you are **not** using the normal environment chain — **previews**, **tests**, or a second client — and already have a **`BlazeDBClient`**.
 
 ```swift
-@BlazeQuery(db: testClient, where: "status", equals: "open")
-var open: [Bug]
+@BlazeStorableQuery(db: testClient, kind: Item.self) var items: [Item]
+@BlazeQuery(db: testClient, where: "status", equals: "open") var open: [Bug]
 ```
-
-`BlazeQueryTyped` = old name for **`BlazeQuery`** — ignore in new code.
 
 ---
 
 ## Refresh
 
-| Action | `@BlazeQuery` (`$items`) | `@BlazeDataQuery` (`$rows`) |
-|--------|---------------------------|-----------------------------|
+| Action | `@BlazeStorableQuery` / `@BlazeQuery` (`$items`) | `@BlazeDataQuery` (`$rows`) |
+|--------|--------------------------------------------------|-----------------------------|
 | Manual | `$items.refresh()` | `$rows.refresh()` |
-| Pull | `.refreshable(query: $items)` | `.refreshable(query: $rows)` |
-| On appear | `.refreshOnAppear($items)` | `.refreshOnAppear($rows)` |
+| Pull | `.refreshable(query: $items)` works for **`@BlazeQuery`** (see module). For **`@BlazeStorableQuery`**, use `.refreshable { $items.refresh() }` until a dedicated overload exists. | `.refreshable(query: $rows)` |
+| On appear | `.refreshOnAppear($items)` for **`@BlazeQuery`**. For **`@BlazeStorableQuery`**, use `.onAppear { $items.refresh() }` or wrap similarly. | `.refreshOnAppear($rows)` |
 
-`$…` is the observer (reload / loading / errors). The plain name is the array.
+**`$…`** is the observer (reload / loading / errors). The property name without **`$`** is the array.
 
 ---
 
 ## How it updates
 
-Writes on **that** client → wrapper refetches → list updates. No need to copy into **`@State`** every time. **`$query.refresh()`** if you must force a reload.
+Writes on **that** client → wrapper refetches → list updates. No need to copy into **`@State`** for every change. Call **`$query.refresh()`** to force a reload.
 
 Details: [Reactive queries explained](../Features/REACTIVE_QUERIES_EXPLAINED.md)
 
@@ -120,7 +175,16 @@ Details: [Reactive queries explained](../Features/REACTIVE_QUERIES_EXPLAINED.md)
 | List doesn’t update | Same **`BlazeDBClient`** for writes and query? |
 | Query empty at startup | **`.blazeDBEnvironment`** above this view? |
 | `@BlazeDataQuery` “ignores” env | Pass **`db:`** — required. |
-| Won’t compile with `@BlazeQuery` | Model needs **`BlazeDocument`** — see [`TypeSafeModels.swift`](../../Examples/TypeSafeModels.swift) |
+| **`@BlazeQuery` won’t compile** | Model must be **`BlazeDocument`** with **`toStorage()`** / **`init(from:)`**. |
+| **`@BlazeStorableQuery` won’t compile** | Model must be **`BlazeStorable`**. |
+
+---
+
+## Legacy / compatibility
+
+- **`BlazeQueryTyped`** — old name for **`BlazeQuery`**; ignore in new code.
+- Older migration notes: [SwiftUI facade migration](../GettingStarted/SWIFTUI_FACADE_MIGRATION.md).
+- **`ObservableQuery`** — imperative/async holder when property wrappers are not enough; see module docs.
 
 ---
 
@@ -128,9 +192,7 @@ Details: [Reactive queries explained](../Features/REACTIVE_QUERIES_EXPLAINED.md)
 
 | Topic | Link |
 |-------|------|
-| App wiring | [SwiftUI DB Patterns](../GettingStarted/SWIFTUI_DATABASE_PATTERNS.md) |
-| Old API names | [Facade migration](../GettingStarted/SWIFTUI_FACADE_MIGRATION.md) |
-| Big example | [`SwiftUIExample.swift`](../../Examples/SwiftUIExample.swift) |
+| App wiring & levels (stores, tabs) | [SwiftUI DB Patterns](../GettingStarted/SWIFTUI_DATABASE_PATTERNS.md) |
+| Why docs are ordered this way (maintainers) | [SwiftUI path maintainer note](../Internal/SWIFTUI_PATH_MAINTAINER_NOTE.md) |
+| Raw-row / advanced SwiftUI samples | [`SwiftUIExample.swift`](../../Examples/SwiftUIExample.swift) (not the minimal default shape) |
 | Indexes / speed | [Query performance](../GettingStarted/QUERY_PERFORMANCE.md) |
-
-Also: **`@BlazeStorableQuery`**, **`ObservableQuery`** — see module docs.

--- a/Docs/Internal/SWIFTUI_PATH_MAINTAINER_NOTE.md
+++ b/Docs/Internal/SWIFTUI_PATH_MAINTAINER_NOTE.md
@@ -1,0 +1,50 @@
+# SwiftUI path and documentation (maintainer note)
+
+This note records **why** BlazeDB’s SwiftUI docs and API guidance look the way they do after the environment-driven **`@BlazeStorableQuery`** work. It is for maintainers and PR review, not end-user onboarding.
+
+## 1. Problem statement
+
+The prior SwiftUI story was easy to misuse because:
+
+- Several overlapping options were described as if they were equally “standard” (**`BlazeDocument`** vs **`BlazeStorable`**, **`@BlazeQuery`** vs **`@BlazeStorableQuery`**, raw **`@BlazeDataQuery`**, explicit **`db:`** vs environment).
+- **`@BlazeStorableQuery`** originally **required** a **`db:`** argument, while **`@BlazeQuery`** could use **`EnvironmentValues.blazeDBClient`**, so the **simplest** Codable path had **more ceremony** than the manual-mapping path.
+- Compiler errors (wrong wrapper for the protocol, missing **`toStorage()`**, ambiguous **`insert`**) did not steer people toward a single obvious fix.
+- Docs listed multiple first steps without a clear **front door**, so readers treated the framework like a menu of internals.
+
+## 2. What changed (API + docs)
+
+- **`@BlazeStorableQuery`** now supports **`db: BlazeDBClient? = nil`** and resolves **`\.blazeDBClient`** like **`@BlazeQuery`**, removing the cursed custom view **`init`** just to wire the wrapper.
+- Documentation was rewritten so **one** path is the default: **`BlazeStorable`** + **`@BlazeStorableQuery(kind:)`** + **`.blazeDBEnvironment`** + **`@Environment(\.blazeDBClient)`** for writes.
+- **`BlazeDocument`** + **`@BlazeQuery`** is explicitly **advanced** (manual **`BlazeDataRecord`** mapping).
+- Legacy and niche items (**`BlazeQueryTyped`**, **`@BlazeDataQuery`**, migration doc) are **labeled**, not mixed into the first paragraph newcomers read.
+
+## 3. Default recommendation (normal SwiftUI apps)
+
+- Model: **`BlazeStorable`**
+- Root: **`.blazeDBEnvironment(BlazeDBClient)`** once
+- Reads: **`@BlazeStorableQuery(kind: Model.self)`** (optional **`db:`** for previews/tests)
+- Writes: **`@Environment(\.blazeDBClient)`** then **`put`** / **`insert`** / etc.
+
+## 4. Why this is better
+
+- Matches typical SwiftUI expectations: inject once, read through a property wrapper, write through environment.
+- Removes a false choice between “easy model” (**`BlazeStorable`**) and “easy SwiftUI” (**`@BlazeQuery`** was only for **`BlazeDocument`**).
+- Reduces support burden: docs and examples reinforce the same first move.
+
+## 5. What stays advanced
+
+- **`BlazeDocument`**, **`toStorage()`**, **`init(from storage:)`**, **`@BlazeQuery`**
+- **`@BlazeDataQuery`** (raw **`BlazeDataRecord`**)
+- Dual protocol conformance on one type ( **`insert`/`upsert` ambiguity** )
+
+## 6. Documentation principle going forward
+
+1. **One default path** for normal SwiftUI usage (storable + storable query + environment).
+2. **One advanced path** for manual storage control (document + blaze query).
+3. **Legacy / niche** (aliases, raw wrappers, migration) — present **after** the default, with explicit labels.
+
+Do not imply symmetry (“pick either; both are standard”) unless there is a rare, documented exception.
+
+## 7. Developer-experience rationale
+
+Users should not need BlazeDB’s internal type graph to ship a list screen. The default path should be learnable from **one** short paragraph and **one** copy-paste shape. Everything else is opt-in depth.

--- a/Examples/SwiftUIExample.swift
+++ b/Examples/SwiftUIExample.swift
@@ -2,8 +2,12 @@
 //  SwiftUIExample.swift
 //  BlazeDB Examples
 //
-//  Real-world examples of using BlazeDB with SwiftUI.
-//  Shows @BlazeDataQuery (raw records) and typed @BlazeQuery refreshing from DB change notifications.
+//  This file focuses on @BlazeDataQuery (raw BlazeDataRecord rows), dynamic filters, and
+//  patterns that need explicit db: — not the minimal default app shape.
+//
+//  For normal SwiftUI apps, start here instead:
+//  - Docs/GettingStarted/SWIFTUI_DATABASE_PATTERNS.md
+//  - BlazeStorable + @BlazeStorableQuery(kind:) + .blazeDBEnvironment + @Environment(\.blazeDBClient)
 //
 //  Created by Michael Danylchuk on 7/1/25.
 //
@@ -11,7 +15,7 @@
 import SwiftUI
 import BlazeDB
 
-// MARK: - Example 1: Simple Bug List
+// MARK: - Example 1: Simple Bug List (raw rows via @BlazeDataQuery)
 
 struct BugListView: View {
     // Auto-fetches and updates! No manual state management! 🔥

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Or in Xcode: **File → Add Package Dependencies** → paste `https://github.com
 
 After `open` → `put` → `get` → `query` makes sense, pick **one** path:
 
-1. **SwiftUI app** → [SwiftUI DB Patterns](Docs/GettingStarted/SWIFTUI_DATABASE_PATTERNS.md) (app wiring: inject once, `@BlazeQuery`, environment writes; full `BlazeDocument` mapping lives in the integration guide). Anything beyond that (filters, raw rows, explicit `db:`): [SwiftUI Integration Guide](Docs/Guides/SWIFTUI_INTEGRATION.md).
+1. **SwiftUI app** → [SwiftUI DB Patterns](Docs/GettingStarted/SWIFTUI_DATABASE_PATTERNS.md) (default: `BlazeStorable`, inject once, `@BlazeStorableQuery(kind:)`, environment writes). Advanced (`BlazeDocument`, `@BlazeQuery`, raw rows): [SwiftUI Integration Guide](Docs/Guides/SWIFTUI_INTEGRATION.md).
 
 2. **UIKit / CLI / server-style app**  
    → [Try BlazeDB from this repo](#try-blazedb-from-this-repo) (`swift run HelloBlazeDB` from a clone)  
@@ -145,9 +145,11 @@ If you skip straight to API tiers or raw APIs without that bridge, you’ll feel
 
 ## SwiftUI Path
 
-**Standard BlazeDB SwiftUI app:** inject **`BlazeDBClient` once** (`.blazeDBEnvironment(_)` or `.environment(\.blazeDBClient, …)`), use **`@BlazeQuery`** for typed reads, and **`@Environment(\.blazeDBClient)`** for writes (`insert` / `put` to match your model). Add a **store** only when the screen’s logic outgrows simple calls.
+**Standard BlazeDB SwiftUI app:** inject **`BlazeDBClient` once** (`.blazeDBEnvironment(_)` or `.environment(\.blazeDBClient, …)`), use **`@BlazeStorableQuery(kind:)`** for typed reads with **`BlazeStorable`** models, and **`@Environment(\.blazeDBClient)`** for writes (`put` / `insert` / etc.). Add a **store** only when the screen’s logic outgrows simple calls.
 
-SwiftUI wiring: [SwiftUI DB Patterns](Docs/GettingStarted/SWIFTUI_DATABASE_PATTERNS.md). Full reference (raw queries, `BlazeDocument` mapping, edge cases): [SwiftUI Integration Guide](Docs/Guides/SWIFTUI_INTEGRATION.md).
+**Advanced:** **`BlazeDocument`** + **`@BlazeQuery`** only when you need manual **`BlazeDataRecord`** mapping (`toStorage()` / `init(from:)`).
+
+SwiftUI wiring: [SwiftUI DB Patterns](Docs/GettingStarted/SWIFTUI_DATABASE_PATTERNS.md). Full reference (filters, raw rows, `BlazeDocument`, explicit `db:`): [SwiftUI Integration Guide](Docs/Guides/SWIFTUI_INTEGRATION.md).
 
 ---
 
@@ -260,14 +262,14 @@ BlazeDB stores all records in one encrypted document collection per database fil
 
 | Protocol | Purpose | Used with |
 |----------|---------|-----------|
-| **`BlazeStorable`** | Automatic Codable serialization, KeyPath queries | `db.insert(model)`, `db.fetch(T.self, id:)`, `db.query(T.self)`, `db.typed(T.self)` |
-| **`BlazeDocument`** | Manual `toStorage()`/`init(from:)` mapping, more control | `@BlazeQuery` SwiftUI wrapper (legacy name: `@BlazeQueryTyped`) |
+| **`BlazeStorable`** | Automatic Codable serialization, KeyPath queries | Default SwiftUI reads: **`@BlazeStorableQuery`**. Also: `db.insert(model)`, `db.put(model)`, `db.fetch(T.self, id:)`, `db.query(T.self)`, `db.typed(T.self)` |
+| **`BlazeDocument`** | Manual `toStorage()`/`init(from:)` mapping | **`@BlazeQuery`** when you need explicit `BlazeDataRecord` layout (legacy name: `@BlazeQueryTyped`) |
 
-`BlazeStorable` is the recommended starting point. `BlazeDocument` is for when you need manual control over how your model maps to `BlazeDataRecord` storage. Both require `Codable` and `Identifiable` with `ID == UUID`.
+**Default:** `BlazeStorable` for normal app models. **Advanced:** `BlazeDocument` only when you need manual control over `BlazeDataRecord` storage. Both require `Codable` and `Identifiable` with `ID == UUID`.
 
 > **`BlazeDocument` persistence:** Prefer `try model.toStorage()` or `try model.resolveStorage()` (or typed client APIs like `insert(model)`) when encoding can fail. The `storage` property is a **deprecated** compatibility shim: if `toStorage()` throws, it **logs** and falls back to an empty record. **Do not** persist that value. Typed insert/update paths already use `toStorage()` and are unaffected.
 
-> **Do not use `@BlazeQuery` / `@BlazeQueryTyped` with `BlazeStorable`-only models. It will not compile.** These wrappers require `BlazeDocument`. If your model only conforms to `BlazeStorable`, you must add `BlazeDocument` conformance (with manual `toStorage()`/`init(from:)`) before you can use typed SwiftUI query wrappers, or use `@BlazeDataQuery` with raw ``BlazeDataRecord`` rows instead.
+> **`@BlazeQuery` requires `BlazeDocument`.** For `BlazeStorable`-only models, use **`@BlazeStorableQuery(kind:)`** (same environment injection as `@BlazeQuery`). Alternatively, add `BlazeDocument` with manual `toStorage()`/`init(from:)`, or use `@BlazeDataQuery` for raw ``BlazeDataRecord`` rows.
 
 ### Encryption
 
@@ -349,23 +351,23 @@ Default storage locations: `~/Library/Application Support/BlazeDB/` (macOS), `~/
 
 ### SwiftUI query wrappers (Apple platforms only)
 
-**Default app path:** inject the client once, then **`@BlazeQuery`** for typed lists (``BlazeDocument``) and the environment handle for writes—see [SwiftUI DB Patterns](Docs/GettingStarted/SWIFTUI_DATABASE_PATTERNS.md). **`@BlazeDataQuery`** is for raw ``BlazeDataRecord`` rows (advanced). Legacy alias **`BlazeQueryTyped`** = **`BlazeQuery`** (do not feature in new examples). Apple platforms only.
+**Default app path:** inject the client once, then **`@BlazeStorableQuery(kind:)`** for typed lists (**`BlazeStorable`**) and **`@Environment(\.blazeDBClient)`** for writes—see [SwiftUI DB Patterns](Docs/GettingStarted/SWIFTUI_DATABASE_PATTERNS.md). **`@BlazeQuery`** is for **`BlazeDocument`** (manual `BlazeDataRecord` mapping). **`@BlazeDataQuery`** is for raw ``BlazeDataRecord`` rows. Legacy alias **`BlazeQueryTyped`** = **`BlazeQuery`**. Apple platforms only.
 
 **Migrating from older wrappers:** [SwiftUI facade migration](Docs/GettingStarted/SWIFTUI_FACADE_MIGRATION.md).
 
 ```swift
-// Standard: environment + typed query (no per-view db:)
+// Standard: environment + Storable query (no per-view init just for the wrapper)
 MyRootView()
     .blazeDBEnvironment(app.db)
 
 struct ListView: View {
     @Environment(\.blazeDBClient) private var database
-    @BlazeQuery var bugs: [Bug]   // [Bug] infers the document type
+    @BlazeStorableQuery(kind: Item.self) private var items: [Item]
 
-    // … writes: try? database?.insert(bug)  (BlazeDocument) or put (BlazeStorable)
+    // writes: try? database?.put(Item(...))  or insert / update
 }
 
-// Advanced / tests / previews: pass db: explicitly on the wrapper
+// Advanced: BlazeDocument + @BlazeQuery, or explicit db: for previews/tests
 @BlazeQuery(db: app.db, where: "status", equals: "open") var openBugs: [Bug]
 ```
 
@@ -408,7 +410,7 @@ The default `BlazeDBClient` uses a binary write-ahead log (`WALMode.legacy`) tha
 | Linux | Core support | Swift 6.2 in CI: PR Tier0, nightly Tier1 + Tier2 core, weekly delta Tier2 extended + Tier3 heavy/perf; SwiftUI wrappers excluded |
 | Android | Core support | `BLAZEDB_LINUX_CORE` path; Swift 6.3+ / Android NDK; best-effort CI |
 
-SwiftUI query wrappers (`@BlazeQuery`, `@BlazeDataQuery`) are only available on Apple platforms. On Linux and Android, the `swift-crypto` package is used in place of Apple CryptoKit.
+SwiftUI query wrappers (`@BlazeStorableQuery`, `@BlazeQuery`, `@BlazeDataQuery`) are only available on Apple platforms. On Linux and Android, the `swift-crypto` package is used in place of Apple CryptoKit.
 
 See [Compatibility Matrix](Docs/COMPATIBILITY.md) for details.
 
@@ -446,7 +448,7 @@ Run with `swift run <ToolName>`.
 - **Single-process only.** Do not share database files between multiple processes. File-level locking prevents concurrent access, but the database is designed for single-process use.
 - **Nested Codable types are not individually queryable.** Nested structs/classes are stored as `BlazeDocumentField.dictionary` values. Round-tripping works, but nested fields cannot be filtered via KeyPath queries. Flatten nested fields into top-level properties if you need to query them.
 - **Password minimum 8 characters.** Enforced at open time.
-- **`@BlazeQuery` / `@BlazeQueryTyped` require `BlazeDocument`.** They will not compile with `BlazeStorable`-only models. Add `BlazeDocument` conformance (manual `toStorage()`/`init(from:)`) or use `@BlazeDataQuery` for raw rows.
+- **`@BlazeQuery` / `@BlazeQueryTyped` require `BlazeDocument`.** For `BlazeStorable`-only models, use **`@BlazeStorableQuery(kind:)`** instead, or add `BlazeDocument` (manual `toStorage()`/`init(from:)`), or use `@BlazeDataQuery` for raw rows.
 - **Android CI is best-effort.** Cross-compilation expects Swift 6.3+ with the Swift Android SDK + Android NDK in a manual lane.
 
 ---


### PR DESCRIPTION
## Summary
- **API:** `@BlazeStorableQuery` accepts optional `db:` and resolves `EnvironmentValues.blazeDBClient` like `@BlazeQuery`. Adds `BlazeStorableEnvironmentQuery` typealias.
- **Docs:** One default SwiftUI path (`BlazeStorable` + `.blazeDBEnvironment` + `@BlazeStorableQuery(kind:)` + env writes); `BlazeDocument` + `@BlazeQuery` framed as advanced. README, guides, API ref, AGENTS/DEVELOPER guides aligned.
- **Maintainers:** `Docs/Internal/SWIFTUI_PATH_MAINTAINER_NOTE.md` captures rationale.

## Test plan
- [x] `swift build --target BlazeDBCore`

Opens: https://github.com/Mikedan37/BlazeDB/pull/new/feature/swiftui-storable-query-environment-docs

Made with [Cursor](https://cursor.com)