### PR TITLE
ci: retry Gradle tasks on transient network failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,14 +89,22 @@ jobs:
           set -euo pipefail
           ./Scripts/verify-readme-samples.sh 2>&1 | tee .logs/verify-readme-samples.log
 
+      - name: Setup Java 17 (KMM Gradle)
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
       - name: KMM shared — build iOS bridge and link framework
         run: |
           set -euo pipefail
-          chmod +x ./Scripts/build-kmm-ios-bridge.sh
+          chmod +x ./Scripts/build-kmm-ios-bridge.sh ./Scripts/ci-gradle-with-retry.sh
           ./Scripts/build-kmm-ios-bridge.sh
-          cd Examples/android
-          chmod +x gradlew
-          ./gradlew :shared:compileKotlinIosSimulatorArm64 :shared:compileKotlinIosArm64 \
+          ./Scripts/ci-gradle-with-retry.sh --no-daemon \
+            :shared:compileKotlinIosSimulatorArm64 :shared:compileKotlinIosArm64 \
             :shared:linkDebugFrameworkIosSimulatorArm64 :shared:linkDebugFrameworkIosArm64 \
             :shared:iosSimulatorArm64Test
 
@@ -327,16 +335,17 @@ jobs:
           distribution: temurin
           java-version: "17"
 
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
       - name: KMM shared — compile Android Kotlin
         run: |
           set -euo pipefail
-          chmod +x ./Scripts/setup-android-gradle-sdk-linux.sh
+          chmod +x ./Scripts/setup-android-gradle-sdk-linux.sh ./Scripts/ci-gradle-with-retry.sh
           ./Scripts/setup-android-gradle-sdk-linux.sh
           export ANDROID_HOME="${ANDROID_HOME:-$PWD/.artifacts/android-gradle-sdk-linux}"
           export ANDROID_SDK_ROOT="$ANDROID_HOME"
-          cd Examples/android
-          chmod +x gradlew
-          ./gradlew :shared:compileDebugKotlinAndroid
+          ./Scripts/ci-gradle-with-retry.sh --no-daemon :shared:compileDebugKotlinAndroid
 
       - name: Stage KMM Android native libs for emulator job
         run: |

--- a/Scripts/ci-gradle-with-retry.sh
+++ b/Scripts/ci-gradle-with-retry.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Run Examples/android/gradlew with retries for transient DNS/network flakes.
+#
+# Usage (from repo root or anywhere):
+#   ./Scripts/ci-gradle-with-retry.sh :shared:iosSimulatorArm64Test
+#   ./Scripts/ci-gradle-with-retry.sh --no-daemon :shared:compileDebugKotlinAndroid
+#
+# Env:
+#   BLAZEDB_GRADLE_MAX_ATTEMPTS — default 3
+#   BLAZEDB_GRADLE_RETRY_BASE_SECONDS — base sleep between attempts (default 15); sleep = base * attempt
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ANDROID_DIR="$ROOT/Examples/android"
+MAX_ATTEMPTS="${BLAZEDB_GRADLE_MAX_ATTEMPTS:-3}"
+RETRY_BASE="${BLAZEDB_GRADLE_RETRY_BASE_SECONDS:-15}"
+
+if [[ ! -x "$ANDROID_DIR/gradlew" ]]; then
+  chmod +x "$ANDROID_DIR/gradlew"
+fi
+
+cd "$ANDROID_DIR"
+
+attempt=1
+while (( attempt <= MAX_ATTEMPTS )); do
+  echo ">>> Gradle (attempt ${attempt}/${MAX_ATTEMPTS}): ./gradlew $*"
+  if ./gradlew "$@"; then
+    exit 0
+  fi
+  status=$?
+  if (( attempt == MAX_ATTEMPTS )); then
+    echo "error: Gradle failed after ${MAX_ATTEMPTS} attempts (exit ${status})" >&2
+    exit "$status"
+  fi
+  sleep_for=$((RETRY_BASE * attempt))
+  echo ">>> Gradle failed (exit ${status}); retrying in ${sleep_for}s..."
+  sleep "$sleep_for"
+  attempt=$((attempt + 1))
+done


### PR DESCRIPTION
## Summary
- Add `Scripts/ci-gradle-with-retry.sh` to retry Gradle wrapper invocations on transient DNS/network failures.
- Wire `setup-java` + `gradle/actions/setup-gradle@v4` into the PR Gate macOS KMM and Android Kotlin compile steps.
- Leaves `reject-automated-prs.yml` untouched.

## Test plan
- [ ] Confirm PR Gate macOS KMM step starts with Setup Java / Set up Gradle
- [ ] Confirm Android Kotlin compile uses the retry wrapper
- [ ] Optional: force a transient failure locally and verify retries (or rely on next real flake)