### PR TITLE
docs: clarify WAL durability wording

### DIFF
--- a/Docs/Status/DURABILITY_MODE_SUPPORT.md
+++ b/Docs/Status/DURABILITY_MODE_SUPPORT.md
@@ -15,7 +15,7 @@ For the default `BlazeDBClient` path, durability is provided by the **legacy bin
 - **Write ordering**
 - For each page write, the encrypted page image is appended to the binary WAL **before** the main data file is updated.
 - WAL entries may be appended with deferred durability and made durable at a later explicit sync boundary; a page write is considered committed only after its WAL data reaches that durability boundary.
-- The main file is then written and fsync’d.
+- The corresponding main-file writes may occur before that boundary; `PageStore.synchronize()` fsyncs the WAL first and then the main data file before catalog or metadata publication.
 - **Crash recovery**
 - On open, `PageStore` replays any remaining WAL entries and reapplies the corresponding page images to the main file.
 - WAL replay is idempotent for committed streams: reapplying the same committed WAL sequence converges to a single final state.

--- a/Docs/Status/DURABILITY_MODE_SUPPORT.md
+++ b/Docs/Status/DURABILITY_MODE_SUPPORT.md
@@ -14,7 +14,7 @@ For the default `BlazeDBClient` path, durability is provided by the **legacy bin
 
 - **Write ordering**
 - For each page write, the encrypted page image is appended to the binary WAL **before** the main data file is updated.
-- The WAL entry is fsync’d to disk before the page write is considered committed.
+- WAL entries may be appended with deferred durability and made durable at a later explicit sync boundary; a page write is considered committed only after its WAL data reaches that durability boundary.
 - The main file is then written and fsync’d.
 - **Crash recovery**
 - On open, `PageStore` replays any remaining WAL entries and reapplies the corresponding page images to the main file.


### PR DESCRIPTION
Summary:
- clarify the WAL durability wording in DURABILITY_MODE_SUPPORT.md
- align wording with the deferred append/sync behavior observed in source references

Validation:
- git diff --check
- static source-reference inspection

Closes #293