### PR TITLE
Docs: canonical PR expectations; reduce policy duplication

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,5 @@
+**Quick rules:** [CONTRIBUTING.md — PR expectations](CONTRIBUTING.md#pr-expectations) (one branch, `preflight`, list commands, docs with behavior, squash merge).
+
 ## Summary
 
 - What changed?
@@ -10,16 +12,17 @@
 
 ## Validation
 
-List exact commands you ran:
+List **exact** commands you ran (copy-paste from your terminal):
 
 ```bash
-# Example
 ./Scripts/preflight.sh
+# add anything else (e.g. swift test --filter …)
 ```
 
 ## Checklist
 
 - [ ] One branch = one concern
-- [ ] `git status`/`git diff` reviewed for containment
-- [ ] Relevant docs updated (if behavior changed)
+- [ ] `git status` / `git diff` reviewed for containment
+- [ ] Docs updated in this PR if behavior or public usage changed
+- [ ] `Docs/SYSTEM_MAP.md` / `Docs/Testing/CI_AND_TEST_TIERS.md` updated **only if** this PR changes material surface, architecture, or CI/tier semantics (see PR expectations)
 - [ ] CI checks pass

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,9 +4,34 @@
 
 This guide explains how to add tests, what will be accepted, and what will be rejected.
 
-## CI gate (GitHub Actions)
+## PR expectations
 
-The default branch workflow (`.github/workflows/ci.yml`) runs on every push/PR **when hosted CI is available**: a **macOS 15** blocking job (core + CLI + Tier0 + `BlazeDB_Tier1`) and a **Linux 6.2** blocking job (core + Tier0). **`nightly.yml`** and **`deep-validation.yml`** add scheduled coverage; weekly deep is **delta-only** (does not repeat PR/nightly tiers—see [CI and test tiers](Docs/Testing/CI_AND_TEST_TIERS.md)). `verify-clean-checkout.sh` and `verify-readme-quickstart.sh` are intentionally **not** in the blocking PR gate. Legacy **`v*` tag buildability** is **not** part of that automatic gate; it runs only from the manual workflow [`.github/workflows/tag-probe.yml`](.github/workflows/tag-probe.yml). Checkouts use full git history (`fetch-depth: 0`). **Forks and billing limits** can prevent workflows from running; in that case use the same commands locally (see [Hosted CI status](Docs/Status/OPEN_SOURCE_READINESS_CHECKLIST.md#hosted-ci-status)). The gate is **not** every test target or every file under `BlazeDBTests/` (some files are excluded per tier in `Package.swift`). Authoritative detail: [CI and test tiers](Docs/Testing/CI_AND_TEST_TIERS.md).
+Keep PRs **narrow** and **self-contained**.
+
+For **most** PRs:
+
+- Use **one branch** for **one concern**
+- Run **`./Scripts/preflight.sh`**
+- In the PR description, **list the exact validation commands** you ran (not just “tests pass”)
+- **Update docs in the same PR** if behavior or public usage changed
+- Prefer **squash merge** when merging to `main`
+
+**Also update these only when your change is relevant:**
+
+| File | When |
+|------|------|
+| [`Docs/SYSTEM_MAP.md`](Docs/SYSTEM_MAP.md) | Material changes to architecture, platforms, modules, or **public** feature surface (see that file for what counts as material) |
+| [`Docs/Testing/CI_AND_TEST_TIERS.md`](Docs/Testing/CI_AND_TEST_TIERS.md) | Changes to **test lanes**, **tier** meaning, or **CI** job behavior |
+
+**If two docs disagree about CI** (blocking jobs, tier scope, workflows), treat **[`Docs/Testing/CI_AND_TEST_TIERS.md`](Docs/Testing/CI_AND_TEST_TIERS.md)** plus **`.github/workflows/*.yml`** as the detailed source of truth—not this paragraph alone.
+
+Forks, billing limits, and hosted CI availability can prevent Actions from running; use the same commands locally if needed ([Hosted CI status](Docs/Status/OPEN_SOURCE_READINESS_CHECKLIST.md#hosted-ci-status)).
+
+---
+
+## CI at a glance
+
+The PR workflow is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Scheduled and weekly workflows add coverage on top; they are documented in [CI and test tiers](Docs/Testing/CI_AND_TEST_TIERS.md). Scripts such as `verify-clean-checkout.sh` and `verify-readme-quickstart.sh` are **not** part of the blocking PR gate unless that doc explicitly says otherwise. **`v*`** tag buildability uses the manual [tag-probe workflow](.github/workflows/tag-probe.yml).
 
 ---
 
@@ -158,9 +183,11 @@ Place test files under the correct `BlazeDBTests/...` paths; target names remain
 
 ---
 
-## Development Workflow
+## Development workflow
 
-### 1. Make Changes
+Normal PRs: follow **[PR expectations](#pr-expectations)** (`./Scripts/preflight.sh` + listed commands in the PR).
+
+### 1. Make changes
 
 ```bash
 # Make your changes
@@ -198,16 +225,6 @@ git commit -m "Description of changes"
 ```
 
 ---
-
-## Before Opening A PR
-
-Run:
-
-```bash
-./Scripts/preflight.sh
-```
-
-If this fails locally, fix it before pushing.
 
 ## Release Tagging Policy
 
@@ -256,41 +273,32 @@ If this fails locally, fix it before pushing.
 
 ---
 
-## Change Discipline
+## Change discipline
+
+See **[PR expectations](#pr-expectations)** for branch scope, docs-with-code, and when to touch `SYSTEM_MAP` / `CI_AND_TEST_TIERS`.
 
 ### Source of truth
 
-`Docs/SYSTEM_MAP.md` is the canonical engineering map for what exists, what state it is in, and where it lives. Read it before making major changes.
+[`Docs/SYSTEM_MAP.md`](Docs/SYSTEM_MAP.md) is the engineering map for what exists, where it lives, and support status. Read it before large or cross-cutting changes.
 
-### When to update the system map
+### Feature surface
 
-Any PR that materially changes feature surface, support status, platform support, or module boundaries must update `Docs/SYSTEM_MAP.md` in the same PR. See that file for what counts as "material."
-
-### Branch and scope rules
-
-- One branch per coherent unit of work. Do not mix unrelated changes.
-- Docs and code must land together — do not ship a feature in one PR and document it in another.
-- Test lane or target boundary changes must be documented in `Docs/Testing/CI_AND_TEST_TIERS.md`.
-- Prefer narrow, surgical edits. Do not rewrite unrelated doc sections.
-
-### Feature surface rules
-
-- Do not advertise internal or deferred features as shipped in `README.md` or other public-facing docs.
-- If a feature is in source but not in stable public onboarding, mark it accordingly in the system map.
-- Tests are evidence of implementation, not automatic evidence of public product maturity.
+- Do not advertise internal or deferred features as shipped in `README.md` or other public onboarding.
+- If something exists in source but is not stable for end users, say so in the system map.
+- Tests prove behavior in CI; they are not by themselves proof of “product ready.”
 
 ### Reconciliation
 
-- Rebase and reconcile `SYSTEM_MAP.md` carefully if multiple PRs touch it.
-- If `CI_AND_TEST_TIERS.md` conflicts, the file plus `.github/workflows/*.yml` are authoritative.
+If multiple PRs touch `SYSTEM_MAP.md`, reconcile carefully. CI/tier conflicts: **`CI_AND_TEST_TIERS.md`** + **workflows** win.
 
 ---
 
 ## Questions?
 
+- Start with **[PR expectations](#pr-expectations)** above
 - Check `Docs/SYSTEM_MAP.md` for the canonical feature inventory and status map
-- Check `Docs/Testing/CI_AND_TEST_TIERS.md` for authoritative CI and tier mapping
-- Check `Docs/Guides/WORKFLOW_AND_STYLE_GUIDE.md` for branch/PR workflow and style expectations
+- Check `Docs/Testing/CI_AND_TEST_TIERS.md` for CI jobs, tiers, and cadence
+- Check `Docs/Guides/WORKFLOW_AND_STYLE_GUIDE.md` for branch naming and local workflow
 - Check `Docs/Guarantees/SAFETY_MODEL.md` for safety guarantees
 - Check `Docs/Compliance/PHASE_1_FREEZE.md` for frozen core details
 

--- a/Docs/Guides/WORKFLOW_AND_STYLE_GUIDE.md
+++ b/Docs/Guides/WORKFLOW_AND_STYLE_GUIDE.md
@@ -1,6 +1,8 @@
-# Workflow And Style Guide
+# Workflow and style guide
 
-## Quick Workflow
+**PR policy in one place:** [CONTRIBUTING.md — PR expectations](../../CONTRIBUTING.md#pr-expectations). This file is **branch naming**, **local habits**, and **style**—not a second copy of CI rules.
+
+## Quick workflow
 
 1. `git switch main && git pull --ff-only`
 2. `git switch -c <feature|test|ci|docs>/<name>`
@@ -52,7 +54,8 @@ Before opening a PR, run:
 
 If it fails, fix it locally before pushing.
 
-## 4) CI Gates
+## 4) CI (do not duplicate here)
 
-- **Local**: `./Scripts/preflight.sh` (build + Tier0)
-- **PR CI**: `ci.yml` on **macOS 15** (BlazeDBCore + CLI builds, Tier0, Tier1); Linux job is best-effort and non-blocking
+- **Local:** `./Scripts/preflight.sh` (build + Tier0) before you push
+- **On GitHub:** [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml) — **both** the macOS and Linux jobs are part of the default PR gate when Actions runs
+- **Authoritative narrative:** [`Docs/Testing/CI_AND_TEST_TIERS.md`](../Testing/CI_AND_TEST_TIERS.md) (if another doc disagrees, trust that file + the workflows)

--- a/Docs/Testing/CI_AND_TEST_TIERS.md
+++ b/Docs/Testing/CI_AND_TEST_TIERS.md
@@ -4,7 +4,7 @@ This file is the single source of truth for BlazeDB CI lanes and test-tier inten
 
 If this file conflicts with other docs, treat this file and `.github/workflows/*.yml` as authoritative.
 
-For branch discipline and PR hygiene, see `Docs/Guides/WORKFLOW_AND_STYLE_GUIDE.md`.
+For **normal PR expectations** (one branch, preflight, validation list, docs, squash merge), see **[CONTRIBUTING.md](../../CONTRIBUTING.md#pr-expectations)**. For **branch naming** and local habits, see `Docs/Guides/WORKFLOW_AND_STYLE_GUIDE.md`.
 
 ## CI Lane Snapshot
 


### PR DESCRIPTION
## Summary
Collapse the **normal PR** mental model into one section in `CONTRIBUTING.md` and point other files at it instead of restating overlapping CI/policy paragraphs.

## What changed
- **CONTRIBUTING.md:** New **PR expectations** (one branch, `./Scripts/preflight.sh`, list commands, docs with behavior, squash merge; when to touch `SYSTEM_MAP` / `CI_AND_TEST_TIERS`; **CI_AND_TEST_TIERS + workflows** as tie-breaker). Replaced the long opening CI paragraph with **CI at a glance** + link to tiers doc. Removed duplicate **Before Opening A PR**. Tightened **Change discipline** / **Questions**.
- **.github/pull_request_template.md:** Link to PR expectations; checklist defers SYSTEM_MAP/CI tiers to *when relevant*.
- **WORKFLOW_AND_STYLE_GUIDE.md:** First line points to CONTRIBUTING; **§4** no longer claims Linux is non-blocking (both `ci.yml` jobs are part of the PR gate); CI detail defers to `CI_AND_TEST_TIERS.md`.
- **CI_AND_TEST_TIERS.md:** Intro links PR expectations; keeps this file as detailed CI truth.

## Validation
`./Scripts/preflight.sh` was started locally but was still running when the PR was opened. Final validation will come from a completed local preflight run and/or green PR CI checks.