### PR TITLE
fix: critical RLS, legacy encryption, KMM live-query, and transaction races

### DIFF
--- a/BlazeDB/Core/BlazeDBManager.swift
+++ b/BlazeDB/Core/BlazeDBManager.swift
@@ -187,14 +187,20 @@ public final class BlazeDBManager {
         let saltURL = kdfSaltURL(for: fileURL)
         let fm = FileManager.default
 
-        if fm.fileExists(atPath: saltURL.path) {
+        let saltFileExists = fm.fileExists(atPath: saltURL.path)
+        if saltFileExists {
             let existing = try Data(contentsOf: saltURL)
             if !existing.isEmpty {
                 return existing
             }
         }
 
-        guard !existingDatabaseArtifactsPresent(for: fileURL) else {
+        let hasExistingArtifacts = existingDatabaseArtifactsPresent(for: fileURL)
+        if !saltFileExists && hasExistingArtifacts {
+            return KeyManager.legacyPasswordSalt
+        }
+
+        guard !hasExistingArtifacts else {
             throw BlazeDBError.corruptedData(
                 location: saltURL.path,
                 reason: "Missing or empty KDF salt sidecar for an existing encrypted database. Restore the original .salt file from backup."

--- a/BlazeDB/Core/DynamicCollection.swift
+++ b/BlazeDB/Core/DynamicCollection.swift
@@ -2186,12 +2186,30 @@ public final class DynamicCollection {
         
         /// Permanently removes all soft-deleted records from disk.
         public func purge() throws {
+            try purge(authorizing: nil)
+        }
+
+        /// Permanently removes all soft-deleted records after authorizing the
+        /// complete purge set. Authorization runs before any record is removed
+        /// so a denied purge cannot partially delete data.
+        internal func purge(
+            authorizing authorize: ((BlazeDataRecord) throws -> Void)?
+        ) throws {
             try queue.sync(flags: .barrier) {
                 // Use snapshot to avoid concurrent modification issues
                 // Note: We're in a barrier block, but still use snapshot for safety
                 let indexMapSnapshot = indexMap
                 let allIDs = Array(indexMapSnapshot.keys)
                 var purgeErrors: [Error] = []
+
+                if let authorize {
+                    for id in allIDs {
+                        if let record = try _fetchNoSync(id: id),
+                           record.storage["isDeleted"]?.boolValue == true {
+                            try authorize(record)
+                        }
+                    }
+                }
                 
                 for id in allIDs {
                     do {

--- a/BlazeDB/Core/DynamicCollection.swift
+++ b/BlazeDB/Core/DynamicCollection.swift
@@ -14,8 +14,7 @@ import Crypto
 private extension DynamicCollection {
     /// Default salt for key derivation (ASCII string, UTF-8 encoding guaranteed)
     static var defaultSalt: Data {
-        // "AshPileSalt" is ASCII, so UTF-8 encoding cannot fail
-        return Data("AshPileSalt".utf8)
+        KeyManager.legacyPasswordSalt
     }
 
     static var writeForensicsEnabled: Bool {

--- a/BlazeDB/Core/DynamicCollection.swift
+++ b/BlazeDB/Core/DynamicCollection.swift
@@ -2183,33 +2183,28 @@ public final class DynamicCollection {
                 try _updateNoSync(id: id, with: BlazeDataRecord(storage))
             }
         }
+
+        /// Returns a consistent snapshot of records eligible for purge.
+        internal func softDeletedRecords() throws -> [BlazeDataRecord] {
+            try queue.sync {
+                try indexMap.keys.compactMap { id in
+                    guard let record = try _fetchNoSync(id: id),
+                          record.storage["isDeleted"]?.boolValue == true else {
+                        return nil
+                    }
+                    return record
+                }
+            }
+        }
         
         /// Permanently removes all soft-deleted records from disk.
         public func purge() throws {
-            try purge(authorizing: nil)
-        }
-
-        /// Permanently removes all soft-deleted records after authorizing the
-        /// complete purge set. Authorization runs before any record is removed
-        /// so a denied purge cannot partially delete data.
-        internal func purge(
-            authorizing authorize: ((BlazeDataRecord) throws -> Void)?
-        ) throws {
             try queue.sync(flags: .barrier) {
                 // Use snapshot to avoid concurrent modification issues
                 // Note: We're in a barrier block, but still use snapshot for safety
                 let indexMapSnapshot = indexMap
                 let allIDs = Array(indexMapSnapshot.keys)
                 var purgeErrors: [Error] = []
-
-                if let authorize {
-                    for id in allIDs {
-                        if let record = try _fetchNoSync(id: id),
-                           record.storage["isDeleted"]?.boolValue == true {
-                            try authorize(record)
-                        }
-                    }
-                }
                 
                 for id in allIDs {
                     do {

--- a/BlazeDB/Core/DynamicCollection.swift
+++ b/BlazeDB/Core/DynamicCollection.swift
@@ -2185,25 +2185,31 @@ public final class DynamicCollection {
         }
 
         /// Returns a consistent snapshot of records eligible for purge.
-        internal func softDeletedRecords() throws -> [BlazeDataRecord] {
+        internal func softDeletedRecords() throws -> [(id: UUID, record: BlazeDataRecord)] {
             try queue.sync {
                 try indexMap.keys.compactMap { id in
                     guard let record = try _fetchNoSync(id: id),
                           record.storage["isDeleted"]?.boolValue == true else {
                         return nil
                     }
-                    return record
+                    return (id, record)
                 }
             }
         }
         
         /// Permanently removes all soft-deleted records from disk.
         public func purge() throws {
+            try purge(ids: nil)
+        }
+
+        /// Permanently removes the specified soft-deleted records. Passing nil
+        /// preserves the public API's "purge all" behavior.
+        internal func purge(ids: Set<UUID>?) throws {
             try queue.sync(flags: .barrier) {
                 // Use snapshot to avoid concurrent modification issues
                 // Note: We're in a barrier block, but still use snapshot for safety
                 let indexMapSnapshot = indexMap
-                let allIDs = Array(indexMapSnapshot.keys)
+                let allIDs = ids.map(Array.init) ?? Array(indexMapSnapshot.keys)
                 var purgeErrors: [Error] = []
                 
                 for id in allIDs {

--- a/BlazeDB/Crypto/KeyManager.swift
+++ b/BlazeDB/Crypto/KeyManager.swift
@@ -21,6 +21,7 @@ enum KeyManagerError: Error {
 }
 
 public final class KeyManager {
+    internal static let legacyPasswordSalt = Data("AshPileSalt".utf8)
     nonisolated(unsafe) private static var passwordKeyCache = [String: SymmetricKey]()
     private static let passwordKeyCacheLock = NSLock()
     private static let pbkdf2OverrideLock = NSLock()
@@ -64,8 +65,7 @@ public final class KeyManager {
         case .password(let pass):
             // DEPRECATED: Legacy fallback using static salt. Only used by tests.
             // Production code must use getKey(from:salt:) with a per-database salt.
-            let legacySalt = Data("AshPileSalt".utf8)
-            return try getKey(from: pass, salt: legacySalt)
+            return try getKey(from: pass, salt: legacyPasswordSalt)
         }
     }
 

--- a/BlazeDB/Exports/BlazeDBClient+AsyncOptimized.swift
+++ b/BlazeDB/Exports/BlazeDBClient+AsyncOptimized.swift
@@ -50,8 +50,9 @@ extension BlazeDBClient {
             // Validate against schema
             try validateAgainstSchema(record)
             
-            // Use true async insert
-            let insertedId = try await collection.insertAsync(record)
+            // Route through the canonical client API so schema, RLS, write
+            // rollback, notifications, and cache invalidation stay consistent.
+            let insertedId = try await insert(record)
             
             // Legacy NDJSON hook (no-op; durability is PageStore WAL)
             legacyTransactionLogNoOp("insert", payload: record.storage)
@@ -78,8 +79,9 @@ extension BlazeDBClient {
         let startTime = Date()
         
         do {
-            // Use true async batch insert
-            let ids = try await collection.insertBatchAsync(records)
+            // Route through the canonical client API so RLS and write safety
+            // cannot be bypassed through this deprecated entry point.
+            let ids = try await insertMany(records)
             
             // Legacy NDJSON hook (no-op; durability is PageStore WAL)
             for (index, _) in ids.enumerated() {
@@ -107,7 +109,7 @@ extension BlazeDBClient {
         let startTime = Date()
         
         do {
-            let record = try await collection.fetchAsync(id: id)
+            let record = try await fetch(id: id)
             
             let duration = Date().timeIntervalSince(startTime) * 1000
             telemetry.record(operation: "fetchAsync", duration: duration, success: true, recordCount: record == nil ? 0 : 1)
@@ -126,7 +128,7 @@ extension BlazeDBClient {
         let startTime = Date()
         
         do {
-            let records = try await collection.fetchAllAsync()
+            let records = try await fetchAll()
             
             let duration = Date().timeIntervalSince(startTime) * 1000
             telemetry.record(operation: "fetchAllAsync", duration: duration, success: true, recordCount: records.count)
@@ -145,7 +147,7 @@ extension BlazeDBClient {
         let startTime = Date()
         
         do {
-            let records = try await collection.fetchPageAsync(offset: offset, limit: limit)
+            let records = try fetchPage(offset: offset, limit: limit)
             
             let duration = Date().timeIntervalSince(startTime) * 1000
             telemetry.record(operation: "fetchPageAsync", duration: duration, success: true, recordCount: records.count)
@@ -167,8 +169,9 @@ extension BlazeDBClient {
             // Validate against schema
             try validateAgainstSchema(data)
             
-            // Use true async update
-            try await collection.updateAsync(id: id, with: data)
+            // Route through the canonical client API so RLS and write safety
+            // cannot be bypassed through this deprecated entry point.
+            try await update(id: id, data: data)
             
             // Legacy NDJSON hook (no-op; durability is PageStore WAL)
             legacyTransactionLogNoOp("update", payload: data.storage)
@@ -188,8 +191,9 @@ extension BlazeDBClient {
         let startTime = Date()
         
         do {
-            // Use true async delete
-            try await collection.deleteAsync(id: id)
+            // Route through the canonical client API so RLS and write safety
+            // cannot be bypassed through this deprecated entry point.
+            try await delete(id: id)
             
             // Legacy NDJSON hook (no-op; durability is PageStore WAL)
             legacyTransactionLogNoOp("delete", payload: ["id": .string(id.uuidString)])

--- a/BlazeDB/Exports/BlazeDBClient.swift
+++ b/BlazeDB/Exports/BlazeDBClient.swift
@@ -300,14 +300,20 @@ public final class BlazeDBClient: @unchecked Sendable {
         let saltURL = kdfSaltURL(for: fileURL)
         let fm = FileManager.default
 
-        if fm.fileExists(atPath: saltURL.path) {
+        let saltFileExists = fm.fileExists(atPath: saltURL.path)
+        if saltFileExists {
             let existing = try Data(contentsOf: saltURL)
             if !existing.isEmpty {
                 return existing
             }
         }
 
-        guard !existingDatabaseArtifactsPresent(for: fileURL) else {
+        let hasExistingArtifacts = existingDatabaseArtifactsPresent(for: fileURL)
+        if !saltFileExists && hasExistingArtifacts {
+            return KeyManager.legacyPasswordSalt
+        }
+
+        guard !hasExistingArtifacts else {
             throw BlazeDBError.corruptedData(
                 location: saltURL.path,
                 reason: "Missing or empty KDF salt sidecar for an existing encrypted database. Restore the original .salt file from backup."

--- a/BlazeDB/Exports/BlazeDBClient.swift
+++ b/BlazeDB/Exports/BlazeDBClient.swift
@@ -1515,9 +1515,12 @@ public final class BlazeDBClient: @unchecked Sendable {
     public func purge() throws {
         try ensureNotClosed()
         try performSafeWrite {
-            try collection.purge { [self] record in
+            // Authorize the complete purge set before deleting anything. The
+            // client write lock keeps this snapshot stable until purge finishes.
+            for record in try collection.softDeletedRecords() {
                 try enforceRLS(.delete, record: record)
             }
+            try collection.purge()
         }
     }
 

--- a/BlazeDB/Exports/BlazeDBClient.swift
+++ b/BlazeDB/Exports/BlazeDBClient.swift
@@ -980,6 +980,12 @@ public final class BlazeDBClient: @unchecked Sendable {
                     BlazeLogger.warn("updateMany: could not fetch \(id): \(error.localizedDescription)")
                     continue
                 }
+
+                // Predicates are caller-provided code and must never receive records
+                // that the active context is not allowed to read.
+                if shouldEnforceRLS && !rls.isAllowed(operation: .select, record: record) {
+                    continue
+                }
                 
                 // Check if record matches predicate
                 guard predicate(record) else { continue }
@@ -1085,6 +1091,12 @@ public final class BlazeDBClient: @unchecked Sendable {
                     record = r
                 } catch {
                     BlazeLogger.warn("deleteMany(where): could not fetch \(id): \(error.localizedDescription)")
+                    continue
+                }
+
+                // Predicates are caller-provided code and must never receive records
+                // that the active context is not allowed to read.
+                if shouldEnforceRLS && !rls.isAllowed(operation: .select, record: record) {
                     continue
                 }
                 
@@ -1503,7 +1515,9 @@ public final class BlazeDBClient: @unchecked Sendable {
     public func purge() throws {
         try ensureNotClosed()
         try performSafeWrite {
-            try collection.purge()
+            try collection.purge { [self] record in
+                try enforceRLS(.delete, record: record)
+            }
         }
     }
 

--- a/BlazeDB/Exports/BlazeDBClient.swift
+++ b/BlazeDB/Exports/BlazeDBClient.swift
@@ -1515,12 +1515,19 @@ public final class BlazeDBClient: @unchecked Sendable {
     public func purge() throws {
         try ensureNotClosed()
         try performSafeWrite {
-            // Authorize the complete purge set before deleting anything. The
-            // client write lock keeps this snapshot stable until purge finishes.
-            for record in try collection.softDeletedRecords() {
-                try enforceRLS(.delete, record: record)
+            guard shouldEnforceRLS else {
+                try collection.purge()
+                return
             }
-            try collection.purge()
+
+            // Authorize the complete purge set before deleting anything. The
+            // collection then purges only those IDs, so concurrent additions
+            // cannot enter the operation after authorization.
+            let candidates = try collection.softDeletedRecords()
+            for candidate in candidates {
+                try enforceRLS(.delete, record: candidate.record)
+            }
+            try collection.purge(ids: Set(candidates.map(\.id)))
         }
     }
 

--- a/BlazeDB/Exports/BlazeDBClient.swift
+++ b/BlazeDB/Exports/BlazeDBClient.swift
@@ -1841,6 +1841,9 @@ public final class BlazeDBClient: @unchecked Sendable {
     /// - Transactions provide ACID guarantees and crash-safe rollback semantics.
     public func beginTransaction() throws {
         try ensureNotClosed()
+        writeLock.lock()
+        defer { writeLock.unlock() }
+
         guard transactionIndexMapSnapshot == nil else {
             throw BlazeDBError.transactionFailed("Transaction already in progress")
         }
@@ -1854,22 +1857,26 @@ public final class BlazeDBClient: @unchecked Sendable {
         try createDurableTransactionBackups()
         try writeDurableTransactionState(phase: "open")
 
-        // Snapshot the indexMap (value-type copy — O(1) COW)
-        transactionIndexMapSnapshot = collection.indexMap
-        transactionSecondaryIndexesSnapshot = collection.secondaryIndexes
-        transactionRangeIndexFieldsSnapshot = collection.btreeIndexManager.indexNames
-        // Snapshot baseline records so rollback can restore updated/deleted rows.
-        var baselineRecords: [UUID: BlazeDataRecord] = [:]
-        for id in collection.indexMap.keys {
-            if let record = try collection.fetch(id: id) {
-                baselineRecords[id] = record
+        // Snapshot collection state under its barrier so the rollback baseline cannot
+        // race concurrent reads or collection mutations.
+        let snapshot = try collection.queue.sync(flags: .barrier) {
+            let indexMap = collection.indexMap
+            var baselineRecords: [UUID: BlazeDataRecord] = [:]
+            for id in indexMap.keys {
+                if let record = try collection._fetchNoSync(id: id) {
+                    baselineRecords[id] = record
+                }
             }
+            return (indexMap, collection.secondaryIndexes, baselineRecords)
         }
-        transactionRecordSnapshot = baselineRecords
+        transactionIndexMapSnapshot = snapshot.0
+        transactionSecondaryIndexesSnapshot = snapshot.1
+        transactionRecordSnapshot = snapshot.2
+        transactionRangeIndexFieldsSnapshot = collection.btreeIndexManager.indexNames
         transactionPagesWritten = []
 
         metrics.incrementTransactionsStarted()
-        BlazeLogger.debug("Transaction started (indexMap snapshot: \(collection.indexMap.count) records)")
+        BlazeLogger.debug("Transaction started (indexMap snapshot: \(snapshot.0.count) records)")
     }
 
     /// Commits the current transaction, making all changes permanent.
@@ -1888,6 +1895,9 @@ public final class BlazeDBClient: @unchecked Sendable {
     /// ```
     public func commitTransaction() throws {
         try ensureNotClosed()
+        writeLock.lock()
+        defer { writeLock.unlock() }
+
         guard transactionIndexMapSnapshot != nil else {
             throw BlazeDBError.transactionFailed("No transaction in progress")
         }
@@ -1935,52 +1945,57 @@ public final class BlazeDBClient: @unchecked Sendable {
     /// ```
     public func rollbackTransaction() throws {
         try ensureNotClosed()
+        writeLock.lock()
+        defer { writeLock.unlock() }
+
         guard let snapshot = transactionIndexMapSnapshot else {
             throw BlazeDBError.transactionFailed("No transaction to roll back")
         }
         let baselineRecords = transactionRecordSnapshot ?? [:]
 
-        // Restore indexMap to pre-transaction state
-        collection.indexMap = snapshot
-        if let secondarySnapshot = transactionSecondaryIndexesSnapshot {
-            collection.secondaryIndexes = secondarySnapshot
-        }
-
-        // Restore pre-transaction payloads for records that still exist.
-        // Without this, in-place updates can survive rollback even if indexMap is restored.
-        for (id, pages) in snapshot {
-            guard let pageIndex = pages.first, let baseline = baselineRecords[id] else { continue }
-            let encoded = try BlazeBinaryEncoder.encodeOptimized(baseline)
-            try collection.store.writePage(index: pageIndex, data: encoded)
-        }
-
-        // Zero out pages that were allocated during this transaction
-        // (they contain data that should not be visible after rollback)
-        for pageIndex in transactionPagesWritten {
-            do {
-                try collection.store.deletePage(index: pageIndex)
-            } catch {
-                BlazeLogger.warn("rollbackTransaction: could not delete staged page \(pageIndex): \(error.localizedDescription)")
+        try collection.queue.sync(flags: .barrier) {
+            // Restore indexMap to pre-transaction state
+            collection.indexMap = snapshot
+            if let secondarySnapshot = transactionSecondaryIndexesSnapshot {
+                collection.secondaryIndexes = secondarySnapshot
             }
-        }
 
-        // Clear caches so reads reflect rolled-back state
-        collection.store.pageCache.clear()
-        collection.recordCache.clear()
-        collection.btreeIndexManager.clearAll()
-        for field in transactionRangeIndexFieldsSnapshot {
-            _ = collection.btreeIndexManager.getOrCreateIndex(for: field)
-        }
-        for (id, record) in baselineRecords {
-            collection.btreeIndexManager.indexRecord(id: id, fields: record.storage)
-        }
-        #if !BLAZEDB_LINUX_CORE
-        collection.clearFetchAllCache()
-        #endif
+            // Restore pre-transaction payloads for records that still exist.
+            // Without this, in-place updates can survive rollback even if indexMap is restored.
+            for (id, pages) in snapshot {
+                guard let pageIndex = pages.first, let baseline = baselineRecords[id] else { continue }
+                let encoded = try BlazeBinaryEncoder.encodeOptimized(baseline)
+                try collection.store.writePage(index: pageIndex, data: encoded)
+            }
 
-        // Persist the rolled-back layout
-        try collection.saveLayout()
-        try collection.store.synchronize()
+            // Zero out pages that were allocated during this transaction
+            // (they contain data that should not be visible after rollback)
+            for pageIndex in transactionPagesWritten {
+                do {
+                    try collection.store.deletePage(index: pageIndex)
+                } catch {
+                    BlazeLogger.warn("rollbackTransaction: could not delete staged page \(pageIndex): \(error.localizedDescription)")
+                }
+            }
+
+            // Clear caches so reads reflect rolled-back state
+            collection.store.pageCache.clear()
+            collection.recordCache.clear()
+            collection.btreeIndexManager.clearAll()
+            for field in transactionRangeIndexFieldsSnapshot {
+                _ = collection.btreeIndexManager.getOrCreateIndex(for: field)
+            }
+            for (id, record) in baselineRecords {
+                collection.btreeIndexManager.indexRecord(id: id, fields: record.storage)
+            }
+            #if !BLAZEDB_LINUX_CORE
+            collection.clearFetchAllCache()
+            #endif
+
+            // Persist the rolled-back layout before readers can observe restored state.
+            try collection.saveLayout()
+            try collection.store.synchronize()
+        }
 
         // Discard transaction state
         transactionIndexMapSnapshot = nil

--- a/BlazeDBTests/Tier0Core/Durability/TransactionDurabilityTests.swift
+++ b/BlazeDBTests/Tier0Core/Durability/TransactionDurabilityTests.swift
@@ -333,6 +333,69 @@ final class TransactionDurabilityTests: XCTestCase {
         }
     }
 
+    func testRollbackIsSafeWithConcurrentReaders() throws {
+        let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString + ".blz")
+        let db = try BlazeDBClient(name: "ConcurrentRollback", fileURL: tempURL, password: "TestPassword-123!")
+        let baselineID = try db.insert(BlazeDataRecord(["value": .string("baseline")]))
+        try db.persist()
+
+        defer {
+            try? db.close()
+            let sidecarBase = tempURL.deletingPathExtension()
+            for ext in ["meta", "wal", "salt"] {
+                try? FileManager.default.removeItem(at: sidecarBase.appendingPathExtension(ext))
+            }
+            try? FileManager.default.removeItem(at: tempURL)
+        }
+
+        let start = DispatchSemaphore(value: 0)
+        let readersFinished = expectation(description: "concurrent readers finished")
+        readersFinished.expectedFulfillmentCount = 4
+        let writerFinished = expectation(description: "transaction writer finished")
+
+        for _ in 0..<4 {
+            DispatchQueue.global().async {
+                start.wait()
+                for _ in 0..<100 {
+                    do {
+                        XCTAssertNotNil(try db.fetch(id: baselineID))
+                        _ = try db.fetchAll()
+                    } catch {
+                        XCTFail("Concurrent read failed during rollback: \(error)")
+                        break
+                    }
+                }
+                readersFinished.fulfill()
+            }
+        }
+
+        DispatchQueue.global().async {
+            start.wait()
+            do {
+                for iteration in 0..<10 {
+                    try db.beginTransaction()
+                    try db.update(
+                        id: baselineID,
+                        with: BlazeDataRecord(["value": .string("temporary-\(iteration)")])
+                    )
+                    try db.rollbackTransaction()
+                }
+            } catch {
+                XCTFail("Concurrent rollback failed: \(error)")
+            }
+            writerFinished.fulfill()
+        }
+
+        for _ in 0..<5 {
+            start.signal()
+        }
+        wait(for: [readersFinished, writerFinished], timeout: 30)
+
+        let restored = try XCTUnwrap(db.fetch(id: baselineID))
+        XCTAssertEqual(restored.storage["value"]?.stringValue, "baseline")
+        XCTAssertEqual(try db.count(), 1)
+    }
+
     func testStartupRestoresInterruptedTransactionBackup() throws {
         let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString + ".blz")
         let metaURL = tempURL.deletingPathExtension().appendingPathExtension("meta")

--- a/BlazeDBTests/Tier1Core/Security/DatabaseSessionKeyLifecycleTests.swift
+++ b/BlazeDBTests/Tier1Core/Security/DatabaseSessionKeyLifecycleTests.swift
@@ -40,6 +40,23 @@ final class DatabaseSessionKeyLifecycleTests: XCTestCase {
         return id
     }
 
+    private func seedLegacySidecarlessDatabase(at url: URL) throws -> UUID {
+        let key = try KeyManager.getKey(from: password, salt: KeyManager.legacyPasswordSalt)
+        let store = try PageStore(fileURL: url, key: key)
+        let collection = try DynamicCollection(
+            store: store,
+            metaURL: url.deletingPathExtension().appendingPathExtension("meta"),
+            project: "legacy",
+            encryptionKey: key,
+            password: password,
+            kdfSalt: KeyManager.legacyPasswordSalt
+        )
+        let id = try collection.insert(BlazeDataRecord(["marker": .string("legacy")]))
+        try collection.persist()
+        try collection.close()
+        return id
+    }
+
     func testColdOpenRunsPBKDF2() throws {
         let dbURL = makeDBURL("cold")
         defer { cleanupBlazeDBFiles(at: dbURL) }
@@ -170,5 +187,51 @@ final class DatabaseSessionKeyLifecycleTests: XCTestCase {
         db = try BlazeDBClient(name: "clear-all", fileURL: dbURL, password: password)
         XCTAssertEqual(KeyManager.pbkdf2DerivationCountForTesting, 1)
         try db.close()
+    }
+
+    func testLegacySidecarlessEncryptedDatabaseStillOpens() throws {
+        let dbURL = makeDBURL("legacy-sidecarless")
+        let saltURL = dbURL.deletingPathExtension().appendingPathExtension("salt")
+        defer {
+            cleanupBlazeDBFiles(at: dbURL)
+            try? FileManager.default.removeItem(at: saltURL)
+        }
+
+        let id = try seedLegacySidecarlessDatabase(at: dbURL)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: saltURL.path))
+
+        BlazeDBClient.clearSessionKeys()
+        let db = try BlazeDBClient(name: "legacy", fileURL: dbURL, password: password)
+        defer { try? db.close() }
+
+        let record = try XCTUnwrap(db.fetch(id: id))
+        XCTAssertEqual(record["marker"], .string("legacy"))
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: saltURL.path),
+            "Opening a legacy sidecarless database must not invent a replacement salt."
+        )
+    }
+
+    func testLegacySidecarlessEncryptedDatabaseMountsThroughManager() throws {
+        let dbURL = makeDBURL("legacy-manager")
+        let saltURL = dbURL.deletingPathExtension().appendingPathExtension("salt")
+        defer {
+            BlazeDBManager.shared.unmountAllDatabases()
+            cleanupBlazeDBFiles(at: dbURL)
+            try? FileManager.default.removeItem(at: saltURL)
+        }
+
+        let id = try seedLegacySidecarlessDatabase(at: dbURL)
+
+        BlazeDBClient.clearSessionKeys()
+        let collection = try BlazeDBManager.shared.mountDatabase(
+            named: "legacy-manager",
+            fileURL: dbURL,
+            password: password
+        )
+
+        let record = try XCTUnwrap(collection.fetch(id: id))
+        XCTAssertEqual(record["marker"], .string("legacy"))
+        try collection.close()
     }
 }

--- a/BlazeDBTests/Tier1Core/Security/RLSEnforcementClientTests.swift
+++ b/BlazeDBTests/Tier1Core/Security/RLSEnforcementClientTests.swift
@@ -144,6 +144,66 @@ final class RLSEnforcementClientTests: XCTestCase {
         XCTAssertEqual(records.first?.storage["teamId"]?.uuidValue, teamA)
     }
 
+    #if !BLAZEDB_LINUX_CORE
+    func testDeprecatedAsyncCRUDCannotBypassRLS() async throws {
+        let db = try makeClient()
+        let owner = UUID()
+        let outsider = UUID()
+        let hiddenID = try db.insert(
+            BlazeDataRecord(["userId": .uuid(owner), "title": .string("hidden")])
+        )
+        _ = try db.insert(
+            BlazeDataRecord(["userId": .uuid(outsider), "title": .string("visible")])
+        )
+
+        db.enableRLS()
+        db.configureRLSAdminAndOwnerPolicies(userIDField: "userId")
+        db.setRLSContext(userID: outsider, roles: ["member"])
+
+        let hidden = try await db.fetchAsync(id: hiddenID)
+        let all = try await db.fetchAllAsync()
+        let page = try await db.fetchPageAsync(offset: 0, limit: 10)
+        XCTAssertNil(hidden)
+        XCTAssertEqual(all.count, 1)
+        XCTAssertEqual(page.count, 1)
+
+        do {
+            _ = try await db.insertAsync(
+                BlazeDataRecord(["userId": .uuid(owner), "title": .string("blocked")])
+            )
+            XCTFail("Expected insertAsync to enforce RLS")
+        } catch BlazeDBError.permissionDenied(_, _) {
+            // Expected.
+        }
+
+        do {
+            _ = try await db.insertManyAsync([
+                BlazeDataRecord(["userId": .uuid(owner), "title": .string("blocked")])
+            ])
+            XCTFail("Expected insertManyAsync to enforce RLS")
+        } catch BlazeDBError.permissionDenied(_, _) {
+            // Expected.
+        }
+
+        do {
+            try await db.updateAsync(
+                id: hiddenID,
+                with: BlazeDataRecord(["userId": .uuid(owner), "title": .string("blocked")])
+            )
+            XCTFail("Expected updateAsync to enforce RLS")
+        } catch BlazeDBError.permissionDenied(_, _) {
+            // Expected.
+        }
+
+        do {
+            try await db.deleteAsync(id: hiddenID)
+            XCTFail("Expected deleteAsync to enforce RLS")
+        } catch BlazeDBError.permissionDenied(_, _) {
+            // Expected.
+        }
+    }
+    #endif
+
     func testRLSEnabledWithoutPoliciesDoesNotBlock() throws {
         let db = try makeClient()
         db.enableRLS()

--- a/BlazeDBTests/Tier1Core/Security/RLSEnforcementClientTests.swift
+++ b/BlazeDBTests/Tier1Core/Security/RLSEnforcementClientTests.swift
@@ -217,26 +217,55 @@ final class RLSEnforcementClientTests: XCTestCase {
         }
     }
 
-    func testUpdateManyThrowsPermissionDeniedWhenRLSBlocks() throws {
+    func testUpdateManyPredicateCannotObserveRowsDeniedBySelectRLS() throws {
         let db = try makeClient()
         let owner = UUID()
         let outsider = UUID()
 
-        _ = try db.insert(BlazeDataRecord(["id": .uuid(UUID()), "userId": .uuid(owner), "title": .string("t1")]))
-        _ = try db.insert(BlazeDataRecord(["id": .uuid(UUID()), "userId": .uuid(owner), "title": .string("t2")]))
+        _ = try db.insert(BlazeDataRecord(["id": .uuid(UUID()), "userId": .uuid(owner), "title": .string("hidden")]))
+        _ = try db.insert(BlazeDataRecord(["id": .uuid(UUID()), "userId": .uuid(outsider), "title": .string("visible")]))
 
         db.enableRLS()
         db.configureRLSAdminAndOwnerPolicies(userIDField: "userId")
         db.setRLSContext(userID: outsider, roles: ["member"])
 
-        XCTAssertThrowsError(
-            try db.updateMany(where: { _ in true }, set: ["title": .string("hacked")])
-        ) { error in
+        var observedTitles: [String] = []
+        let updated = try db.updateMany(where: { record in
+            observedTitles.append(record.storage["title"]?.stringValue ?? "")
+            return true
+        }, set: ["title": .string("updated")])
+
+        XCTAssertEqual(updated, 1)
+        XCTAssertEqual(observedTitles, ["visible"])
+
+        db.disableRLS()
+        let records = try db.fetchAll()
+        XCTAssertTrue(records.contains { $0.storage["title"]?.stringValue == "hidden" })
+        XCTAssertTrue(records.contains { $0.storage["title"]?.stringValue == "updated" })
+    }
+
+    func testPurgeFailsBeforeDeletingRowsDeniedByRLS() throws {
+        let db = try makeClient()
+        let teamA = UUID()
+        let teamB = UUID()
+        let idA = try db.insert(BlazeDataRecord(["teamId": .uuid(teamA), "title": .string("A")]))
+        let idB = try db.insert(BlazeDataRecord(["teamId": .uuid(teamB), "title": .string("B")]))
+        try db.softDelete(id: idA)
+        try db.softDelete(id: idB)
+
+        db.enableRLS()
+        db.configureRLSAdminAndTeamPolicies(teamIDField: "teamId")
+        db.setRLSContext(userID: UUID(), teamIDs: [teamA], roles: ["member"])
+
+        XCTAssertThrowsError(try db.purge()) { error in
             guard case BlazeDBError.permissionDenied(let operation, _) = error else {
                 return XCTFail("Expected permissionDenied, got \(error)")
             }
-            XCTAssertTrue(operation.contains("RLS denied UPDATE"))
+            XCTAssertTrue(operation.contains("RLS denied DELETE"))
         }
+
+        XCTAssertNotNil(try db.collection.fetch(id: idA))
+        XCTAssertNotNil(try db.collection.fetch(id: idB))
     }
 
     func testDeleteManyIDsThrowsPermissionDeniedWhenRLSBlocks() throws {
@@ -258,23 +287,30 @@ final class RLSEnforcementClientTests: XCTestCase {
         }
     }
 
-    func testDeleteManyWhereThrowsPermissionDeniedWhenRLSBlocks() throws {
+    func testDeleteManyPredicateCannotObserveRowsDeniedBySelectRLS() throws {
         let db = try makeClient()
         let owner = UUID()
         let outsider = UUID()
 
-        _ = try db.insert(BlazeDataRecord(["id": .uuid(UUID()), "userId": .uuid(owner), "title": .string("t1")]))
+        let hiddenID = try db.insert(BlazeDataRecord(["id": .uuid(UUID()), "userId": .uuid(owner), "title": .string("hidden")]))
+        let visibleID = try db.insert(BlazeDataRecord(["id": .uuid(UUID()), "userId": .uuid(outsider), "title": .string("visible")]))
 
         db.enableRLS()
         db.configureRLSAdminAndOwnerPolicies(userIDField: "userId")
         db.setRLSContext(userID: outsider, roles: ["member"])
 
-        XCTAssertThrowsError(try db.deleteMany(where: { _ in true })) { error in
-            guard case BlazeDBError.permissionDenied(let operation, _) = error else {
-                return XCTFail("Expected permissionDenied, got \(error)")
-            }
-            XCTAssertTrue(operation.contains("RLS denied DELETE"))
+        var observedTitles: [String] = []
+        let deleted = try db.deleteMany(where: { record in
+            observedTitles.append(record.storage["title"]?.stringValue ?? "")
+            return true
         }
+
+        XCTAssertEqual(deleted, 1)
+        XCTAssertEqual(observedTitles, ["visible"])
+
+        db.disableRLS()
+        XCTAssertNotNil(try db.fetch(id: hiddenID))
+        XCTAssertNil(try db.fetch(id: visibleID))
     }
 
     func testCountDistinctFetchPageFetchBatchApplyRLS() throws {

--- a/Examples/BlazeDBAndroidBridge/Sources/BlazeDBAndroidBridge.swift
+++ b/Examples/BlazeDBAndroidBridge/Sources/BlazeDBAndroidBridge.swift
@@ -19,6 +19,7 @@ private enum BridgeError: Error {
 
 private final class LiveQuerySlot: @unchecked Sendable {
     let db: BlazeDBClient
+    private let closeDatabaseOnStop: Bool
     private let lock = NSLock()
     private var cancelled = false
 
@@ -27,13 +28,16 @@ private final class LiveQuerySlot: @unchecked Sendable {
     // is not pumped from JNI on Android. Poll on a background queue instead (bridge-only).
     private let callback: blazedb_bridge_live_query_cb
     private let userData: UnsafeMutableRawPointer?
+    private let pollingGroup = DispatchGroup()
 
     init(
         db: BlazeDBClient,
+        closeDatabaseOnStop: Bool,
         callback: blazedb_bridge_live_query_cb,
         userData: UnsafeMutableRawPointer?
     ) {
         self.db = db
+        self.closeDatabaseOnStop = closeDatabaseOnStop
         self.callback = callback
         self.userData = userData
         emitCurrent()
@@ -62,7 +66,10 @@ private final class LiveQuerySlot: @unchecked Sendable {
     }
 
     private func startPolling() {
-        DispatchQueue.global(qos: .utility).async { [weak self] in
+        pollingGroup.enter()
+        let group = pollingGroup
+        DispatchQueue.global(qos: .utility).async { [weak self, group] in
+            defer { group.leave() }
             while let self {
                 self.lock.lock()
                 let stop = self.cancelled
@@ -82,19 +89,25 @@ private final class LiveQuerySlot: @unchecked Sendable {
         lock.lock()
         cancelled = true
         lock.unlock()
-        try? db.close()
+        pollingGroup.wait()
+        if closeDatabaseOnStop {
+            try? db.close()
+        }
     }
 #else
     let query: BlazeLiveQuery<Todo>
 
-    init(db: BlazeDBClient, query: BlazeLiveQuery<Todo>) {
+    init(db: BlazeDBClient, closeDatabaseOnStop: Bool, query: BlazeLiveQuery<Todo>) {
         self.db = db
+        self.closeDatabaseOnStop = closeDatabaseOnStop
         self.query = query
     }
 
     func stop() {
         query.stop()
-        try? db.close()
+        if closeDatabaseOnStop {
+            try? db.close()
+        }
     }
 #endif
 }
@@ -225,41 +238,86 @@ public func blazedb_bridge_live_query_start(
         let pass = try cString(password)
         let url = databaseURL(from: path)
         let db = try BlazeDBClient.open(at: url, password: pass)
-
-#if os(Android)
-        let slot = LiveQuerySlot(db: db, callback: callback, userData: userData)
-        return liveQueryRegistry.insert(slot)
-#else
-        let live = BlazeLiveQuery<Todo>(
+        return startLiveQuery(
             db: db,
-            where: "isDone",
-            equals: .bool(false),
-            sortBy: "title",
-            descending: false
+            closeDatabaseOnStop: true,
+            callback: callback,
+            userData: userData
         )
-        live.onResults = { result in
-            switch result {
-            case .success(let rows):
-                let json = encodeTodos(rows)
-                json.withCString { cstr in
-                    callback(cstr, userData)
-                }
-            case .failure(let error):
-                let message = "{\"error\":\"\(error.localizedDescription)\"}"
-                message.withCString { cstr in
-                    callback(cstr, userData)
-                }
-            }
-        }
-        live.start()
-
-        let slot = LiveQuerySlot(db: db, query: live)
-        return liveQueryRegistry.insert(slot)
-#endif
     } catch {
         return -1
     }
 }
+
+@_cdecl("blazedb_bridge_live_query_start_for_handle")
+public func blazedb_bridge_live_query_start_for_handle(
+    _ dbHandle: Int64,
+    _ callback: blazedb_bridge_live_query_cb?,
+    _ userData: UnsafeMutableRawPointer?
+) -> Int64 {
+    guard let callback else { return -1 }
+    guard let session = sessionRegistry.get(dbHandle) else { return -2 }
+    return startLiveQuery(
+        db: session.db,
+        closeDatabaseOnStop: false,
+        callback: callback,
+        userData: userData
+    )
+}
+
+#if os(Android)
+private func startLiveQuery(
+    db: BlazeDBClient,
+    closeDatabaseOnStop: Bool,
+    callback: blazedb_bridge_live_query_cb,
+    userData: UnsafeMutableRawPointer?
+) -> Int64 {
+    let slot = LiveQuerySlot(
+        db: db,
+        closeDatabaseOnStop: closeDatabaseOnStop,
+        callback: callback,
+        userData: userData
+    )
+    return liveQueryRegistry.insert(slot)
+}
+#else
+private func startLiveQuery(
+    db: BlazeDBClient,
+    closeDatabaseOnStop: Bool,
+    callback: blazedb_bridge_live_query_cb,
+    userData: UnsafeMutableRawPointer?
+) -> Int64 {
+    let live = BlazeLiveQuery<Todo>(
+        db: db,
+        where: "isDone",
+        equals: .bool(false),
+        sortBy: "title",
+        descending: false
+    )
+    live.onResults = { result in
+        switch result {
+        case .success(let rows):
+            let json = encodeTodos(rows)
+            json.withCString { cstr in
+                callback(cstr, userData)
+            }
+        case .failure(let error):
+            let message = "{\"error\":\"\(error.localizedDescription)\"}"
+            message.withCString { cstr in
+                callback(cstr, userData)
+            }
+        }
+    }
+    live.start()
+
+    let slot = LiveQuerySlot(
+        db: db,
+        closeDatabaseOnStop: closeDatabaseOnStop,
+        query: live
+    )
+    return liveQueryRegistry.insert(slot)
+}
+#endif
 
 @_cdecl("blazedb_bridge_live_query_stop")
 public func blazedb_bridge_live_query_stop(_ handle: Int64) {

--- a/Examples/BlazeDBAndroidBridge/include/blazedb_android_bridge.h
+++ b/Examples/BlazeDBAndroidBridge/include/blazedb_android_bridge.h
@@ -20,6 +20,13 @@ int64_t blazedb_bridge_live_query_start(
     void *user_data
 );
 
+/// Start a live query using an existing blazedb_bridge_open handle. The caller owns db_handle.
+int64_t blazedb_bridge_live_query_start_for_handle(
+    int64_t db_handle,
+    blazedb_bridge_live_query_cb callback,
+    void *user_data
+);
+
 /// Stop a live query started with blazedb_bridge_live_query_start.
 void blazedb_bridge_live_query_stop(int64_t handle);
 

--- a/Examples/android/app/src/androidTest/kotlin/com/blazedb/example/BlazeDBRuntimeSmokeTest.kt
+++ b/Examples/android/app/src/androidTest/kotlin/com/blazedb/example/BlazeDBRuntimeSmokeTest.kt
@@ -4,9 +4,13 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.blazedb.kmm.BlazeDB
 import com.blazedb.kmm.Todo
+import com.blazedb.kmm.observeOpenTodos
 import com.blazedb.kmm.putTodo
 import com.blazedb.kmm.queryTodos
 import java.io.File
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -46,6 +50,29 @@ class BlazeDBRuntimeSmokeTest {
             assertEquals(0, db.putTodo(Todo(title = "typed-kmm")))
             val todos = db.queryTodos()
             assertTrue(todos.any { it.title == "typed-kmm" })
+        } finally {
+            db.close()
+        }
+    }
+
+    @Test
+    fun observeOpenTodosReusesExistingDatabaseHandle() = runBlocking {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val dbFile = File(context.filesDir, "blazedb/kmm-live-query.blazedb")
+        dbFile.parentFile?.mkdirs()
+        dbFile.delete()
+
+        val db = BlazeDB.open(dbFile.absolutePath, MainActivity.DEMO_PASSWORD)
+        try {
+            assertEquals(0, db.putTodo(Todo(title = "live-query-borrowed-handle")))
+
+            val observed = withTimeout(3_000) {
+                db.observeOpenTodos().first { todos ->
+                    todos.any { it.title == "live-query-borrowed-handle" }
+                }
+            }
+
+            assertTrue(observed.any { it.title == "live-query-borrowed-handle" })
         } finally {
             db.close()
         }

--- a/Examples/android/app/src/main/cpp/blazedb_jni_shim.c
+++ b/Examples/android/app/src/main/cpp/blazedb_jni_shim.c
@@ -203,6 +203,41 @@ Java_com_blazedb_shared_bridge_BlazeDBBridge_nativeLiveQueryStart(
     return (jlong)handle;
 }
 
+JNIEXPORT jlong JNICALL
+Java_com_blazedb_shared_bridge_BlazeDBBridge_nativeLiveQueryStartForHandle(
+    JNIEnv *env,
+    jclass clazz,
+    jlong dbHandle,
+    jobject callback) {
+    (void)clazz;
+    live_query_ctx_t *ctx = (live_query_ctx_t *)calloc(1, sizeof(live_query_ctx_t));
+    if (ctx == NULL) {
+        return -1;
+    }
+    ctx->callback_global = (*env)->NewGlobalRef(env, callback);
+
+    int64_t handle = blazedb_bridge_live_query_start_for_handle(
+        (int64_t)dbHandle,
+        live_query_trampoline,
+        ctx
+    );
+
+    if (handle <= 0) {
+        (*env)->DeleteGlobalRef(env, ctx->callback_global);
+        free(ctx);
+        return handle;
+    }
+
+    if (!register_live_query(handle, ctx)) {
+        blazedb_bridge_live_query_stop(handle);
+        (*env)->DeleteGlobalRef(env, ctx->callback_global);
+        free(ctx);
+        return -2;
+    }
+
+    return (jlong)handle;
+}
+
 JNIEXPORT void JNICALL
 Java_com_blazedb_shared_bridge_BlazeDBBridge_nativeLiveQueryStop(
     JNIEnv *env,

--- a/Examples/android/shared/src/androidMain/kotlin/com/blazedb/kmm/BlazeDB.android.kt
+++ b/Examples/android/shared/src/androidMain/kotlin/com/blazedb/kmm/BlazeDB.android.kt
@@ -3,20 +3,20 @@ package com.blazedb.kmm
 import com.blazedb.shared.bridge.BlazeDBBridge
 
 actual class BlazeDB private constructor(
-    private val handle: Long,
+    internal actual val nativeHandle: Long,
     actual val dbPath: String,
     internal actual val password: String,
 ) {
-    actual fun close() = BlazeDBBridge.nativeClose(handle)
+    actual fun close() = BlazeDBBridge.nativeClose(nativeHandle)
 
     actual fun put(kind: String, json: String): Int =
-        BlazeDBBridge.nativePutJson(handle, kind, json)
+        BlazeDBBridge.nativePutJson(nativeHandle, kind, json)
 
     actual fun get(key: String): String? =
-        BlazeDBBridge.nativeGetJson(handle, key)
+        BlazeDBBridge.nativeGetJson(nativeHandle, key)
 
     actual fun query(kind: String): String =
-        BlazeDBBridge.nativeQueryJson(handle, kind)
+        BlazeDBBridge.nativeQueryJson(nativeHandle, kind)
 
     actual companion object {
         actual fun open(path: String, password: String): BlazeDB {

--- a/Examples/android/shared/src/androidMain/kotlin/com/blazedb/kmm/LiveQuery.android.kt
+++ b/Examples/android/shared/src/androidMain/kotlin/com/blazedb/kmm/LiveQuery.android.kt
@@ -6,14 +6,14 @@ import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 
-internal actual fun platformObserveOpenTodos(path: String, password: String): Flow<List<Todo>> =
+internal actual fun platformObserveOpenTodos(db: BlazeDB): Flow<List<Todo>> =
     callbackFlow {
         val callback = object : LiveQueryCallback {
             override fun onResults(jsonPayload: String) {
                 trySend(parseTodos(jsonPayload))
             }
         }
-        val handle = BlazeDBBridge.nativeLiveQueryStart(path, password, callback)
+        val handle = BlazeDBBridge.nativeLiveQueryStartForHandle(db.nativeHandle, callback)
         check(handle > 0) { "BlazeDB live query failed ($handle)" }
         awaitClose { BlazeDBBridge.nativeLiveQueryStop(handle) }
     }

--- a/Examples/android/shared/src/androidMain/kotlin/com/blazedb/shared/bridge/BlazeDBBridge.kt
+++ b/Examples/android/shared/src/androidMain/kotlin/com/blazedb/shared/bridge/BlazeDBBridge.kt
@@ -23,6 +23,11 @@ internal object BlazeDBBridge {
         callback: LiveQueryCallback,
     ): Long
 
+    external fun nativeLiveQueryStartForHandle(
+        dbHandle: Long,
+        callback: LiveQueryCallback,
+    ): Long
+
     external fun nativeLiveQueryStop(handle: Long)
 }
 

--- a/Examples/android/shared/src/commonMain/kotlin/com/blazedb/kmm/BlazeDB.kt
+++ b/Examples/android/shared/src/commonMain/kotlin/com/blazedb/kmm/BlazeDB.kt
@@ -12,6 +12,7 @@ expect class BlazeDB {
     /** Absolute path to the encrypted `.blazedb` file. */
     val dbPath: String
     internal val password: String
+    internal val nativeHandle: Long
 
     fun close()
     /** Insert fields JSON under [kind] namespace. Returns 0 on success. */

--- a/Examples/android/shared/src/commonMain/kotlin/com/blazedb/kmm/BlazeDBExt.kt
+++ b/Examples/android/shared/src/commonMain/kotlin/com/blazedb/kmm/BlazeDBExt.kt
@@ -12,8 +12,8 @@ fun BlazeDB.queryTodos(): List<Todo> = parseTodos(query("todo"))
 
 /** Live-updating open todos (`isDone == false`). Platform uses JNI callback on Android, polling on iOS. */
 fun BlazeDB.observeOpenTodos(): Flow<List<Todo>> =
-    platformObserveOpenTodos(dbPath, password)
+    platformObserveOpenTodos(this)
         .map { todos -> todos.filter { !it.isDone } }
         .distinctUntilChanged()
 
-internal expect fun platformObserveOpenTodos(path: String, password: String): Flow<List<Todo>>
+internal expect fun platformObserveOpenTodos(db: BlazeDB): Flow<List<Todo>>

--- a/Examples/android/shared/src/iosMain/kotlin/com/blazedb/kmm/BlazeDB.ios.kt
+++ b/Examples/android/shared/src/iosMain/kotlin/com/blazedb/kmm/BlazeDB.ios.kt
@@ -11,19 +11,19 @@ import kotlinx.cinterop.toKString
 
 @OptIn(ExperimentalForeignApi::class)
 actual class BlazeDB private constructor(
-    private val handle: Long,
+    internal actual val nativeHandle: Long,
     actual val dbPath: String,
     internal actual val password: String,
 ) {
     actual fun close() {
-        blazedb_bridge_close(handle)
+        blazedb_bridge_close(nativeHandle)
     }
 
     actual fun put(kind: String, json: String): Int =
-        blazedb_bridge_put_json(handle, kind, json)
+        blazedb_bridge_put_json(nativeHandle, kind, json)
 
     actual fun get(key: String): String? {
-        val ptr = blazedb_bridge_get_json(handle, key) ?: return null
+        val ptr = blazedb_bridge_get_json(nativeHandle, key) ?: return null
         return try {
             ptr.toKString()
         } finally {
@@ -32,7 +32,7 @@ actual class BlazeDB private constructor(
     }
 
     actual fun query(kind: String): String {
-        val ptr = blazedb_bridge_query_json(handle, kind)
+        val ptr = blazedb_bridge_query_json(nativeHandle, kind)
             ?: return "[]"
         return try {
             ptr.toKString()

--- a/Examples/android/shared/src/iosMain/kotlin/com/blazedb/kmm/LiveQuery.ios.kt
+++ b/Examples/android/shared/src/iosMain/kotlin/com/blazedb/kmm/LiveQuery.ios.kt
@@ -7,14 +7,9 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.isActive
 import kotlin.time.Duration.Companion.milliseconds
 
-internal actual fun platformObserveOpenTodos(path: String, password: String): Flow<List<Todo>> = flow {
-    val db = BlazeDB.open(path, password)
-    try {
-        while (currentCoroutineContext().isActive) {
-            emit(parseTodos(db.query("todo")))
-            delay(250.milliseconds)
-        }
-    } finally {
-        db.close()
+internal actual fun platformObserveOpenTodos(db: BlazeDB): Flow<List<Todo>> = flow {
+    while (currentCoroutineContext().isActive) {
+        emit(parseTodos(db.query("todo")))
+        delay(250.milliseconds)
     }
 }


### PR DESCRIPTION
## Summary
- Close RLS batch/purge bypasses, avoid purge policy reentrancy, and enforce RLS in deprecated async CRUD.
- Preserve access to legacy encrypted databases.
- Reuse open KMM handles for live queries.
- Serialize transaction snapshot/rollback state to avoid concurrent reader races.

Re-homed from closed Cursor bot PR #254 onto a human-owned branch so `reject-automated-prs` can stay strict. No CI/infra changes in this PR (see #255 for Gradle retry hardening).

## Test plan
- [ ] PR Gate green on this branch
- [ ] Review/verify `RLSEnforcementClientTests` and related security tests
- [ ] Review/verify `TransactionDurabilityTests` / `DatabaseSessionKeyLifecycleTests`
- [ ] Spot-check KMM live-query / bridge changes on iOS + Android paths