### PR TITLE
fix(core): enforce strict .blazedb naming convention

### DIFF
--- a/BlazeDB/Exports/BlazeDBClient+Convenience.swift
+++ b/BlazeDB/Exports/BlazeDBClient+Convenience.swift
@@ -10,6 +10,21 @@
 import Foundation
 
 extension BlazeDBClient {
+    private static let canonicalDatabaseExtension = "blazedb"
+    
+    public enum DatabaseNameConventionError: LocalizedError {
+        case emptyName
+        case unsupportedExtension(found: String, expected: String)
+        
+        public var errorDescription: String? {
+            switch self {
+            case .emptyName:
+                return "Database name is empty."
+            case .unsupportedExtension(let found, let expected):
+                return "Unsupported database extension '.\(found)'. Expected '.\(expected)'."
+            }
+        }
+    }
     
     // MARK: - Convenience Initializers
     
@@ -81,7 +96,7 @@ extension BlazeDBClient {
     /// - Throws: BlazeDBError if the default directory cannot be accessed
     public static func defaultDatabaseURL(for name: String) throws -> URL {
         let blazeDBDir = try PathResolver.defaultDatabaseDirectory()
-        let dbName = name.hasSuffix(".blazedb") ? name : "\(name).blazedb"
+        let dbName = try normalizedDatabaseFileName(fromUserInput: name)
         let canonicalURL = blazeDBDir.appendingPathComponent(dbName)
 
         #if os(Linux)
@@ -93,6 +108,41 @@ extension BlazeDBClient {
         #endif
 
         return canonicalURL
+    }
+
+    /// Normalize user input to canonical `.blazedb` naming.
+    ///
+    /// Rules:
+    /// - `foo` -> `foo.blazedb`
+    /// - `foo.blazedb` -> `foo.blazedb`
+    /// - `foo.anything` -> error (explicit unsupported extension)
+    ///
+    /// Note: extension detection only inspects the final path component suffix.
+    public static func normalizedDatabaseFileName(fromUserInput raw: String) throws -> String {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty {
+            throw DatabaseNameConventionError.emptyName
+        }
+
+        // Strip any path components if a caller accidentally passes a path-like string.
+        let lastComponent = (trimmed as NSString).lastPathComponent
+        let ext = (lastComponent as NSString).pathExtension.lowercased()
+        let base = (lastComponent as NSString).deletingPathExtension.trimmingCharacters(in: .whitespacesAndNewlines)
+        if base.isEmpty {
+            throw DatabaseNameConventionError.emptyName
+        }
+
+        switch ext {
+        case "":
+            return "\(lastComponent).\(canonicalDatabaseExtension)"
+        case canonicalDatabaseExtension:
+            return lastComponent
+        default:
+            throw DatabaseNameConventionError.unsupportedExtension(
+                found: ext,
+                expected: canonicalDatabaseExtension
+            )
+        }
     }
 
     #if os(Linux)
@@ -152,7 +202,7 @@ extension BlazeDBClient {
     /// ```
     public static func findDatabase(named name: String) throws -> DatabaseDiscoveryInfo? {
         let databases = try discoverDatabases()
-        let searchName = name.hasSuffix(".blazedb") ? name : "\(name).blazedb"
+        let searchName = try normalizedDatabaseFileName(fromUserInput: name)
         return databases.first { $0.path.hasSuffix(searchName) }
     }
     

--- a/BlazeDBTests/Tier0Core/CoreCorrectness/PathResolverDefaultLocationTests.swift
+++ b/BlazeDBTests/Tier0Core/CoreCorrectness/PathResolverDefaultLocationTests.swift
@@ -26,6 +26,43 @@ final class PathResolverDefaultLocationTests: XCTestCase {
             .appendingPathComponent("telemetry.blazedb")
     }
 
+    func testDefaultDatabaseURL_AddsCanonicalExtensionWhenMissing() throws {
+        let bare = try BlazeDBClient.defaultDatabaseURL(for: "ashpile")
+        XCTAssertEqual(bare.lastPathComponent, "ashpile.blazedb")
+    }
+
+    func testDefaultDatabaseURL_PreservesCanonicalExtension() throws {
+        let canonical = try BlazeDBClient.defaultDatabaseURL(for: "ashpile.blazedb")
+        XCTAssertEqual(canonical.lastPathComponent, "ashpile.blazedb")
+    }
+
+    func testDefaultDatabaseURL_RejectsUnsupportedExtension() throws {
+        XCTAssertThrowsError(try BlazeDBClient.defaultDatabaseURL(for: "ashpile.blaze")) { error in
+            XCTAssertTrue(error.localizedDescription.contains(".blaze"))
+        }
+        XCTAssertThrowsError(try BlazeDBClient.defaultDatabaseURL(for: "ashpile.db")) { error in
+            XCTAssertTrue(error.localizedDescription.contains(".db"))
+        }
+        XCTAssertThrowsError(try BlazeDBClient.defaultDatabaseURL(for: "my.project")) { error in
+            XCTAssertTrue(error.localizedDescription.contains(".project"))
+        }
+    }
+
+    func testDefaultDatabaseURL_PathLikeInput_UsesFinalNameComponent() throws {
+        let fromPathNoExt = try BlazeDBClient.defaultDatabaseURL(for: "folder/mydb")
+        XCTAssertEqual(fromPathNoExt.lastPathComponent, "mydb.blazedb")
+
+        let fromPathCanonical = try BlazeDBClient.defaultDatabaseURL(for: "folder/mydb.blazedb")
+        XCTAssertEqual(fromPathCanonical.lastPathComponent, "mydb.blazedb")
+    }
+
+    func testDefaultDatabaseURL_DotfileLikeName_NormalizesPredictably() throws {
+        // NSString.pathExtension treats ".hiddenname" as extensionless.
+        // We lock behavior: auto-append canonical suffix.
+        let hidden = try BlazeDBClient.defaultDatabaseURL(for: ".hiddenname")
+        XCTAssertEqual(hidden.lastPathComponent, ".hiddenname.blazedb")
+    }
+
     #if !os(Windows)
     private static func assertPrivateDirectoryPermissions(_ url: URL, file: StaticString = #filePath, line: UInt = #line) throws {
         let attributes = try FileManager.default.attributesOfItem(atPath: url.path)


### PR DESCRIPTION
## Summary
- add a shared database-name normalization helper for `defaultDatabaseURL(for:)`/`findDatabase(named:)`
- auto-append `.blazedb` only when extension is missing
- reject unsupported explicit extensions (for example `.db`, `.sqlite`, `.blaze`) with clear errors

## Test plan
- [x] `swift test --filter PathResolverDefaultLocationTests`
- [x] verify new cases: missing extension normalize, canonical extension preserve, unsupported extension reject, path-like inputs, dotfile input