### PR TITLE
test(tier0): BlazeBinary misaligned subdata regression (#30)

### DIFF
--- a/BlazeDBTests/Tier0Core/CoreCorrectness/BlazeBinaryMisalignedSliceTests.swift
+++ b/BlazeDBTests/Tier0Core/CoreCorrectness/BlazeBinaryMisalignedSliceTests.swift
@@ -1,0 +1,34 @@
+//
+//  BlazeBinaryMisalignedSliceTests.swift
+//  BlazeDB
+//
+//  Regression guard for GitHub #30: binary decode must not assume the backing
+//  buffer starts at a scalar-aligned address (Linux traps on misaligned raw loads).
+
+import XCTest
+import Foundation
+#if canImport(BlazeDBCore)
+@testable import BlazeDBCore
+#else
+@testable import BlazeDB
+#endif
+
+final class BlazeBinaryMisalignedSliceTests: XCTestCase {
+
+    func testDecodeBlazeBinaryFromOneBytePaddedSubdataDoesNotTrap() throws {
+        let record = BlazeDataRecord([
+            "label": .string("misaligned-slice"),
+            "n": .int(42),
+        ])
+        let encoded = try BlazeBinaryEncoder.encode(record)
+        XCTAssertGreaterThanOrEqual(encoded.count, 8, "need full BlazeBinary header")
+
+        let padded = Data([0x00]) + encoded
+        let slice = padded.subdata(in: 1..<padded.count)
+        XCTAssertEqual(slice.count, encoded.count)
+
+        let decoded = try BlazeBinaryDecoder.decode(slice)
+        XCTAssertEqual(decoded.string("label", default: ""), "misaligned-slice")
+        XCTAssertEqual(decoded.int("n", default: 0), 42)
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Tests
+
+- **Tier0:** `BlazeBinaryMisalignedSliceTests` decodes BlazeBinary from a `subdata` slice with a 1-byte prefix so the payload base is byte-offset from allocation alignment — regression guard for Linux misaligned-load crashes tracked in [#30](https://github.com/Mikedan37/BlazeDB/issues/30).
+
 ### Documentation
 
 - **SwiftUI:** [SWIFTUI_INTEGRATION.md](Docs/Guides/SWIFTUI_INTEGRATION.md) and [SWIFTUI_DATABASE_PATTERNS.md](Docs/GettingStarted/SWIFTUI_DATABASE_PATTERNS.md) now show **macOS** vs **iOS** minimal examples (list + toolbar vs **`NavigationStack`** + **`ToolbarItem(placement: .topBarTrailing)`**), plus a **wrong vs right** toolbar snippet and placement table so iOS navigation hierarchy issues are not mistaken for BlazeDB bugs.


### PR DESCRIPTION
## Summary

Contributes to [#30](https://github.com/Mikedan37/BlazeDB/issues/30) (alignment-safety audit): adds a **Tier0 regression test** so BlazeBinary decode cannot silently regress to misaligned raw loads on Linux.

**This is a test-only guard, not a decode logic change.**

## What changed

- New `BlazeBinaryMisalignedSliceTests`: encode a record, prepend one byte, decode via `subdata(in: 1..<)` so the BlazeBinary payload may start at a byte offset that is not naturally aligned for wider scalars.
- **CHANGELOG** ([Unreleased] → Tests): one line linking #30.

## Verification

`swift test --filter BlazeBinaryMisalignedSliceTests` (Tier0, 1 test).
