### PR TITLE
test: Linux-safe DataSeeding performance measure path

### DIFF
--- a/BlazeDBTests/Tier2Integration/BlazeDBIntegrationTests/DataSeedingTests.swift
+++ b/BlazeDBTests/Tier2Integration/BlazeDBIntegrationTests/DataSeedingTests.swift
@@ -336,12 +336,21 @@ final class DataSeedingTests: XCTestCase {
     }
     
     func testSeedPerformance() throws {
-        // Bare `measure { }` triggers XCTest variance checks (~10% max σ). Linux nightly GitHub
-        // runners frequently exceed that; `XCTEST_MEASURE_MAX_STDDEV` is honored on
-        // swift-corelibs-xctest — see nightly.yml linux-tier2-core env.
+        // Keep richer metrics on Apple XCTest while preserving Linux corelibs compatibility.
+        #if os(Linux) || os(Android)
+        measure {
+            do {
+                _ = try requireFixture(db).seed(Bug.self, count: 100) { i in
+                    Bug(title: "Perf Bug \(i)", priority: i % 10)
+                }
+                _ = try requireFixture(db).deleteMany { _ in true }
+            } catch {
+                XCTFail("measure block failed: \(error)")
+            }
+        }
+        #else
         let options = XCTMeasureOptions()
         options.iterationCount = 10
-
         measure(metrics: [XCTClockMetric()], options: options) {
             do {
                 _ = try requireFixture(db).seed(Bug.self, count: 100) { i in
@@ -352,6 +361,7 @@ final class DataSeedingTests: XCTestCase {
                 XCTFail("measure block failed: \(error)")
             }
         }
+        #endif
     }
     
     // MARK: - Edge Cases


### PR DESCRIPTION
## Summary

Follow-up to merged #181. Latest nightly still failed on Linux Tier1 and Tier2 due to compile errors in `DataSeedingTests.testSeedPerformance`:

- `cannot find XCTMeasureOptions in scope`
- `cannot find XCTClockMetric in scope`

This PR keeps the existing Apple XCTest path unchanged and adds a Linux/Android-safe fallback.

## Changes

- `DataSeedingTests.testSeedPerformance`:
  - `#if os(Linux) || os(Android)`: use plain `measure { ... }`
  - `#else`: keep `XCTMeasureOptions` + `XCTClockMetric` + `iterationCount = 10`

## Why

SwiftPM compiles additional test targets during filtered Linux jobs, so this single compile error in a Tier2 file broke both Linux Tier1 and Tier2 lanes. This patch restores Linux compatibility without drifting macOS behavior.

## Verification

- `swift test --disable-swift-testing --filter DataSeedingTests.testSeedPerformance`
- Lints on edited file clean

Made with [Cursor](https://cursor.com)