### PR TITLE
Add sort-only BlazeStorableQuery initializer

### DIFF
--- a/BlazeDB/SwiftUI/BlazeStorableLiveQuery.swift
+++ b/BlazeDB/SwiftUI/BlazeStorableLiveQuery.swift
@@ -69,6 +69,31 @@ public struct BlazeStorableQuery<T: BlazeStorable>: DynamicProperty {
             limitCount: limit
         ))
     }
+
+    /// Creates a live query for all stored models, sorted by the specified field.
+    ///
+    /// - Parameters:
+    ///   - db: Pass `nil` to resolve the client from ``EnvironmentValues/blazeDBClient``.
+    ///   - kind: The stored model type.
+    ///   - field: The persisted field name used for sorting.
+    ///   - descending: Whether to return results in descending order.
+    ///   - limit: The maximum number of results to return.
+    public init(
+        db: BlazeDBClient? = nil,
+        kind: T.Type,
+        sortBy field: String,
+        descending: Bool = false,
+        limit: Int? = nil
+    ) {
+        self.explicitDB = db
+        _observer = StateObject(wrappedValue: BlazeStorableQueryObserver(
+            db: db,
+            filters: [],
+            sortField: field,
+            sortDescending: descending,
+            limitCount: limit
+        ))
+    }
 }
 
 /// Alias for ``BlazeStorableQuery`` when you want a name that signals environment-driven resolution.

--- a/BlazeDBTests/SwiftUI/BlazeStorableQueryTests.swift
+++ b/BlazeDBTests/SwiftUI/BlazeStorableQueryTests.swift
@@ -1,0 +1,69 @@
+import XCTest
+
+#if canImport(SwiftUI) && canImport(Combine) && (os(macOS) || os(iOS) || os(watchOS) || os(tvOS))
+import SwiftUI
+@testable import BlazeDB
+
+private struct StorableTask: BlazeStorable, Equatable {
+    var id: UUID
+    let title: String
+    let priority: Int
+}
+
+@MainActor
+final class BlazeStorableQueryTests: XCTestCase {
+    func testSortWithoutFilter() async throws {
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("storable-query-\(UUID().uuidString)")
+            .appendingPathExtension("blazedb")
+
+        let db = try BlazeDBClient(
+            name: "StorableQueryTests",
+            fileURL: tempURL,
+            password: "Test-Password-123"
+        )
+
+        defer {
+            let extensions = ["", "meta", "indexes", "wal", "backup", "transaction_backup"]
+
+            for ext in extensions {
+                let url = ext.isEmpty
+                    ? tempURL
+                    : tempURL.deletingPathExtension().appendingPathExtension(ext)
+
+                try? FileManager.default.removeItem(at: url)
+            }
+        }
+
+        for priority in [3, 1, 5, 2, 4] {
+            try await db.insert(
+                StorableTask(
+                    id: UUID(),
+                    title: "Task \(priority)",
+                    priority: priority
+                )
+            )
+        }
+
+        try await db.persist()
+
+        let wrapper = BlazeStorableQuery<StorableTask>(
+            db: db,
+            kind: StorableTask.self,
+            sortBy: "priority",
+            descending: true
+        )
+
+        let observer = wrapper.projectedValue
+        let deadline = Date().addingTimeInterval(2)
+
+        while observer.isLoading && Date() < deadline {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+
+        XCTAssertFalse(observer.isLoading, "Query timed out")
+        XCTAssertNil(observer.error)
+        XCTAssertEqual(observer.results.map(\.priority), [5, 4, 3, 2, 1])
+    }
+}
+#endif

--- a/Package.swift
+++ b/Package.swift
@@ -55,7 +55,7 @@ var blazeTargets: [Target] = [
                 // crash on Swift 6.0.x, they can add the same flag to their own target.
             ]
         ),
-        
+
         // MARK: - Umbrella Target (backward compatibility)
         // Provides "BlazeDB" product for downstream consumers
         // Re-exports BlazeDBCore only; distributed modules excluded until Swift 6 compliant
@@ -79,7 +79,7 @@ var blazeTargets: [Target] = [
             dependencies: [],
             path: "BlazeDB/TelemetryStaging"
         ),
-        
+
         // MARK: - CLI (blazedb)
         .target(
             name: "BlazeCLICore",
@@ -171,7 +171,7 @@ var blazeTargets: [Target] = [
             path: "Examples/ReferenceConsumer",
             exclude: ["README.md"]
         ),
-        
+
         // MARK: - Test Targets
 
         // Tier 0: deterministic correctness and gate-level durability checks.
@@ -208,6 +208,18 @@ if !tier0OnlyTestScope {
                 .define("BLAZEDB_LINUX_CORE", .when(platforms: [.linux, .android]))
             ]
         ),
+        // Apple-platform SwiftUI wrapper tests.
+
+            .testTarget(
+
+                name: "BlazeDB_SwiftUITests",
+
+                dependencies: ["BlazeDB"],
+
+                path: "BlazeDBTests/SwiftUI"
+
+            ),
+
         // Tier 2: integration/recovery and deeper deterministic validation.
         .testTarget(
             name: "BlazeDB_Tier2",


### PR DESCRIPTION
**Quick rules:** [CONTRIBUTING.md — PR expectations](CONTRIBUTING.md#pr-expectations) (one branch, `preflight`, list commands, docs with behavior, squash merge).

## Summary

- Added a new sort-only `BlazeStorableQuery` initializer that supports `sortBy`, `descending`, and `limit` without requiring a filter.
- Added a dedicated SwiftUI test target and a focused test verifying descending ordering for typed results.
- This was needed because the existing API supported:
  - unfiltered, unsorted queries
  - filtered queries with optional sorting

  but did not support querying all stored models with sorting and no filter.

Example usage:

```swift
@BlazeStorableQuery(
    kind: Task.self,
    sortBy: "priority",
    descending: true
)
var tasks: [Task]
```

## Scope

- In scope:
  - Add an unfiltered sorted initializer for `BlazeStorableQuery`.
  - Forward `sortBy`, `descending`, and `limit` into the existing `BlazeStorableQueryObserver`.
  - Reuse the existing `BlazeLiveQuery` sorting path.
  - Add an active SwiftUI XCTest target.
  - Add a test verifying that an unfiltered typed query returns results in descending order.

- Out of scope:
  - KeyPath-based sorting.
  - Changes to BlazeDB sorting internals.
  - Changes to filtered-query behavior.
  - Changes to persistence or indexing behavior.
  - Broader restructuring of existing test tiers or CI workflows.

## Validation

List **exact** commands you ran:

```bash
xcrun swift build

xcrun swift package describe >/dev/null

xcrun swift test list | rg "BlazeStorableQueryTests|testSortWithoutFilter"

xcrun swift test \
  --filter 'BlazeDB_SwiftUITests.BlazeStorableQueryTests/testSortWithoutFilter'

git diff --cached --check
```

Test result:

```text
Executed 1 test, with 0 failures
```

The focused test verifies the complete public path from the new initializer through `BlazeStorableQueryObserver` and `BlazeLiveQuery`, returning decoded `BlazeStorable` models in descending order.

## Checklist

- [x] One branch = one concern
- [x] `git status` / `git diff` reviewed for containment
- [x] Docs updated in this PR if behavior or public usage changed
- [x] `Docs/SYSTEM_MAP.md` / `Docs/Testing/CI_AND_TEST_TIERS.md` updated only if this PR changes material surface, architecture, or CI/tier semantics
- [ ] CI checks pass