### PR TITLE
docs(swiftui): macOS vs iOS examples and NavigationStack toolbar guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Documentation
+
+- **SwiftUI:** [SWIFTUI_INTEGRATION.md](Docs/Guides/SWIFTUI_INTEGRATION.md) and [SWIFTUI_DATABASE_PATTERNS.md](Docs/GettingStarted/SWIFTUI_DATABASE_PATTERNS.md) now show **macOS** vs **iOS** minimal examples (list + toolbar vs **`NavigationStack`** + **`ToolbarItem(placement: .topBarTrailing)`**), plus a **wrong vs right** toolbar snippet and placement table so iOS navigation hierarchy issues are not mistaken for BlazeDB bugs.
+
 ### Changed
 
 - **Apple platforms (iOS fix):** `PathResolver.defaultDatabaseDirectory()` no longer uses `FileManager.homeDirectoryForCurrentUser` (unavailable on iOS). macOS and iOS now both use **`FileManager.url(for: .applicationSupportDirectory, …)`** + `BlazeDB/` — same relative layout as before on macOS (`~/Library/Application Support/BlazeDB/`).

--- a/Docs/API/API_REFERENCE.md
+++ b/Docs/API/API_REFERENCE.md
@@ -750,7 +750,7 @@ On Apple platforms, property wrappers re-run queries when BlazeDB posts change n
 @BlazeDataQuery(db: client, where: "status", equals: .string("open")) var rows: [BlazeDataRecord]
 ```
 
-See [SwiftUI Integration Guide](../Guides/SWIFTUI_INTEGRATION.md).
+See [SwiftUI Integration Guide](../Guides/SWIFTUI_INTEGRATION.md). On **iOS / iPadOS**, put lists that need a nav bar **Add** action inside **`NavigationStack`** and use **`ToolbarItem(placement:)`** — see **Toolbars and NavigationStack on iOS** in that guide (toolbar-only **`List`** often shows **no** top button without a navigation container).
 
 ---
 

--- a/Docs/GettingStarted/SWIFTUI_DATABASE_PATTERNS.md
+++ b/Docs/GettingStarted/SWIFTUI_DATABASE_PATTERNS.md
@@ -50,6 +50,8 @@ struct MyApp: App {
 }
 ```
 
+**Model** (shared):
+
 ```swift
 import SwiftUI
 import BlazeDB
@@ -58,7 +60,11 @@ struct Item: BlazeStorable {
     var id: UUID = UUID()
     var title: String
 }
+```
 
+**macOS** — list + window toolbar (no **`NavigationStack`** required for a typical window toolbar):
+
+```swift
 struct ContentView: View {
     @Environment(\.blazeDBClient) private var db
     @BlazeStorableQuery(kind: Item.self) private var items: [Item]
@@ -71,6 +77,35 @@ struct ContentView: View {
             Button("Add") {
                 guard let db else { return }
                 try? db.put(Item(title: "New"))
+            }
+        }
+    }
+}
+```
+
+**iOS / iPadOS** — wrap in **`NavigationStack`** and use **`ToolbarItem(placement:)`** so the **Add** button appears in the navigation bar (see [SwiftUI Integration Guide — toolbars on iOS](../Guides/SWIFTUI_INTEGRATION.md#toolbars-and-navigationstack-on-ios)):
+
+```swift
+struct ContentView: View {
+    @Environment(\.blazeDBClient) private var db
+    @BlazeStorableQuery(kind: Item.self) private var items: [Item]
+
+    var body: some View {
+        NavigationStack {
+            List(items, id: \.id) { item in
+                Text(item.title)
+            }
+            .navigationTitle("Items")
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Add") {
+                        guard let db else { return }
+                        _ = try? db.put(Item(title: "New"))
+                    }
+                }
+            }
+            .onAppear {
+                print("view did appear")
             }
         }
     }

--- a/Docs/Guides/SWIFTUI_INTEGRATION.md
+++ b/Docs/Guides/SWIFTUI_INTEGRATION.md
@@ -13,6 +13,8 @@ That is the standard SwiftUI path.
 
 Use **`import SwiftUI`** and **`import BlazeDB`** only (the **`BlazeDB`** product re-exports core; you do not need **`import BlazeDBCore`** for normal app targets).
 
+Shared setup (all platforms): one **`App`** injects **`BlazeDBClient`**; the model is **`BlazeStorable`**.
+
 ```swift
 import SwiftUI
 import BlazeDB
@@ -36,7 +38,13 @@ struct MyApp: App {
         }
     }
 }
+```
 
+### macOS — minimal list + toolbar
+
+On **macOS**, a **`List`** with **`.toolbar { ... }`** is often enough: the **Add** button shows in the **window** toolbar without wrapping the list in **`NavigationStack`**.
+
+```swift
 struct ContentView: View {
     @Environment(\.blazeDBClient) private var db
     @BlazeStorableQuery(kind: Item.self) private var items: [Item]
@@ -54,6 +62,86 @@ struct ContentView: View {
     }
 }
 ```
+
+### iOS / iPadOS — `NavigationStack` + explicit toolbar placement
+
+On **iPhone and iPad**, toolbar items are tied to a **navigation bar**. Put the list inside **`NavigationStack`** (or **`NavigationView`**) and use **`ToolbarItem`** with an explicit **placement** so the button lands where users expect (usually trailing top).
+
+```swift
+struct ContentView: View {
+    @Environment(\.blazeDBClient) private var db
+    @BlazeStorableQuery(kind: Item.self) private var items: [Item]
+
+    var body: some View {
+        NavigationStack {
+            List(items, id: \.id) { item in
+                Text(item.title)
+            }
+            .navigationTitle("Items")
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Add") {
+                        guard let db else { return }
+                        _ = try? db.put(Item(title: "New"))
+                    }
+                }
+            }
+            .onAppear {
+                print("view did appear")
+            }
+        }
+    }
+}
+```
+
+### Toolbars and NavigationStack on iOS
+
+Docs often show **`.toolbar { Button("Add") { ... } }`** as if the button materializes by itself. On **iOS**, it does not: **toolbar items are rendered in a navigation bar** (or tab bar / bottom bar, depending on placement). If there is **no** navigation container, the bar — and your button — may be **invisible**, which feels like BlazeDB or SwiftUI is broken. It is not; the view hierarchy is incomplete.
+
+**Requirement:** On iOS, embed content that needs a top bar button in **`NavigationStack { ... }`** (or an equivalent that provides a navigation bar).
+
+**Does not show the button** (no navigation bar to attach to):
+
+```swift
+List(items, id: \.id) { item in
+    Text(item.title)
+}
+.toolbar {
+    Button("Add") {
+        guard let db else { return }
+        try? db.put(Item(title: "New"))
+    }
+}
+```
+
+**Works** — bar exists, **`ToolbarItem`** has a home:
+
+```swift
+NavigationStack {
+    List(items, id: \.id) { item in
+        Text(item.title)
+    }
+    .navigationTitle("Items")
+    .toolbar {
+        ToolbarItem(placement: .topBarTrailing) {
+            Button("Add") {
+                guard let db else { return }
+                try? db.put(Item(title: "New"))
+            }
+        }
+    }
+}
+```
+
+**Placement (be explicit):**
+
+| Placement | Typical use |
+|-----------|-------------|
+| **`.topBarTrailing`** | Trailing navigation bar — what most “+ / Add” actions want on iPhone. |
+| **`.bottomBar`** | Bottom of the screen when you want an action near the thumb or tab bar. |
+| **Omitted / default** | Behavior can vary by OS version and container; when something looks “random” or missing, set **`ToolbarItem(placement:)`** explicitly. |
+
+**BlazeDB writes** stay the same: resolve **`db`** from **`@Environment(\.blazeDBClient)`**, then **`put`** / **`insert`** as above. The only SwiftUI pitfall is **where** the button lives in the UI hierarchy, not the database API.
 
 Open the database **once**; do not create a second client for every screen.
 


### PR DESCRIPTION
**Quick rules:** [CONTRIBUTING.md — PR expectations](CONTRIBUTING.md#pr-expectations) (one branch, `preflight`, list commands, docs with behavior, squash merge).

## Summary

- **What changed?** SwiftUI docs now show **macOS** and **iOS/iPadOS** minimal `BlazeStorable` + `@BlazeStorableQuery` examples: macOS uses a plain `List` + window toolbar; iOS uses `NavigationStack`, `navigationTitle`, `ToolbarItem(placement: .topBarTrailing)`, and the same `db.put` write path. Added **Toolbars and NavigationStack on iOS** with wrong vs right snippets, a placement table (`.topBarTrailing`, `.bottomBar`), and an explicit note that invisible toolbar buttons on iOS are usually a **missing navigation container**, not BlazeDB.
- **Why was it needed?** On iOS, toolbar items attach to a **navigation bar**. Bare `List` + `.toolbar { Button }` examples often show **no** button and make the library look broken.

## Scope

- **In scope:** `Docs/Guides/SWIFTUI_INTEGRATION.md`, `Docs/GettingStarted/SWIFTUI_DATABASE_PATTERNS.md` (Level 1), `Docs/API/API_REFERENCE.md` SwiftUI blurb, `CHANGELOG.md` Unreleased.
- **Out of scope:** Runtime code, CI/tier semantics, SYSTEM_MAP.

## Validation

```bash
swift build
```

## Checklist

- [x] One branch = one concern
- [x] `git status` / `git diff` reviewed for containment
- [x] Docs updated in this PR where onboarding behavior is explained
- [x] `Docs/SYSTEM_MAP.md` / `Docs/Testing/CI_AND_TEST_TIERS.md` — **N/A** (doc-only UX)
- [ ] CI checks pass
