### PR TITLE
fix(query): treat missing field as matching notEquals

### DIFF
--- a/BlazeDB/Query/QueryBuilder.swift
+++ b/BlazeDB/Query/QueryBuilder.swift
@@ -145,14 +145,19 @@ public final class QueryBuilder: @unchecked Sendable {
         return self
     }
     
-    /// Filter records where field does not equal value
+    /// Filter records where field does not equal value.
+    ///
+    /// A missing field is treated as matching `notEquals` — i.e. a record
+    /// with no `field` at all counts as "not equal to `value`", consistent
+    /// with `whereNil` semantics. This is the deliberate asymmetry with
+    /// `where(_:equals:)`, which treats a missing field as a non-match.
     @discardableResult
     public func `where`(_ field: String, notEquals value: BlazeDocumentField) -> QueryBuilder {
         BlazeLogger.debug("Query: WHERE \(field) != \(value)")
         filterFields.insert(field)
         filterDescriptors.append(FilterDescriptor(field: field, operation: "ne", value: value))
         filters.append { record in
-            guard let fieldValue = record.storage[field] else { return false }
+            guard let fieldValue = record.storage[field] else { return true }
             return !fieldsEqual(fieldValue, value)
         }
         return self

--- a/BlazeDBTests/Tier0Core/CoreCorrectness/QueryNotEqualsMissingFieldTests.swift
+++ b/BlazeDBTests/Tier0Core/CoreCorrectness/QueryNotEqualsMissingFieldTests.swift
@@ -1,0 +1,94 @@
+//
+//  QueryNotEqualsMissingFieldTests.swift
+//  BlazeDBTests — #327: where(notEquals:) treats missing field as non-match
+//
+//  A missing field must match `notEquals`, consistent with `whereNil`
+//  semantics: absent is "not equal" to any given value. This mirrors
+//  `where(_:equals:)`'s (correct, unchanged) behavior of treating a missing
+//  field as a non-match — the two are deliberately asymmetric.
+//
+
+import XCTest
+#if canImport(BlazeDBCore)
+@testable import BlazeDBCore
+#else
+@testable import BlazeDB
+#endif
+
+final class QueryNotEqualsMissingFieldTests: XCTestCase {
+    private var dbURL: URL!
+    private var db: BlazeDBClient!
+
+    override func setUp() {
+        super.setUp()
+        dbURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("NotEqualsMissing-\(UUID().uuidString).blazedb")
+        db = try! BlazeDBClient(
+            name: "NotEqualsMissing",
+            fileURL: dbURL,
+            password: "NotEqualsMissing-Pass_123!"
+        )
+    }
+
+    override func tearDown() {
+        try? db.close()
+        let base = dbURL.deletingPathExtension()
+        for ext in ["blazedb", "meta", "wal", "salt", "indexes"] {
+            try? FileManager.default.removeItem(at: base.appendingPathExtension(ext))
+        }
+        try? FileManager.default.removeItem(at: dbURL)
+        db = nil
+        dbURL = nil
+        super.tearDown()
+    }
+
+    /// #327 reproduction: a record with no `status` field at all must match
+    /// `notEquals: .string("archived")`, alongside a record whose `status`
+    /// is present but unequal. A record whose `status` equals the given
+    /// value must still be excluded.
+    func testNotEquals_MissingField_MatchesAlongsidePresentUnequal() throws {
+        _ = try db.insert(BlazeDataRecord(["name": .string("a")])) // no status field
+        _ = try db.insert(BlazeDataRecord(["name": .string("b"), "status": .string("archived")]))
+        _ = try db.insert(BlazeDataRecord(["name": .string("c"), "status": .string("active")]))
+
+        let rows = try db.query()
+            .where("status", notEquals: .string("archived"))
+            .execute()
+
+        let names = Set(try rows.records.compactMap { $0.storage["name"]?.stringValue })
+        XCTAssertEqual(names, ["a", "c"])
+    }
+
+    func testNotEquals_PresentEqualValue_IsExcluded() throws {
+        _ = try db.insert(BlazeDataRecord(["name": .string("archived-one"), "status": .string("archived")]))
+
+        let rows = try db.query()
+            .where("status", notEquals: .string("archived"))
+            .execute()
+
+        XCTAssertTrue(rows.isEmpty)
+    }
+
+    func testNotEquals_PresentUnequalValue_IsIncluded() throws {
+        _ = try db.insert(BlazeDataRecord(["name": .string("active-one"), "status": .string("active")]))
+
+        let rows = try db.query()
+            .where("status", notEquals: .string("archived"))
+            .execute()
+
+        XCTAssertEqual(rows.count, 1)
+        XCTAssertEqual(try rows.records.first?.storage["name"]?.stringValue, "active-one")
+    }
+
+    /// Scope guard: `equals` missing-field behavior is unchanged by this fix
+    /// (still a non-match).
+    func testEquals_MissingField_IsStillExcluded() throws {
+        _ = try db.insert(BlazeDataRecord(["name": .string("no-status")])) // no status field
+
+        let rows = try db.query()
+            .where("status", equals: .string("archived"))
+            .execute()
+
+        XCTAssertTrue(rows.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary

- **What changed?** `where(_:notEquals:)` now treats a record that has no value for the queried field as a match, instead of excluding it. The missing-field guard returns `true` rather than `false`, and the method's doc comment states the behaviour explicitly.
- **Why was it needed?** Fixes #327. `where("status", notEquals: .string("archived"))` was dropping records with no `status` field at all, even though "missing ≠ archived". `equals` returning `false` for a missing field is correct; extending that same reasoning to `notEquals` was the asymmetry.

## Scope

- **In scope:** the `notEquals` missing-field predicate, its doc comment, and four unit tests.
- **Out of scope:** `equals` / `greaterThan` / `lessThan` missing-field rules, left untouched per the scope boundary in #327. One of the new tests asserts that `equals` still excludes a missing field, so that boundary is pinned rather than assumed.

## Validation

List **exact** commands you ran (copy-paste from your terminal):

```bash
BLAZEDB_TEST_SCOPE=tier0 swift test --filter BlazeDB_Tier0
# Executed 213 tests, with 9 tests skipped and 0 failures — includes the 4 new tests

BLAZEDB_TEST_SCOPE=tier0 swift test --filter QueryNotEqualsMissingFieldTests
# Executed 4 tests, 0 failures

./Scripts/preflight.sh
# rc=1 — swift build OK; Tier 0 xunit records tests="213" failures="0" errors="0";
# run then aborts in Scripts/verify_execution_coverage.py
```

`./Scripts/preflight.sh` does not currently reach a clean exit on Linux, for two reasons that are **pre-existing and unrelated to this PR** — a fresh clone of `main` at `0cd09a2` fails the same way, earlier. I filed both rather than working around them:

- #341 — `RLSEnforcementClientTests.swift` is missing a closing paren, so any build including Tier 1 fails
- #342 — `verify_execution_coverage.py` calls `xcodebuild` unconditionally, so preflight cannot pass on Linux

I checked ours-vs-yours before filing: the offending file is byte-identical to `main` and untouched by this commit, and the Tier 0 gate that actually exercises this change passes.

Regression test bite check — reverting only `QueryBuilder.swift` and re-running the new suite fails exactly one test:

```
QueryNotEqualsMissingFieldTests.testNotEquals_MissingField_MatchesAlongsidePresentUnequal :
XCTAssertEqual failed: ("["c"]") is not equal to ("["c", "a"]")
```

The three control cases (equals-still-excludes, present-equal, present-unequal) pass with or without the fix, as they should.

Environment: Swift 6.2.4 on Debian 13 x86_64. The macOS and Apple-platform jobs cannot run on this machine, so I have not exercised them.

## Checklist

- [x] One branch = one concern
- [x] `git status` / `git diff` reviewed for containment — 2 files, +101/-2
- [x] Docs updated in this PR if behavior or public usage changed — the behaviour is documented on the `notEquals` doc comment. I searched `Docs/` for existing statements of the old semantics and found none: `Docs/Guides/NULL_HANDLING.md` covers `whereNil`/`whereNotNil` only and never mentions `notEquals`, and the other hits are bare signatures or usage examples that do not describe missing-field behaviour.
- [x] `Docs/SYSTEM_MAP.md` / `Docs/Testing/CI_AND_TEST_TIERS.md` updated **only if** material — not triggered. SYSTEM_MAP's own criteria exclude "bug fixes... that do not change what is shipped or supported"; no public API added, removed or renamed. No workflow, job, tier meaning or test-lane change.
- [x] Storage/WAL/encryption/recovery changes — not applicable; this is an in-memory query predicate and touches no on-disk format, WAL, encryption, or recovery path.
- [x] CI checks pass — not yet observable; this is a fork PR and I will confirm once the run completes.

Generated by Claude Opus 5 (brief, review), Claude Sonnet 5 (implementation, testing)
