### PR TITLE
fix(ci): stabilize Linux CodableIntegration perf measurement

### DIFF
--- a/BlazeDBTests/Tier2Integration/BlazeDBIntegrationTests/Integration/CodableIntegrationTests.swift
+++ b/BlazeDBTests/Tier2Integration/BlazeDBIntegrationTests/Integration/CodableIntegrationTests.swift
@@ -611,8 +611,24 @@ final class CodableIntegrationTests: XCTestCase {
     // MARK: - Performance
     
     func testCodablePerformance() throws {
-        // Measure Codable insert
-        measure {
+        // Measure Codable insert + cleanup
+        #if os(Linux) || os(Android)
+        // Avoid XCTest measure() σ checks on Linux CI: shared runners often exceed corelibs-xctest
+        // relative standard deviation limits even when work is correct.
+        let start = Date()
+        do {
+            let bugs = (0..<100).map { SimpleBug(title: "Bug \($0)", priority: $0 % 10) }
+            _ = try requireFixture(db).insertMany(bugs)
+            _ = try requireFixture(db).deleteMany { _ in true }
+        } catch {
+            XCTFail("codable perf block failed: \(error)")
+        }
+        let elapsed = Date().timeIntervalSince(start)
+        XCTAssertLessThan(elapsed, 300, "insertMany+deleteMany should finish within a generous wall-clock budget")
+        #else
+        let options = XCTMeasureOptions()
+        options.iterationCount = 10
+        measure(metrics: [XCTClockMetric()], options: options) {
             do {
                 let bugs = (0..<100).map { SimpleBug(title: "Bug \($0)", priority: $0 % 10) }
                 _ = try requireFixture(db).insertMany(bugs)
@@ -621,6 +637,7 @@ final class CodableIntegrationTests: XCTestCase {
                 XCTFail("measure block failed: \(error)")
             }
         }
+        #endif
     }
     
     func testCodableVsDynamicPerformance() throws {


### PR DESCRIPTION
## Summary
- Stop false Nightly Confidence failures on Linux Tier2 when `CodableIntegrationTests.testCodablePerformance` hits swift-corelibs-xctest's 10% measure() σ gate on noisy shared runners
- Mirror the existing `DataSeedingTests.testSeedPerformance` pattern: wall-clock budget on Linux/Android, `XCTClockMetric` on Apple platforms

## Test plan
- [x] `swift test --filter 'CodableIntegrationTests.testCodablePerformance'` passes on macOS