### PR TITLE
ci: fix Linux nightly Tier2 measure() flake

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -318,6 +318,10 @@ jobs:
         run: mkdir -p .logs .artifacts
 
       - name: Test Tier 2 (core)
+        env:
+          # swift-corelibs-xctest: relax measure() σ gate for noisy shared Linux runners (e.g.
+          # DataSeedingTests.testSeedPerformance failing at ~40% vs 10% default).
+          XCTEST_MEASURE_MAX_STDDEV: "50"
         run: |
           set -euo pipefail
           mkdir -p .logs

--- a/BlazeDBTests/Tier2Integration/BlazeDBIntegrationTests/DataSeedingTests.swift
+++ b/BlazeDBTests/Tier2Integration/BlazeDBIntegrationTests/DataSeedingTests.swift
@@ -336,7 +336,13 @@ final class DataSeedingTests: XCTestCase {
     }
     
     func testSeedPerformance() throws {
-        measure {
+        // Bare `measure { }` triggers XCTest variance checks (~10% max σ). Linux nightly GitHub
+        // runners frequently exceed that; `XCTEST_MEASURE_MAX_STDDEV` is honored on
+        // swift-corelibs-xctest — see nightly.yml linux-tier2-core env.
+        let options = XCTMeasureOptions()
+        options.iterationCount = 10
+
+        measure(metrics: [XCTClockMetric()], options: options) {
             do {
                 _ = try requireFixture(db).seed(Bug.self, count: 100) { i in
                     Bug(title: "Perf Bug \(i)", priority: i % 10)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### CI
+
+- **Nightly (Linux Tier2 core):** Set `XCTEST_MEASURE_MAX_STDDEV` so XCTest `measure()` tolerates noisy shared runners; `DataSeedingTests.testSeedPerformance` uses explicit `XCTClockMetric` with multiple iterations instead of bare `measure { }`, avoiding false failures when relative timing σ exceeded the default 10% cap.
+
 ### Tests
 
 - **Tier0:** `BlazeBinaryMisalignedSliceTests` decodes BlazeBinary from a `subdata` slice with a 1-byte prefix so the payload base is byte-offset from allocation alignment — regression guard for Linux misaligned-load crashes tracked in [#30](https://github.com/Mikedan37/BlazeDB/issues/30).


### PR DESCRIPTION
## Summary

Nightly **Nightly Confidence (daily)** failed on **Linux (Swift 6.2) — Tier2 (core)** (e.g. run 2026-04-19) while **macOS Tier2 (strict)** passed. The only failing test was `DataSeedingTests.testSeedPerformance`: XCTest `measure` rejected the run because **relative standard deviation of wall-clock samples exceeded the default 10%** (~39% on a shared runner), not because of a BlazeDB bug.

## Changes

- **`.github/workflows/nightly.yml`:** For the Linux Tier2 core job only, set `XCTEST_MEASURE_MAX_STDDEV=50` (supported by swift-corelibs-xctest) so `measure()` allows realistic CI noise.
- **`DataSeedingTests.testSeedPerformance`:** Use `measure(metrics: [XCTClockMetric()], options:)` with `iterationCount = 10` instead of bare `measure { }` for clearer metrics and more samples.
- **`CHANGELOG.md`:** [Unreleased] **CI** entry.

## Verification

- `swift test --disable-swift-testing --filter DataSeedingTests.testSeedPerformance` (local)


Made with [Cursor](https://cursor.com)