### PR TITLE
test: shorten #81 concurrency regression (fetchAll vs update)

### DIFF
--- a/BlazeDBTests/Tier1Extended/Concurrency/BlazeDBEnhancedConcurrencyTests.swift
+++ b/BlazeDBTests/Tier1Extended/Concurrency/BlazeDBEnhancedConcurrencyTests.swift
@@ -262,9 +262,7 @@ final class BlazeDBEnhancedConcurrencyTests: XCTestCase {
         }
     }
     
-    /// Regression (GitHub #81): legacy `update` must run under the same concurrent-queue barrier as reads.
-    /// Concurrent `fetchAll` walks `indexMap` inside `queue.sync` while `update` mutates it; without a barrier
-    /// on Linux (`BLAZEDB_LINUX_CORE`), that was a data race.
+    /// Regression (GitHub #81): legacy update path must stay synchronized with reads under `BLAZEDB_LINUX_CORE`.
     func testConcurrentFetchAllDuringSingleRecordUpdates() throws {
         guard let dbRef = db else {
             XCTFail("db not set")
@@ -272,31 +270,33 @@ final class BlazeDBEnhancedConcurrencyTests: XCTestCase {
         }
         let id = try dbRef.insert(BlazeDataRecord(["name": .string("initial")]))
         try dbRef.collection.persist()
-        
+
         let done = expectation(description: "fetch/update workers complete")
         done.expectedFulfillmentCount = 2
-        
+
         let workQueue = DispatchQueue(label: "test.fetchupdate.concurrent", attributes: .concurrent)
-        
+
+        // Small iteration count keeps Tier2 extended runs fast while still interleaving work.
+        let iterations = 50
+
         workQueue.async {
-            for _ in 0..<400 {
+            for _ in 0..<iterations {
                 _ = try? dbRef.fetchAll()
             }
             done.fulfill()
         }
         workQueue.async {
-            for i in 0..<400 {
+            for i in 0..<iterations {
                 try? dbRef.update(id: id, with: BlazeDataRecord(["name": .string("v\(i)")]))
             }
             done.fulfill()
         }
-        
-        wait(for: [done], timeout: 60.0)
-        
+
+        wait(for: [done], timeout: 15.0)
+
         let final = try requireFixture(db).fetch(id: id)
         XCTAssertNotNil(final)
-        let name = final!.string("name", default: "")
-        XCTAssertTrue(name.hasPrefix("v"), "Expected updated name, got \(name)")
+        XCTAssertTrue(final!.string("name", default: "").hasPrefix("v"))
     }
     
     /// Test concurrent deletes don't cause corruption


### PR DESCRIPTION
## Summary

Follow-up to [#177](https://github.com/Mikedan37/BlazeDB/pull/177): the regression test is correct but unnecessarily heavy for Tier2 extended CI.

## Changes

- **50** iterations per worker (was 400)
- **15s** wait timeout (was 60s)
- Tighter doc comment; same assertions

No production code changes.

Made with [Cursor](https://cursor.com)