### PR TITLE
docs(swiftui): document sort-only BlazeStorableQuery initializer

### DIFF
--- a/Docs/GettingStarted/SWIFTUI_DATABASE_PATTERNS.md
+++ b/Docs/GettingStarted/SWIFTUI_DATABASE_PATTERNS.md
@@ -214,6 +214,17 @@ struct DoneItemsView: View {
 }
 ```
 
+Need **every** row sorted, with no `where`? Use the sort-only form (`sortBy` is the persisted field name string, not a `KeyPath`):
+
+```swift
+@BlazeStorableQuery(
+    kind: Item.self,
+    sortBy: "title",
+    descending: true
+)
+private var itemsByTitle: [Item]
+```
+
 Use **`MainTabView()`** in the **`WindowGroup`** instead of **`ContentView()`** when you adopt this shape — the injection line is unchanged:
 
 ```swift

--- a/Docs/Guides/SWIFTUI_INTEGRATION.md
+++ b/Docs/Guides/SWIFTUI_INTEGRATION.md
@@ -166,6 +166,19 @@ Filtered list:
 private var openTasks: [Task]
 ```
 
+All rows, sorted (no filter) — use the sort-only initializer:
+
+```swift
+@BlazeStorableQuery(
+    kind: Task.self,
+    sortBy: "priority",
+    descending: true
+)
+private var tasksByPriority: [Task]
+```
+
+`sortBy` takes the **persisted field name** (`String`), the same encoding name you would use in filters — not a `KeyPath`. For KeyPath-based ordering outside SwiftUI, use `db.query(T.self).orderBy(\.field, ...)`.
+
 Readable alias (same type as **`@BlazeStorableQuery`**):
 
 ```swift


### PR DESCRIPTION
## Summary
- Document the sort-only `@BlazeStorableQuery(kind:sortBy:…)` initializer added in #253.
- Clarify that `sortBy` uses persisted field-name strings (not `KeyPath`).
- Closes the docs half of #172; KeyPath-based SwiftUI sort remains out of scope.

Fixes #172

## Test plan
- [ ] Skim updated examples in `Docs/Guides/SWIFTUI_INTEGRATION.md`
- [ ] Skim Level 3 note in `Docs/GettingStarted/SWIFTUI_DATABASE_PATTERNS.md`
- [ ] Confirm examples match `BlazeStorableQuery` inits on `main`