### PR TITLE
fix: legacy update() uses DispatchQueue barrier on Linux (#81)

### DIFF
--- a/BlazeDB/Core/DynamicCollection.swift
+++ b/BlazeDB/Core/DynamicCollection.swift
@@ -1566,15 +1566,10 @@ public final class DynamicCollection {
                 return
             }
             
-            // Legacy Path: Original implementation
-            #if !BLAZEDB_LINUX_CORE
+            // Legacy Path: Original implementation — barrier on all platforms (insert/delete already do).
             try queue.sync(flags: .barrier) {
                 try _updateNoSync(id: id, with: data)
             }
-            #else
-            // On Linux, use basic update without queue optimizations
-            try _updateNoSync(id: id, with: data)
-            #endif
         }
         
         public func contains(_ id: UUID) -> Bool {

--- a/BlazeDBTests/Tier1Extended/Concurrency/BlazeDBEnhancedConcurrencyTests.swift
+++ b/BlazeDBTests/Tier1Extended/Concurrency/BlazeDBEnhancedConcurrencyTests.swift
@@ -262,6 +262,43 @@ final class BlazeDBEnhancedConcurrencyTests: XCTestCase {
         }
     }
     
+    /// Regression (GitHub #81): legacy `update` must run under the same concurrent-queue barrier as reads.
+    /// Concurrent `fetchAll` walks `indexMap` inside `queue.sync` while `update` mutates it; without a barrier
+    /// on Linux (`BLAZEDB_LINUX_CORE`), that was a data race.
+    func testConcurrentFetchAllDuringSingleRecordUpdates() throws {
+        guard let dbRef = db else {
+            XCTFail("db not set")
+            return
+        }
+        let id = try dbRef.insert(BlazeDataRecord(["name": .string("initial")]))
+        try dbRef.collection.persist()
+        
+        let done = expectation(description: "fetch/update workers complete")
+        done.expectedFulfillmentCount = 2
+        
+        let workQueue = DispatchQueue(label: "test.fetchupdate.concurrent", attributes: .concurrent)
+        
+        workQueue.async {
+            for _ in 0..<400 {
+                _ = try? dbRef.fetchAll()
+            }
+            done.fulfill()
+        }
+        workQueue.async {
+            for i in 0..<400 {
+                try? dbRef.update(id: id, with: BlazeDataRecord(["name": .string("v\(i)")]))
+            }
+            done.fulfill()
+        }
+        
+        wait(for: [done], timeout: 60.0)
+        
+        let final = try requireFixture(db).fetch(id: id)
+        XCTAssertNotNil(final)
+        let name = final!.string("name", default: "")
+        XCTAssertTrue(name.hasPrefix("v"), "Expected updated name, got \(name)")
+    }
+    
     /// Test concurrent deletes don't cause corruption
     func testConcurrentDeletes() throws {
         // Insert 100 records


### PR DESCRIPTION
## Summary

Fixes [#81](https://github.com/Mikedan37/BlazeDB/issues/81).

On the **legacy non-MVCC** path, `DynamicCollection.update()` used `queue.sync(flags: .barrier)` on Apple but called `_updateNoSync` directly when `BLAZEDB_LINUX_CORE` was defined. Reads still went through `queue.sync`, so `indexMap` could be mutated concurrently with iteration — a data race.

## Change

Always run legacy `_updateNoSync` under `queue.sync(flags: .barrier)`, matching **insert** and **delete** on all platforms.

## Test

Added `testConcurrentFetchAllDuringSingleRecordUpdates`: one thread repeatedly `fetchAll()`, another repeatedly `update()` on the same record; assert completion, record survival, and updated field value.

## Verification

- Local: `swift test --filter BlazeDBEnhancedConcurrencyTests` (macOS).
- **Linux CI** (and ideally **TSan** in nightly) are the authoritative check that the contested path is safe under `BLAZEDB_LINUX_CORE`; macOS green does not substitute for that.

Made with [Cursor](https://cursor.com)