### PR TITLE
docs: public positioning and engineering-focus navigation

### DIFF
--- a/Docs/Contributing/ISSUE_GUIDE.md
+++ b/Docs/Contributing/ISSUE_GUIDE.md
@@ -7,6 +7,21 @@ This guide helps outside contributors pick work that matches BlazeDB’s support
 
 For product priorities see [`ROADMAP.md`](../../ROADMAP.md). For tracker health see [`Docs/Product/ISSUE_TRACKER_AUDIT.md`](../Product/ISSUE_TRACKER_AUDIT.md).
 
+## How to read the open issue count
+
+Dozens of open issues does **not** mean every ticket is a release blocker. The tracker deliberately keeps verified defects visible rather than hiding them for cosmetics. Rough buckets:
+
+| Bucket | Typical labels | Who owns it |
+|--------|----------------|-------------|
+| Good first issues | `good first issue`, often `documentation` | New contributors |
+| Help wanted | `help wanted` | Outside contributors with maintainer backup |
+| Maintainer-owned correctness | `bug` + `durability` / `concurrency` / `High Priority` | Maintainers / experienced systems contributors |
+| Needs design | `needs design` | Decision before code |
+| Measurement / packaging | `performance`, `ci`, `linux`, `Portability` | After evidence or platform gates |
+| Experimental / later | Android, KMM, deferred sync | Not the default product path |
+
+Release-oriented focus is summarized in [`ROADMAP.md`](../../ROADMAP.md) (**Current engineering focus**) and the README.
+
 ## Finding work
 
 | Filter | Meaning |

--- a/Docs/Product/ISSUE_TRACKER_AUDIT.md
+++ b/Docs/Product/ISSUE_TRACKER_AUDIT.md
@@ -1,8 +1,8 @@
 # BlazeDB Issue Tracker Audit
 
-**Date:** 2026-07-26  
-**Repo tip at audit:** `c2ad82cf`  
-**Open issues counted:** 41  
+**Date:** 2026-07-26 (inventory refresh 2026-07-26 evening)  
+**Repo tip at audit:** `c2ad82cf` (refresh observed tip `cd4a6e1d`)  
+**Open issues counted:** 41 (refresh: 55 open at tip)  
 **Method:** Live GitHub inventory + code/docs evidence + agent cross-checks. Mutations that close/relabel many issues are **proposed only** until maintainer approval (Phase 12).
 
 Document roles (unchanged):
@@ -27,7 +27,7 @@ The tracker is **already strong**: most #258–#291 issues are evidence-backed, 
 
 | Priority | Issues | Why |
 |----------|--------|-----|
-| P0 correctness | #277, #278, #279 | Data loss window; UB iteration; deadlock |
+| P0 correctness | #277 | Data loss window (#278 live-keys mutation and #279 nested-sync deadlock **closed**) |
 | P0 durability semantics | #276 (fix gated on #291), #281, #283 | Txn I/O, index/durability order, Linux barrier |
 | P1 caches / API honesty | #280, #282, #274/#261 | Stale reads; silent drops; scan vs index claims |
 | P1 product hardening (Now) | #263–#266, #259 | Fixtures, Go, BlazeDBC, schema docs, CLI honesty |
@@ -68,8 +68,8 @@ Evidence quality: **proven** / **strong** / **weak** / **stale**.
 | 275 | LiveQuery coalesce | strong | no | keep |
 | 276 | txn fsync amortize | proven | no | rewritten; optimize **blocked on #291**; `durability` |
 | 277 | crash lose commit | proven | no | keep; `durability` + release-blocking |
-| 278 | live keys mutation | proven | no | keep |
-| 279 | nested sync deadlock | proven | no | keep |
+| 278 | live keys mutation | **closed** | — | fixed (lifecycle / batch-predicate races) |
+| 279 | nested sync deadlock | **closed** | — | fixed (lifecycle / nested sync) |
 | 280 | fetchAll cache | proven | no | keep; optional split A/B |
 | 281 | insertBatch index before sync | proven | no | keep |
 | 282 | typed bulk silent drop | proven | no | keep |
@@ -82,6 +82,9 @@ Evidence quality: **proven** / **strong** / **weak** / **stale**.
 | 289 | ./dev arch mismatch | strong | yes | keep |
 | 290 | Dump/Info JSON | strong | yes | keep |
 | 291 | widen write-profile | strong | no | keep; **blocks #276 optimize** |
+| 301 | Linux `fflush(stdout)` Swift 6.2 | **closed** | — | fixed in `1f6dee88`; rationale issue |
+| 302 | Linux Tier0 NestedQueue Sendable | proven | no | keep (Linux PR Gate) |
+| 314 | Tier1 RLS test missing `)` | proven | yes (syntax-only) | **filed**; `bug`+`tests`+`rls` |
 
 ### Duplicate / linkage map
 
@@ -91,13 +94,14 @@ Evidence quality: **proven** / **strong** / **weak** / **stale**.
 #276 ──related──► #277 (commit restore) / #281 / #284
 #286 ──related──► #288 (fail-open docs)
 #270 ──related──► #273 (doc iterations)
+#314 (Tier1 RLS syntax) ──distinct from──► #302 (Linux Tier0 Sendable)
 ```
 
 ---
 
 ## Label inventory
 
-**Present and useful:** `bug`, `documentation`, `enhancement`, `good first issue`, `help wanted`, `ci`, `tests`, `security`, `storage-engine`, `reliability`, `concurrency`, `api-correctness`, `linux`, `Portability`, `High Priority`, `tech-debt`, `cleanup`, `typed-store`, …
+**Present and useful:** `bug`, `documentation`, `enhancement`, `good first issue`, `help wanted`, `ci`, `tests`, `rls`, `security`, `storage-engine`, `reliability`, `concurrency`, `api-correctness`, `linux`, `Portability`, `High Priority`, `tech-debt`, `cleanup`, `typed-store`, …
 
 **Gaps (optional, do not explode taxonomy):**
 
@@ -160,7 +164,8 @@ Evidence quality: **proven** / **strong** / **weak** / **stale**.
 | Issue | Recommendation |
 |-------|----------------|
 | #277 | Add `durability` + treat as **release-blocking** until fixed or explicitly risk-accepted |
-| #278/#279 | Keep High Priority; ensure reproduction snippets in body (already code-proven) |
+| #278/#279 | **Closed** — leave closed; do not re-open for sequencing theater |
+| #314 | Syntax-only Tier1 compile break; fix independently of #302 |
 | #288 | Docs-only Non-goals; remove implication of auth redesign |
 | #276 | State: **optimize blocked on #291**; measurement already sufficient for “defect exists” |
 | #291 | Investigation only — no optimization acceptance criteria |
@@ -189,6 +194,14 @@ Evidence quality: **proven** / **strong** / **weak** / **stale**.
 | [#292](https://github.com/Mikedan37/BlazeDB/issues/292) | Docs: Correct QUERY_PLANNER O(log n) claims |
 | [#293](https://github.com/Mikedan37/BlazeDB/issues/293) | Docs: Fix DURABILITY_MODE_SUPPORT WAL fsync wording |
 | [#294](https://github.com/Mikedan37/BlazeDB/issues/294) | Docs: SAFETY_MODEL buffered txn I/O honesty |
+
+### C. CI/workstream filing pass (no sequencing)
+
+| # | Title | Labels | Status |
+|---|-------|--------|--------|
+| [#301](https://github.com/Mikedan37/BlazeDB/issues/301) | Linux Swift 6.2: `fflush(stdout)` concurrency | bug, linux, ci, tests, swift-6, concurrency | **closed** (fixed `1f6dee88`) |
+| [#302](https://github.com/Mikedan37/BlazeDB/issues/302) | Linux Tier 0: NestedQueueSyncQueryTests Sendable | bug, linux, ci, tests, swift-6, concurrency | open |
+| [#314](https://github.com/Mikedan37/BlazeDB/issues/314) | Fix missing closing parenthesis in RLSEnforcementClientTests | bug, tests, rls | open (filed this pass) |
 
 ### Still proposed only (do not file yet)
 

--- a/Docs/Product/NEXT_ENGINEERING_AUDIT.md
+++ b/Docs/Product/NEXT_ENGINEERING_AUDIT.md
@@ -3,9 +3,10 @@
 **Date:** 2026-07-26  
 **Base commit:** `1760fb8d`  
 **Method:** Seven parallel investigation agents + code verification.  
-**Rules:** No new GitHub issues. No product code changes. No label mass-edits.
+**Rules (original pass):** No speculative issue flood; evidence-first.  
+**Rules (filing update 2026-07-26):** Cap removed. File every proven, supported, independently actionable defect. Hypotheses / experimental / duplicates stay here.
 
-Known tracked work (#258–#294, especially #276–#283, #291) is treated as **already owned**. This document adds only non-duplicative planning signal.
+Known tracked work (#258–#299, especially #276–#283, #291, #295–#299) is treated as **already owned** where applicable.
 
 Related: [ISSUE_TRACKER_AUDIT](ISSUE_TRACKER_AUDIT.md) · [ISSUE_CODE_INDEX](../Contributing/ISSUE_CODE_INDEX.md) · [CODEBASE_MAP](../Architecture/CODEBASE_MAP.md) · [ROADMAP](../../ROADMAP.md)
 
@@ -21,7 +22,7 @@ BlazeDB’s hottest write/open/query defects are already ticketed. The audit’s
 4. **Coverage holes** that leave #277 and concurrent close/vacuum untested in PR gates.
 5. **Feature asks** that stay in audit/backlog until designed (FFI handle generation, CLI argv secrets, Linux `.so`).
 
-**Do not open 30 tickets.** Prefer fixing or extending existing issues, then at most ~10–12 strong new candidates after approval.
+**Discipline is evidence quality, not issue-count cosmetics.** Speculative umbrellas and unsupported surfaces stay in this audit / roadmap.
 
 ---
 
@@ -197,31 +198,35 @@ Speculative durability-boundary mega-refactor as separate epic; distributed; “
 
 ---
 
-## Proposed GitHub actions (approval required)
+## GitHub filing status (cap removed)
 
-| Candidate | Type | Evidence | Duplicate search | Existing | Proposed action |
-|-----------|------|----------|------------------|----------|-----------------|
-| Vacuum closes live store under barrier / no txn guard | bug | Proven | vacuum concurrent close store | none | **new issue candidate** (C-NEW-1) |
-| close() vs concurrent writers TOCTOU | bug | Proven | close writeLock concurrent | LifecycleTests only | **new issue candidate** (C-NEW-2) |
-| softDelete docs vs hidden fetch | documentation / API | Proven | softDelete fetch isDeleted | none | **new issue candidate** (docs-first) |
-| count() vs getRecordCount() semantics | API | Proven | count getRecordCount soft-delete | none | **new issue candidate** (or fold into soft-delete) |
-| BlazeDBC handle UAF / double-close | security/ffi | Proven | use-after-close BlazeDBC | N7 audit only | **new issue candidate** (with #267) |
-| beginTxn O(N) snapshot + full backup cost | investigation | Proven | beginTransaction snapshot backup | near #276/#291 | **update #291** + note on #276 |
-| deletePage per-page fsync / deleteBatch | performance | Proven | deletePage synchronize batch | not #284 | **new issue candidate** or extend #291 |
-| Linux insertMany fallback | performance / platform | Proven | BLAZEDB_LINUX_CORE insertMany | near #51 | **update #51** or small new issue |
-| QueryCache / RecordCache lifecycle | investigation | Strong | QueryCache unbounded | near #280 | **keep in audit** until #280 lands |
-| rawDump unsynchronized | bug | Proven | rawDump queue | none | **new issue candidate** (lower priority) |
-| put([T]) non-atomic | API design | Strong | put array transaction | none | **keep in audit** / Discussion |
-| CLI password argv | security | Proven | password argv Doctor | N6 | **keep in audit** until design |
-| Soft-delete upsert resurrection | bug | Strongly supported | softDelete upsert | none | **new issue candidate** after soft-delete decision |
-| PageStore static OID caches | investigation | Strong | writeBatches memoryMappedFiles | none | **keep in audit** |
-| Overflow orphan reclaim test | testing | Strong | C3 backlog | ROADMAP_BACKLOG | **keep in backlog** |
-| #277 missing crash-after-commit test | testing | Proven | — | #277 | **add test requirement** to #277 |
-| #291 matrix widen | investigation | — | — | #291 | **update existing issue** |
+| Candidate | Disposition |
+|-----------|-------------|
+| Vacuum closed-store resume (C-NEW-1) | **#295** (closed; fixed) |
+| close/write TOCTOU (C-NEW-2) | **#296** (closed; fixed) |
+| softDelete docs + count/getRecordCount (A-NEW-1/2) | **#297** (`needs design`) |
+| BlazeDBC handle UAF / double-close (C-NEW-5) | **#298** |
+| rawDump unsynchronized (C-NEW-6) | **#299** |
+| Soft-delete upsert resurrection (A-NEW-3) | **#304** |
+| Meta fsync undercount (P-NEW-4) | **#305** |
+| QueryCache cross-DB keys (M-NEW-1 observable) | **#306** |
+| RecordCache close/registry (M-NEW-2) | **#307** |
+| PageStore static OID maps (C-NEW-7) | **#308** |
+| put([T]) non-atomic (A-NEW-4) | **#309** |
+| CLI password argv (A-NEW-6 / N6) | **#310** |
+| deletePage per-page fsync (P-NEW-2) | **#311** |
+| Linux insertMany silent fallback (P-NEW-3) | **#312** (+ comment on #51) |
+| beginTxn O(N) snapshot/backup (P-NEW-1 / M-NEW-4) | **update #291** / near #276 — not a separate bug |
+| #277 crash-after-commit test | owned by **#277** |
+| BlazeDBC put throughput (P-NEW-6) | **withheld** — needs measurement (#291); not filed |
+| Android SessionRegistry race | **withheld** — experimental surface |
+| Linux `.so` packaging | **withheld** — unimplemented distribution goal |
+| Overflow orphan reclaim test | **ROADMAP_BACKLOG** |
+| close() rolls back open txn (A-NEW-5) | **intentional contract** — document only |
+| CLI vs engine password policy split (A-NEW-7) | **intentional / design** — not filed as defect |
+| “Unbounded cache cleanup” umbrella | **rejected** — filed observable defects only |
 
-**Reject / do not file:** duplicate latency of #276; LiveQuery (#275); fetchAll (#280); index-before-sync (#281); nested sync (#279); RLS fail-open behavior change.
-
-**Limit:** file at most the strongest **8–10** after approval (prefer C-NEW-1/2, soft-delete/count, BlazeDBC UAF, delete fsync, Linux insertMany, rawDump, soft-delete resurrection).
+**Reject / do not file:** duplicate latency of #276; LiveQuery (#275); fetchAll (#280); index-before-sync (#281); nested sync (#279 closed); RLS fail-open behavior change; BlazeDBC “could be faster” without measurement.
 
 ---
 
@@ -244,10 +249,10 @@ Unverified: deterministic vacuum+insert crash; BlazeDBC double-close crash on th
 
 **Validation explicitly not run this audit:** full Tier0, `BLAZEDB_BENCH_MODE=write_profile`, Thread Sanitizer, Instruments / `fs_usage` / `strace`.
 
-### Linux `insertMany` note (withheld from new-issue flood)
+### Linux `insertMany` note
 
-`BlazeDBClient.insertMany` / `deleteMany(ids:)` use `#if !BLAZEDB_LINUX_CORE` → `insertBatch` / batch delete on Apple, else a loop of individual ops. Public API comments still describe optimized batching. `Docs/GettingStarted/LINUX_PLATFORM_MODEL.md` tells migrators to replace `insertBatch` with insert loops — so collection-level batch gaps are partly documented, but **client `insertMany` silently loses batch durability amortization on Linux**. Keep measurement under #291; surface as a comment on #51 rather than a sixth issue in the filing pass.
+Filed as **#312**; measurement remains under #291; Tier1/CI contract remains #51.
 
-### Filing pass (post-approval)
+### Filing pass (complete)
 
-Planned new issues (≤5): vacuum closed-store resume; close/write race; soft-delete/count contract; BlazeDBC handle lifecycle; rawDump unsynchronized (proven: `indexMap` iteration + `readPageWithOverflow` off `collection.queue`).
+First wave: #295–#299. Cap-removed wave: #304–#312. See table above.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # BlazeDB
 
-BlazeDB is an encrypted embedded document database written in Swift. It runs inside your process, stores data locally, and does not require a separate database server or network connection.
+BlazeDB is a Swift-native, encrypted embedded document database for local applications: typed models, transactions, WAL recovery, CLI tooling, and a stable C ABI, single-process by design.
 
-It is intended for applications that need private local persistence, typed Swift models, transactions, and inspection tooling without operating a separate database service.
+It runs inside your process, stores data locally, and does not require a separate database server or network connection. It is intended for apps that need private local persistence and inspection tooling without operating a database service. “Local” here means on-device / in-process storage — not a multiplayer sync or distributed-replica product.
 
 You can use BlazeDB from Swift applications, from the `blazedb` CLI, or through its documented C ABI. Published C symbols and signatures follow the compatibility rules defined in the ABI documentation. The primary open-source product is the embedded Swift engine. The C ABI is one way to reach that same engine, not a replacement for the Swift product story.
 
@@ -36,6 +36,28 @@ See [Compatibility](Docs/COMPATIBILITY.md) for minimum versions and support deta
 ### Guarantees and boundaries
 
 BlazeDB’s public database-opening APIs require a password, and persisted data is encrypted at rest with AES-GCM. Durability for the default client path is WAL-backed; see [Durability Mode Support](Docs/Status/DURABILITY_MODE_SUPPORT.md) for modes, fsync behavior, and recovery details. The engine is single-process oriented. Multi-writer and network filesystem behavior are not the primary design target.
+
+### Current engineering focus
+
+Near-term correctness and packaging work (not a feature laundry list):
+
+- Crash-recovery correctness
+- Lifecycle and concurrency hardening
+- Cache / isolation correctness across open databases
+- CLI consistency and diagnostics
+- Linux and C ABI packaging
+
+The [issue tracker](https://github.com/Mikedan37/BlazeDB/issues) includes verified defects, contributor tasks, documentation work, and deferred platform improvements. **Not every open issue is a release blocker.** Use labels to navigate:
+
+| Label / filter | Meaning |
+|----------------|---------|
+| [`good first issue`](https://github.com/Mikedan37/BlazeDB/labels/good%20first%20issue) | Bounded docs/tooling for new contributors |
+| [`help wanted`](https://github.com/Mikedan37/BlazeDB/labels/help%20wanted) | Maintainer-backed outside contributions |
+| [`durability`](https://github.com/Mikedan37/BlazeDB/labels/durability) / [`concurrency`](https://github.com/Mikedan37/BlazeDB/labels/concurrency) / [`High Priority`](https://github.com/Mikedan37/BlazeDB/labels/High%20Priority) | Maintainer-owned correctness |
+| [`needs design`](https://github.com/Mikedan37/BlazeDB/labels/needs%20design) | Contract decision before coding |
+| Experimental / later | Android, KMM, deferred sync — see [Compatibility](Docs/COMPATIBILITY.md) and [ROADMAP](ROADMAP.md) |
+
+Details: [ISSUE_GUIDE](Docs/Contributing/ISSUE_GUIDE.md) · [ROADMAP](ROADMAP.md). Forensic audits live under [Docs/Product/](Docs/Product/) for serious contributors; they are not the first-time product path.
 
 ---
 
@@ -282,10 +304,7 @@ Distributed sync, discovery, server paths, and full telemetry packaging are outs
 
 ## Roadmap
 
-See [ROADMAP.md](ROADMAP.md) for current priorities and exploratory work.
-Planned items are directional and are not release guarantees.
-
-Near-term direction includes contributor safety for storage changes, on-disk compatibility fixtures, truthful Go packaging (sources + CI, then a versioned module), and additive C ABI evolution such as iterators. Evidence: [Docs/Product/PRODUCT_AUDIT.md](Docs/Product/PRODUCT_AUDIT.md).
+See [ROADMAP.md](ROADMAP.md) for Now / Next priorities. Planned items are directional and are not release guarantees. For how open issues relate to release risk, see [Current engineering focus](#current-engineering-focus) above. Maintainer evidence and audits: [Docs/Product/](Docs/Product/).
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,6 +11,20 @@ Use milestones or GitHub issues for concrete release commitments. Use this docum
 | [`ROADMAP_BACKLOG.md`](Docs/Product/ROADMAP_BACKLOG.md) | Verified gaps worth retaining (not a public Now list) |
 | [`PRODUCT_AUDIT.md`](Docs/Product/PRODUCT_AUDIT.md) | Full evidence and inventory |
 
+## Current engineering focus
+
+Correctness and packaging ahead of feature expansion:
+
+- Crash-recovery correctness ([#277](https://github.com/Mikedan37/BlazeDB/issues/277))
+- Lifecycle / concurrency hardening (recent: #278/#279/#295/#296 closed)
+- Cache / isolation across databases ([#306](https://github.com/Mikedan37/BlazeDB/issues/306), [#280](https://github.com/Mikedan37/BlazeDB/issues/280), [#307](https://github.com/Mikedan37/BlazeDB/issues/307))
+- API contract decisions ([#297](https://github.com/Mikedan37/BlazeDB/issues/297), [#309](https://github.com/Mikedan37/BlazeDB/issues/309)) and CLI secret handling ([#310](https://github.com/Mikedan37/BlazeDB/issues/310))
+- Linux and C ABI packaging ([#51](https://github.com/Mikedan37/BlazeDB/issues/51), [#265](https://github.com/Mikedan37/BlazeDB/issues/265), [#312](https://github.com/Mikedan37/BlazeDB/issues/312))
+
+The tracker mixes verified defects, contributor tasks, documentation work, and deferred platform improvements. **Not every open issue is a release blocker.** See [ISSUE_GUIDE](Docs/Contributing/ISSUE_GUIDE.md) for label navigation (`good first issue`, `help wanted`, `needs design`, durability/concurrency).
+
+Suggested engineering sequence: **#277 → #306 (isolation) → #297/#309 contracts → #310 → measurement (#291) → amortize (#276)**.
+
 ## Now
 
 Work that should happen next because it reduces breakage, overclaim, or contributor risk.


### PR DESCRIPTION
## Summary
- Safer product one-liner: local applications (not “local-first” sync baggage)
- README + ROADMAP “Current engineering focus” and issue-bucket navigation
- ISSUE_GUIDE: how to read the open issue count
- NEXT_ENGINEERING_AUDIT / ISSUE_TRACKER_AUDIT: filing status refresh (#304–#312, closed #278/#279)

## Test plan
- [x] Docs-only change; no product code
- [x] Rebased onto latest `origin/main` before push
- [ ] Spot-check README opening + engineering-focus table render on GitHub