### PR TITLE
docs: multiple databases in SwiftUI guides

### DIFF
--- a/Docs/GettingStarted/SWIFTUI_DATABASE_PATTERNS.md
+++ b/Docs/GettingStarted/SWIFTUI_DATABASE_PATTERNS.md
@@ -79,10 +79,21 @@ struct ContentView: View {
 
 ### Why this is the standard
 
-- One **`BlazeDBClient`** for the app.
-- **`@BlazeStorableQuery`** stays in sync with writes; **no custom view `init`** just to pass **`db`** into the wrapper.
+- Open the database **once** per logical database; inject with **`.blazeDBEnvironment`** at the root of the subtree that should use it.
+- **`@BlazeStorableQuery`** stays in sync with writes; **no custom view `init`** just to pass **`db`** into the wrapper (unless you intentionally override — see **Multiple databases**).
 - No manual **`BlazeDataRecord`** mapping for normal Codable models.
-- Child views inherit the client from the root; you do not pretend there are two databases.
+- Child views inherit **`blazeDBClient`** from the **nearest** ancestor that set **`.blazeDBEnvironment`**; use a **different** injection on another branch when that subtree should use another database.
+
+### Multiple databases
+
+**`blazeDBClient`** is **one slot per environment subtree**, not one database per app.
+
+For most apps with multiple databases:
+
+- Inject a different client into each subtree with **`.blazeDBEnvironment(...)`**.
+- Use explicit **`db:`** only for previews, tests, or screens that intentionally bypass the default environment.
+
+Use custom environment keys only for advanced cases where one subtree genuinely needs multiple named clients at once. More detail: [SwiftUI Integration Guide — Multiple databases](../Guides/SWIFTUI_INTEGRATION.md#multiple-databases).
 
 ---
 
@@ -129,7 +140,7 @@ struct ListWithStoreView: View {
 
 ## Level 3 — Larger apps
 
-Keep **one** **`BlazeDBClient`** for the process (same **`AppDatabase`** + **`.blazeDBEnvironment`** as Level 1). Add tabs, navigation stacks, or feature modules as ordinary SwiftUI; each screen uses **`@BlazeStorableQuery`** (or **`@BlazeQuery`** if you use **`BlazeDocument`**) and, when needed, its own store — **do not** open a second database.
+For **one** shared app database, keep the same **`AppDatabase`** + **`.blazeDBEnvironment`** at the root as Level 1. Add tabs, navigation stacks, or feature modules as ordinary SwiftUI; each screen uses **`@BlazeStorableQuery`** (or **`@BlazeQuery`** if you use **`BlazeDocument`**) and, when needed, its own store. Avoid opening **extra** clients ad hoc in leaf views — if you have **separate** databases (e.g. personal vs. work), inject each at the **root of its subtree** (see **Multiple databases** under Level 1).
 
 Below, **`Item`** includes a **`isCompleted`** field so one tab can filter on it (same pattern as Level 1, one extra property).
 

--- a/Docs/Guides/SWIFTUI_INTEGRATION.md
+++ b/Docs/Guides/SWIFTUI_INTEGRATION.md
@@ -86,6 +86,62 @@ Readable alias (same type as **`@BlazeStorableQuery`**):
 
 Writes on the **same** **`BlazeDBClient`** you injected cause the query to refetch; you usually do not need **`@State`** copies of the whole list. Call **`$items.refresh()`** on the projected value if you need a forced reload.
 
+### Multiple databases
+
+**`blazeDBClient`** is **one slot per environment subtree**, not one database per app.
+
+The default SwiftUI path assumes **one active `BlazeDBClient` for the current view subtree**. That keeps normal app code simple. If your app uses more than one database, you usually do one of these:
+
+**1. Different subtrees use different databases**
+
+This is the normal SwiftUI answer for multi-account, personal/work, or separate tabs.
+
+```swift
+TabView {
+    PersonalItemsView()
+        .tabItem { Label("Personal", systemImage: "person") }
+        .blazeDBEnvironment(personalDB)
+
+    WorkItemsView()
+        .tabItem { Label("Work", systemImage: "briefcase") }
+        .blazeDBEnvironment(workDB)
+}
+```
+
+Each subtree reads and writes using its own injected client.
+
+**2. One view intentionally uses another client**
+
+Use explicit **`db:`** when a screen, preview, or test should bypass the environment.
+
+```swift
+struct ItemListView: View {
+    let db: BlazeDBClient
+    @BlazeStorableQuery private var items: [Item]
+
+    init(db: BlazeDBClient) {
+        self.db = db
+        self._items = BlazeStorableQuery(db: db, kind: Item.self)
+    }
+
+    var body: some View {
+        List(items, id: \.id) { item in
+            Text(item.title)
+        }
+    }
+}
+```
+
+Explicit **`db:`** overrides the environment for that wrapper.
+
+**3. The active database changes at runtime**
+
+When the active database changes, re-apply **`.blazeDBEnvironment(...)`** at the **root of that subtree** so child views read from the new client.
+
+**Advanced: multiple named clients in one subtree**
+
+If one subtree truly needs multiple named clients at the same time, use custom **`EnvironmentKey`**s and explicit wrapper binding where needed. Most apps do not need this.
+
 ---
 
 ## Common mistakes

--- a/Docs/Internal/SWIFTUI_PATH_MAINTAINER_NOTE.md
+++ b/Docs/Internal/SWIFTUI_PATH_MAINTAINER_NOTE.md
@@ -52,3 +52,9 @@ Do not imply symmetry (“pick either; both are standard”) unless there is a r
 ## 7. Developer-experience rationale
 
 Users should not need BlazeDB’s internal type graph to ship a list screen. The default path should be learnable from **one** short paragraph and **one** copy-paste shape. Everything else is opt-in depth.
+
+## 8. Multiple databases (documentation placement)
+
+- **`blazeDBClient`** is **one environment slot per subtree**, not “one database per app.” Say that in user docs; do not make readers infer it from implementation details.
+- **Where it lives:** [SwiftUI Integration Guide](../Guides/SWIFTUI_INTEGRATION.md) under **Default path (detail) → Multiple databases**, and a short recap in [SwiftUI DB Patterns](../GettingStarted/SWIFTUI_DATABASE_PATTERNS.md) after Level 1 **Why this is the standard**. Do **not** put multi-DB scenarios in the **opening** paragraph of the integration guide or README SwiftUI blurb.
+- **Preferred patterns:** different **`.blazeDBEnvironment(...)`** per branch; **`db:`** for previews/tests/intentional override; custom **`EnvironmentKey`**s only as an **advanced** footnote when one subtree needs multiple named clients at once.


### PR DESCRIPTION
## Summary

Adds a short **Multiple databases** section to the SwiftUI guides.

This clarifies that `blazeDBClient` is one slot per environment subtree, not one database per app, and documents the recommended order of solutions for multi-DB SwiftUI usage:

1. Subtree injection with `.blazeDBEnvironment(...)`
2. Explicit `db:` for previews/tests/intentional overrides
3. Runtime re-injection when the active client changes

It also updates the maintainer note so this guidance stays aligned with the default SwiftUI path.

## Scope

**In scope**

- `Docs/Guides/SWIFTUI_INTEGRATION.md`
- `Docs/GettingStarted/SWIFTUI_DATABASE_PATTERNS.md`
- `Docs/Internal/SWIFTUI_PATH_MAINTAINER_NOTE.md`

**Out of scope**

- Runtime/API changes
- Query wrapper behavior changes
- Multi-client framework abstractions beyond current documented patterns

## Validation

Docs-only changes; preflight was not run for this update. PR CI is the validation check.