### PR TITLE
chore(ci): rename Android PR Gate jobs to build / run / package

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -11,7 +11,9 @@ Checkouts use **`fetch-depth: 0`**.
 | `macOS 15 — build, CLI, tests` | yes |
 | `Apple platforms — cross-compile BlazeDBCore` | yes (iOS, watchOS, tvOS; visionOS best-effort) |
 | `Linux (Swift 6.2) — core + Tier 0` | yes |
-| `Android — BlazeDBCore cross-compile (OSS Swift 6.3)` | yes |
+| `Android — Cross-Compile` | yes |
+| `KMM Android — x86_64 Emulator Runtime` | yes |
+| `KMM Android — arm64 Artifact Packaging` | yes |
 
 **Deleted from the repo (must not return on `main`):** `oss-readiness-evidence.yml`, duplicate CI files. If GitHub still shows “OSS Readiness Evidence” or “Build & Test”, `main` has not picked up the latest workflow commits — merge and push.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,7 +251,7 @@ jobs:
           retention-days: 7
 
   android-cross-compile:
-    name: Android — cross-compile BlazeDBAndroidBridge
+    name: Android — Cross-Compile
     runs-on: ubuntu-22.04
     timeout-minutes: 60
 
@@ -390,7 +390,7 @@ jobs:
           retention-days: 7
 
   kmm-android-emulator:
-    name: KMM Android — emulator runtime (Linux KVM)
+    name: KMM Android — x86_64 Emulator Runtime
     runs-on: ubuntu-latest
     needs: android-cross-compile
     timeout-minutes: 60
@@ -468,7 +468,7 @@ jobs:
           retention-days: 7
 
   kmm-android-packaging:
-    name: KMM Android — packaging (macOS)
+    name: KMM Android — arm64 Artifact Packaging
     runs-on: macos-15
     needs: android-cross-compile
     timeout-minutes: 45

--- a/Docs/Testing/CI_AND_TEST_TIERS.md
+++ b/Docs/Testing/CI_AND_TEST_TIERS.md
@@ -89,15 +89,15 @@ In short: the nightly workflow optimizes for coverage visibility and time-to-sig
 - Runs `./Scripts/ci-apple-cross-compile.sh`: compile-only `swift build --target BlazeDBCore` for **iOS** (simulator + device), **watchOS** (simulator + device), and **tvOS** (simulator + device). **visionOS** is attempted but may be non-blocking when SwiftPM does not yet recognize `xros` triples during dependency resolution (`⚠️ visionOS skipped (SwiftPM/toolchain)` in the job summary); unexpected visionOS **compile** failures still fail CI. Set `BLAZEDB_APPLE_REQUIRE_VISIONOS=1` to require visionOS success once toolchains catch up. The script asserts `Package.swift` `platforms:` are covered — add targets there when Apple ships another OS.
 - **Compile-only:** no XCTest or simulator runtime in this job. macOS-hosted Tier0/Tier1 remain the behavioral gate; optional Phase 2 is nightly iOS Simulator Tier0 after this lane is stable.
 
-- **Secondary (blocking):** `Android — cross-compile BlazeDBAndroidBridge`
+- **Secondary (blocking):** `Android — Cross-Compile`
 - Runner: `ubuntu-22.04`
 - OSS Swift **6.3.2** via `./Scripts/install-android-swift.sh` (must match Android SDK bundle in `Scripts/android-swift-config.sh` — **not** Xcode Swift)
 - Caches `.build`, `~/.swiftpm/swift-sdks`, and NDK under the SDK bundle
 - Runs `./Scripts/ci-android-cross-compile.sh` (arm64 + x86_64 `libBlazeDBAndroidBridge.so`)
 - Verifies both `.build/aarch64-unknown-linux-android28/debug/` and `.build/x86_64-unknown-linux-android28/debug/` bridge libs
 - **KMM Android compile-only (Linux):** Java 17 + `./Scripts/setup-android-gradle-sdk-linux.sh`, then `./gradlew :shared:compileDebugKotlinAndroid`. Uploads native libs for downstream KMM jobs.
-- **KMM Android emulator (Linux KVM):** Job `kmm-android-emulator` — `ubuntu-latest` + `reactivecircus/android-emulator-runner` (`arch: x86_64`) + `./Scripts/ci-kmm-android-emulator-smoke.sh` (`connectedDebugAndroidTest` with `-PBLAZEDB_ANDROID_ABIS=x86_64`).
-- **KMM Android packaging (macOS):** Job `kmm-android-packaging` — stages arm64 native libs + `./Scripts/package-kmm-artifacts.sh`. See [KMM CI (Android + iOS)](#kmm-ci-android--ios).
+- **`KMM Android — x86_64 Emulator Runtime`:** Job `kmm-android-emulator` — `ubuntu-latest` + Linux KVM + `reactivecircus/android-emulator-runner` (`arch: x86_64`) + `./Scripts/ci-kmm-android-emulator-smoke.sh` (`connectedDebugAndroidTest` with `-PBLAZEDB_ANDROID_ABIS=x86_64`).
+- **`KMM Android — arm64 Artifact Packaging`:** Job `kmm-android-packaging` — macOS stages arm64 native libs + `./Scripts/package-kmm-artifacts.sh`. See [KMM CI (Android + iOS)](#kmm-ci-android--ios).
 
 - `.github/workflows/tag-probe.yml`
 - Trigger: **manual** (`workflow_dispatch`) only
@@ -174,8 +174,9 @@ Kotlin Multiplatform integration lives in `Examples/android/shared` (`expect cla
 | Job | Platform | CI step | Runtime? |
 | --- | --- | --- | --- |
 | `macOS 15 — build, CLI, tests` | iOS (simulator) | `./Scripts/build-kmm-ios-bridge.sh` → `:shared:linkDebugFrameworkIosSimulatorArm64` + `:shared:iosSimulatorArm64Test` | **Yes** — `BlazeDBRuntimeSmokeTest` (`open` / `put` / `query`) |
-| `Android — cross-compile BlazeDBAndroidBridge` | Android (JVM/Kotlin) | `:shared:compileDebugKotlinAndroid` after OSS Swift cross-compile | Compile-only on Linux |
-| `KMM Android — emulator runtime + packaging` | Android (arm64 emulator) | `ci-kmm-android-emulator-smoke.sh` + `package-kmm-artifacts.sh` | **Yes** — instrumentation test (`open` / `put` / `query`) |
+| `Android — Cross-Compile` | Android (native + JVM/Kotlin) | OSS Swift cross-compile + `:shared:compileDebugKotlinAndroid` | Compile-only on Linux |
+| `KMM Android — x86_64 Emulator Runtime` | Android (x86_64 emulator, Linux KVM) | `ci-kmm-android-emulator-smoke.sh` | **Yes** — instrumentation test (`open` / `put` / `query`) |
+| `KMM Android — arm64 Artifact Packaging` | Android (arm64 packaging, macOS) | `package-kmm-artifacts.sh` | No — AAR / native `.so` / packaging verify |
 
 ### What CI does **not** prove (local scripts)
 
@@ -310,7 +311,7 @@ Use precise language so status and dashboards do not blur the PR gate with deepe
 | **PR3 transitional companions** | `BlazeDB_Tier2_Extended`, `BlazeDB_Tier3_Heavy_Perf`; temporary bridge targets slated for PR4 filesystem/target normalization. |
 | **Nightly Confidence (daily)** | `nightly.yml`: macOS Tier2 strict, clean checkout, README quickstart, Tier0 TSan; **Linux** `linux-tier1` + `linux-tier2-core` only (no Linux Tier0 nightly — covered in PR `ci.yml`). |
 | **Deep Validation (weekly)** | `deep-validation.yml` (weekly, Sun 03:00 UTC + manual), **delta-only**: **`deep-macos-tier3-heavy-destructive`**, **`deep-macos-tsan-tier1`**, **`deep-linux-tier2-extended`**, **`deep-linux-tier3-heavy`**, **`deep-linux-tier3-heavy-profile`**, **`deep-linux-tier3-heavy-perf`** — does not re-run PR/nightly tiers. |
-| **KMM PR gate** | iOS: `iosSimulatorArm64Test`. Android compile (Linux). Android emulator runtime (Linux KVM `kmm-android-emulator`). Android packaging (macOS `kmm-android-packaging`). |
+| **KMM PR gate** | iOS: `iosSimulatorArm64Test`. Progression: `Android — Cross-Compile` → `KMM Android — x86_64 Emulator Runtime` (`kmm-android-emulator`) → `KMM Android — arm64 Artifact Packaging` (`kmm-android-packaging`). |
 | **Canonical Tier1** | `BlazeDB_Tier1` (single canonical Tier1 target). |
 
 Inventory/bootstrap code may still bucket all three SwiftPM modules under a single **`T1`** label for file-level manifests; that is a storage convenience. **Human-facing** summaries (CI names, release notes, team chat) should use the table above, not a vague “T1 passed.”


### PR DESCRIPTION
**Quick rules:** [CONTRIBUTING.md — PR expectations](CONTRIBUTING.md#pr-expectations) (one branch, `preflight`, list commands, docs with behavior, squash merge).

## Summary

- Rename Android/KMM PR Gate **display names** so the checks UI shows three distinct contracts instead of near-duplicate “Android” labels:
  - `Android — Cross-Compile`
  - `KMM Android — x86_64 Emulator Runtime`
  - `KMM Android — arm64 Artifact Packaging`
- Align `Docs/Testing/CI_AND_TEST_TIERS.md` and `.github/workflows/README.md` with those names (and split the old “emulator + packaging” docs row into two rows).

## Scope

- In scope: job `name:` fields in `.github/workflows/ci.yml`; CI docs that quote those display names.
- Out of scope: job IDs (`android-cross-compile`, `kmm-android-emulator`, `kmm-android-packaging`), scripts, path filters, or changing what each job runs.

## Branch protection / required checks

Renaming a GitHub Actions job changes the reported **check context**. Before merge, confirm required-status configuration still matches.

Checked for this repo:

```bash
gh api repos/Mikedan37/BlazeDB/branches/main/protection/required_status_checks
# → HTTP 404 Branch not protected

gh api repos/Mikedan37/BlazeDB/rulesets
# → []
```

No classic branch protection and no rulesets currently pin the old check names. If required checks are added later, pin the **new** display names above—not the previous `emulator runtime (Linux KVM)` / `packaging (macOS)` strings.

## Validation

```bash
pwd && git remote -v && git branch --show-current && git status --short
rg -n 'name: (Android —|KMM Android —)' .github/workflows/ci.yml
git diff --check
gh api repos/Mikedan37/BlazeDB/branches/main/protection/required_status_checks
gh api repos/Mikedan37/BlazeDB/rulesets
```

## Checklist

- [x] One branch = one concern
- [x] `git status` / `git diff` reviewed for containment
- [x] Docs updated in this PR if behavior or public usage changed (CI job display-name docs)
- [x] `Docs/SYSTEM_MAP.md` / `Docs/Testing/CI_AND_TEST_TIERS.md` updated **only if** this PR changes material surface, architecture, or CI/tier semantics
- [x] Storage/WAL/encryption/recovery changes: N/A
- [ ] CI checks pass