### PR TITLE
chore: add GitHub Sponsors funding metadata

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: Mikedan37


### PR DESCRIPTION
## Summary

Adds `.github/FUNDING.yml` so GitHub can display a Sponsor button on the BlazeDB repo. Uses GitHub Sponsors handle `Mikedan37`.

- No source code changes.
- No CI changes.
- No README changes.

A README "Support BlazeDB" section will land as a separate small commit/PR — keeping this one minimal so the change is unambiguous.