### PR TITLE
fix(scripts): guard xcodebuild presence in coverage metadata

### DIFF
--- a/Scripts/verify_execution_coverage.py
+++ b/Scripts/verify_execution_coverage.py
@@ -12,6 +12,7 @@ import argparse
 import os
 import json
 import re
+import shutil
 import subprocess
 import sys
 import xml.etree.ElementTree as ET
@@ -151,7 +152,11 @@ def main() -> int:
         "runExitCode": run_proc.returncode,
         "environment": {
             "swiftVersion": run(["swift", "--version"], root).stdout.strip(),
-            "xcodeVersion": run(["xcodebuild", "-version"], root).stdout.strip(),
+            "xcodeVersion": (
+                run(["xcodebuild", "-version"], root).stdout.strip()
+                if shutil.which("xcodebuild")
+                else "unavailable"
+            ),
             "arch": run(["uname", "-m"], root).stdout.strip(),
             "numWorkers": args.num_workers,
             "tmpdir": os.environ.get("TMPDIR", ""),


### PR DESCRIPTION
## Summary

- **What changed?** `Scripts/verify_execution_coverage.py` now checks whether `xcodebuild` is on `PATH` before shelling out to it, recording `"unavailable"` in the environment metadata instead of raising.
- **Why was it needed?** Fixes #342. The call was unconditional, so on any machine without Xcode — including Linux, which has its own CI lane here — it raised `FileNotFoundError` and failed `preflight` *after* the tests had already passed. The failure was in metadata collection, not in any test result.

## Scope

- **In scope:** the single `xcodeVersion` field in the `environment` payload, plus the `shutil` import.
- **Out of scope:** the neighbouring `swift --version` and `uname -m` calls, which are portable and untouched. No change to test selection, artifact layout, or exit-code handling.

## Validation

List **exact** commands you ran (copy-paste from your terminal):

```bash
./Scripts/preflight.sh
# rc=0 — "=== Tier 0 complete ===" / "=== Preflight complete ==="
# Tier 0 ran to [209/209]
```

Evidence the guard actually fired, from the emitted artifact:

```
.artifacts/quick/20260727-190818/BlazeDB_Tier0.execution.json
  "xcodeVersion": "unavailable"
```

`xcodebuild` is genuinely absent on this machine (`shutil.which("xcodebuild")` → `None`, `swift` present at `/usr/bin/swift`), so this is the real missing-tool path rather than a simulated one.

Environment: Swift 6.2.4 on Debian 13 x86_64, no Xcode. The macOS and Apple-platform jobs cannot run here and were not exercised.

## Checklist

- [x] One branch = one concern
- [x] `git status` / `git diff` reviewed for containment — 1 file, +5/-1
- [x] Docs updated in this PR if behavior or public usage changed — not applicable; this changes only a metadata field's value on machines lacking Xcode, with no public API or documented behaviour affected
- [x] `Docs/SYSTEM_MAP.md` / `Docs/Testing/CI_AND_TEST_TIERS.md` updated **only if** material — not triggered. No workflow, job, tier meaning or test-lane change; SYSTEM_MAP's own criteria exclude fixes that do not change what is shipped or supported.
- [x] Storage/WAL/encryption/recovery changes — not applicable; this is a build-tooling script.
- [ ] CI checks pass — not yet observable; this is a fork PR and I will confirm once the run is approved.

Generated by Claude Opus 5 (brief, review), Kimi K2.7 Code (implementation)