### PR TITLE
test: migrate DXQueryExplainTests to explain() / DetailedQueryPlan (#84)

### DIFF
--- a/BlazeDB/Query/QueryExplain.swift
+++ b/BlazeDB/Query/QueryExplain.swift
@@ -19,10 +19,20 @@ public struct DetailedQueryPlan: CustomStringConvertible {
     public let candidateIndexes: [String]
     public let estimatedTime: TimeInterval
     public let warnings: [String]
+    /// Count of chained filter predicates (same notion as deprecated `QueryExplanation.filterCount`).
+    public let filterPredicateCount: Int
+    /// Field names from `where` clauses, sorted for stable logging and tests.
+    public let referencedFilterFields: [String]
 
     public var description: String {
         var output = "Query Execution Plan:\n"
         output += "  Estimated records: \(estimatedRecords)\n"
+        output += "  Filter predicates: \(filterPredicateCount)\n"
+        if referencedFilterFields.isEmpty {
+            output += "  Filter fields: none\n"
+        } else {
+            output += "  Filter fields: \(referencedFilterFields.joined(separator: ", "))\n"
+        }
 
         if !candidateIndexes.isEmpty {
             output += "  Candidate indexes: \(candidateIndexes.joined(separator: ", "))\n"
@@ -237,7 +247,9 @@ extension QueryBuilder {
             estimatedRecords: estimatedRecords,
             candidateIndexes: candidateIndexes,
             estimatedTime: estimatedTime,
-            warnings: warnings
+            warnings: warnings,
+            filterPredicateCount: filters.count,
+            referencedFilterFields: Array(filterFields).sorted()
         )
     }
     

--- a/BlazeDBTests/Core/DXQueryExplainTests.swift
+++ b/BlazeDBTests/Core/DXQueryExplainTests.swift
@@ -26,12 +26,13 @@ final class DXQueryExplainTests: XCTestCase {
         // Insert test data
         try db.insert(BlazeDataRecord(["name": .string("Alice"), "age": .int(30)]))
         
-        let explanation = try db.query()
+        let plan = try db.query()
             .where("name", equals: .string("Alice"))
             .where("age", greaterThan: .int(25))
-            .explainCost()
+            .explain()
         
-        XCTAssertEqual(explanation.filterCount, 2)
+        XCTAssertEqual(plan.filterPredicateCount, 2)
+        XCTAssertEqual(Set(plan.referencedFilterFields), ["age", "name"])
     }
     
     func testExplain_WarnsForUnindexedFilter() throws {
@@ -39,16 +40,15 @@ final class DXQueryExplainTests: XCTestCase {
         try db.insert(BlazeDataRecord(["name": .string("Alice"), "status": .string("active")]))
         
         // Query without index
-        let explanation = try db.query()
+        let plan = try db.query()
             .where("status", equals: .string("active"))
-            .explainCost()
+            .explain()
         
-        // Should warn about unindexed filter (if index detection works)
-        // If index detection is unavailable, riskLevel will be .unknown
-        XCTAssertTrue(
-            explanation.riskLevel == .warnUnindexedFilter ||
-            explanation.riskLevel == .unknown
-        )
+        XCTAssertEqual(plan.filterPredicateCount, 1)
+        XCTAssertEqual(plan.referencedFilterFields, ["status"])
+        XCTAssertTrue(plan.candidateIndexes.isEmpty)
+        XCTAssertTrue(plan.steps.contains { if case .tableScan = $0.type { return true }; return false })
+        XCTAssertTrue(plan.steps.contains { if case .filter = $0.type { return true }; return false })
     }
     
     func testExecuteWithWarnings_ReturnsSameResultsAsExecute() throws {
@@ -72,9 +72,9 @@ final class DXQueryExplainTests: XCTestCase {
     }
     
     func testExplain_HandlesEmptyQuery() throws {
-        let explanation = try db.query().explainCost()
+        let plan = try db.query().explain()
         
-        XCTAssertEqual(explanation.filterCount, 0)
-        XCTAssertTrue(explanation.filterFields.isEmpty)
+        XCTAssertEqual(plan.filterPredicateCount, 0)
+        XCTAssertTrue(plan.referencedFilterFields.isEmpty)
     }
 }

--- a/BlazeDBTests/Tier1Core/Core/DXQueryExplainTests.swift
+++ b/BlazeDBTests/Tier1Core/Core/DXQueryExplainTests.swift
@@ -39,12 +39,13 @@ final class DXQueryExplainTests: XCTestCase {
         // Insert test data
         _ = try db.insert(BlazeDataRecord(["name": .string("Alice"), "age": .int(30)]))
         
-        let explanation = try db.query()
+        let plan = try db.query()
             .where("name", equals: .string("Alice"))
             .where("age", greaterThan: .int(25))
-            .explainCost()
+            .explain()
         
-        XCTAssertEqual(explanation.filterCount, 2)
+        XCTAssertEqual(plan.filterPredicateCount, 2)
+        XCTAssertEqual(Set(plan.referencedFilterFields), ["age", "name"])
     }
     
     func testExplain_WarnsForUnindexedFilter() throws {
@@ -53,16 +54,16 @@ final class DXQueryExplainTests: XCTestCase {
         _ = try db.insert(BlazeDataRecord(["name": .string("Alice"), "status": .string("active")]))
         
         // Query without index
-        let explanation = try db.query()
+        let plan = try db.query()
             .where("status", equals: .string("active"))
-            .explainCost()
+            .explain()
         
-        // Should warn about unindexed filter (if index detection works)
-        // If index detection is unavailable, riskLevel will be .unknown
-        XCTAssertTrue(
-            explanation.riskLevel == .warnUnindexedFilter ||
-            explanation.riskLevel == .unknown
-        )
+        // No index on `status`: detailed plan should show filters without candidate indexes.
+        XCTAssertEqual(plan.filterPredicateCount, 1)
+        XCTAssertEqual(plan.referencedFilterFields, ["status"])
+        XCTAssertTrue(plan.candidateIndexes.isEmpty)
+        XCTAssertTrue(plan.steps.contains { if case .tableScan = $0.type { return true }; return false })
+        XCTAssertTrue(plan.steps.contains { if case .filter = $0.type { return true }; return false })
     }
     
     func testExecuteWithWarnings_ReturnsSameResultsAsExecute() throws {
@@ -89,9 +90,9 @@ final class DXQueryExplainTests: XCTestCase {
     
     func testExplain_HandlesEmptyQuery() throws {
         let db = try XCTUnwrap(self.db, "db should be set in setUp")
-        let explanation = try db.query().explainCost()
+        let plan = try db.query().explain()
         
-        XCTAssertEqual(explanation.filterCount, 0)
-        XCTAssertTrue(explanation.filterFields.isEmpty)
+        XCTAssertEqual(plan.filterPredicateCount, 0)
+        XCTAssertTrue(plan.referencedFilterFields.isEmpty)
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Added
 
+- **`DetailedQueryPlan`:** `filterPredicateCount` and `referencedFilterFields` mirror filter metadata previously only available via deprecated `explainCost()` ([#84](https://github.com/Mikedan37/BlazeDB/issues/84)).
 - `BlazeDBClient.delete(_:)` typed convenience for `BlazeStorable` models (sync + async).
 - **Tier0 regression tests** (`PathResolverDefaultLocationTests`): on Apple platforms, default DB directory and the default telemetry metrics URL layout both resolve under **Application Support/BlazeDB/** (and Linux under **~/.local/share/blazedb**), guarding against `homeDirectoryForCurrentUser` regressions on iOS.
 


### PR DESCRIPTION
## Summary

Closes [#84](https://github.com/Mikedan37/BlazeDB/issues/84).

**This is a migration-enabling parity fix, not a planner behavior change.** Query planning and execution logic are unchanged; only `DetailedQueryPlan` surface area and tests move off deprecated `explainCost()`.

## Changes

- Adds **`filterPredicateCount`** and **`referencedFilterFields`** to `DetailedQueryPlan` so callers can inspect filter metadata without `QueryExplanation` / `explainCost()`.
- Migrates **`DXQueryExplainTests`** (Tier1 SwiftPM copy and the `BlazeDBTests/Core` duplicate) from deprecated **`explainCost()`** to **`explain()`**.
- Preserves the same behavioral intent: multi-filter count, empty query, unindexed filter case (table scan + filter steps, no candidate indexes), and `executeWithWarnings` parity with `execute`.
- **CHANGELOG** ([Unreleased] → Added): documents the new plan fields.

## Verification

`swift test --filter DXQueryExplainTests` (4 tests, Tier1).
