### PR TITLE
chore: add Support BlazeDB section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,6 +503,16 @@ Run with `swift run <ToolName>`.
 
 ---
 
+## Support BlazeDB
+
+BlazeDB is an open-source Swift-native embedded database focused on deterministic storage, crash recovery, encrypted local persistence, and local-first developer infrastructure.
+
+If BlazeDB helps your work, you can support ongoing maintenance through GitHub Sponsors.
+
+[Become a sponsor](https://github.com/sponsors/Mikedan37)
+
+---
+
 **License:** MIT
 
 **Maintained by:** Danylchuk Studios, LLC


### PR DESCRIPTION
## Summary

Adds a brief "Support BlazeDB" section near the bottom of `README.md`, between Community and License. Points at the GitHub Sponsors page enabled by `.github/FUNDING.yml` in #190.

Modest tone — what BlazeDB is, plus a single "Become a sponsor" link.

- No code changes.
- No CI changes.
- No funding metadata change (that's in #190).
- 10 lines added, 0 removed.

## Depends on (loosely)

#190 sets up the GitHub Sponsors funding metadata. The link in this PR (`https://github.com/sponsors/Mikedan37`) is valid once your Sponsors profile is live, independent of #190 merging — the two PRs are independent and can land in either order.