### PR TITLE
fix(tests): close deleteMany closure call in RLS test

### DIFF
--- a/BlazeDBTests/Tier1Core/Security/RLSEnforcementClientTests.swift
+++ b/BlazeDBTests/Tier1Core/Security/RLSEnforcementClientTests.swift
@@ -363,7 +363,7 @@ final class RLSEnforcementClientTests: XCTestCase {
         let deleted = try db.deleteMany(where: { record in
             observedTitles.append(record.storage["title"]?.stringValue ?? "")
             return true
-        }
+        })
 
         XCTAssertEqual(deleted, 1)
         XCTAssertEqual(observedTitles, ["visible"])


### PR DESCRIPTION
## Summary

- **What changed?** Added the missing `)` that closes the `deleteMany(where:)` call in `testDeleteManyPredicateCannotObserveRowsDeniedBySelectRLS`. One character.
- **Why was it needed?** Fixes #314. The closure is opened and never closed, so `BlazeDBTests/Tier1Core/Security/RLSEnforcementClientTests.swift` does not compile and takes the whole `BlazeDB_Tier1` test target with it.

## Scope

- **In scope:** the single unclosed call in that one test.
- **Out of scope:** everything else. The test's name, structure and assertions are unchanged — this only makes the existing test compile.

## Validation

List **exact** commands you ran (copy-paste from your terminal):

```bash
swift build --build-tests
# WITH the fix:    rc=0 — "Build complete! (88.19s)", BlazeDB_Tier1 among the compiled targets

git checkout upstream/main -- BlazeDBTests/Tier1Core/Security/RLSEnforcementClientTests.swift
swift build --build-tests
# WITHOUT the fix: rc=1
#   RLSEnforcementClientTests.swift:366:10: error: expected ',' separator
#   RLSEnforcementClientTests.swift:368:24: error: use of local variable 'deleted' before its declaration
#   RLSEnforcementClientTests.swift:368:9: error: extra argument in call
```

Note `swift build --build-tests` **without** `BLAZEDB_TEST_SCOPE=tier0` is what exercises this — `Package.swift:5` reads that variable and `Package.swift:195` only appends the `BlazeDB_Tier1` target when it is not `tier0`, so a tier0-scoped build never compiles this file. That is also why the Linux PR Gate stays green over it.

Environment: Swift 6.2.4 on Debian 13 x86_64. The macOS and Apple-platform jobs cannot run here and were not exercised.

## Checklist

- [x] One branch = one concern
- [x] `git status` / `git diff` reviewed for containment — 1 file, +1/-1
- [x] Docs updated in this PR if behavior or public usage changed — not applicable; this is a compile fix to an existing test, no behaviour or public surface changes
- [x] `Docs/SYSTEM_MAP.md` / `Docs/Testing/CI_AND_TEST_TIERS.md` updated **only if** material — not triggered. No tier meaning, workflow or lane change; SYSTEM_MAP's criteria exclude fixes that do not change what is shipped.
- [x] Storage/WAL/encryption/recovery changes — not applicable.
- [ ] CI checks pass — not yet observable; this is a fork PR and I will confirm once the run is approved.

Generated by Claude Opus 5 (brief, review, verification), Claude Sonnet 5 (implementation)