### PR TITLE
docs: finish WHY_NOT_SQLITE platform and capability corrections

### DIFF
--- a/Docs/Architecture/ARCHITECTURE_DETAILED.md
+++ b/Docs/Architecture/ARCHITECTURE_DETAILED.md
@@ -28,7 +28,7 @@ The initial motivation came from needing predictable, encrypted, local-first sto
 
 A custom storage engine made sense because the constraints were specific: sub-millisecond query latency, deterministic encoding for content-addressable storage, per-page encryption without compromising performance, and schema flexibility without migration complexity. These requirements didn't align well with existing systems.
 
-The custom binary format (BlazeBinary) emerged from benchmarking JSON, CBOR, and MessagePack. Swift's type system enabled optimizations that generic formats couldn't provide—common field compression, inline string encoding, and deterministic key sorting. The result is approximately 53% smaller than JSON and roughly 48% faster to encode/decode.
+The custom binary format (BlazeBinary) emerged from benchmarking JSON, CBOR, and MessagePack. Swift's type system enabled optimizations that generic formats couldn't provide: common field compression, inline string encoding, and deterministic key sorting. The result is approximately 53% smaller than JSON and roughly 48% faster to encode/decode.
 
 Key constraints that shaped the architecture: latency requirements demanded careful attention to hot paths, encryption needed to be per-page to enable efficient garbage collection, concurrency required MVCC to avoid read-write contention, and determinism was necessary for reproducible builds and content-addressable storage. These constraints led to a layered architecture with clear separation of concerns, making the system easier to debug and optimize.
 
@@ -139,9 +139,9 @@ BlazeDB makes explicit tradeoffs to optimize for its target use cases:
 
 **Query Planner:** Uses rule-based heuristics rather than a cost-based optimizer. This works well for common patterns but may not choose optimal plans for complex queries. A cost-based optimizer is planned but not yet implemented.
 
-**Distributed Consensus:** No distributed consensus, automatic sharding, or multi-master replication. BlazeDB is a single primary database with optional sync capabilities. This is intentional—distributed consensus is a different problem space.
+**Distributed Consensus:** No distributed consensus, automatic sharding, or multi-master replication. BlazeDB is a single primary database with optional sync capabilities. This is intentional: distributed consensus is a different problem space.
 
-**Platform support:** macOS and Linux are runtime-tested in CI; other Apple platforms are compile-tested; Android/KMM is experimental. Do not treat “optimized for Apple Silicon” as a measured claim — see [Benchmarks](../Benchmarks/README.md) and [COMPATIBILITY](../COMPATIBILITY.md).
+**Platform support:** macOS and Linux are runtime-tested in CI; other Apple platforms are compile-tested; Android/KMM is experimental. Do not treat “optimized for Apple Silicon” as a measured claim. See [Benchmarks](../Benchmarks/README.md) and [COMPATIBILITY](../COMPATIBILITY.md).
 
 **MVCC Storage Overhead:** Multi-version concurrency control can increase storage requirements, especially with long-running read transactions that delay garbage collection. In practice, this hasn't been an issue for typical workloads, but it's a tradeoff to be aware of.
 
@@ -296,14 +296,14 @@ BlazeDB draws inspiration from several well-established systems while making dif
 
 ## Why Not SQLite / Core Data / Realm / LMDB?
 
-> **Authority:** Prefer [`Docs/GettingStarted/WHY_NOT_SQLITE.md`](../GettingStarted/WHY_NOT_SQLITE.md) and [`Docs/COMPATIBILITY.md`](../COMPATIBILITY.md) over this summary. The table below is a short orientation only — not a stopwatch or licensing brief.
+> **Authority:** Prefer [`Docs/GettingStarted/WHY_NOT_SQLITE.md`](../GettingStarted/WHY_NOT_SQLITE.md) and [`Docs/COMPATIBILITY.md`](../COMPATIBILITY.md) over this summary. The table below is a short orientation only, not a stopwatch or licensing brief.
 
 | Feature | BlazeDB | SQLite | Core Data | Realm | LMDB |
 |---------|---------|--------|----------|-------|------|
 | **Encryption** | AES-256-GCM per page at rest (password on public open APIs) | Optional extension | No built-in at-rest cipher | Optional / product-dependent | No |
 | **Schema** | Flexible by default; optional validation + migration APIs | Static SQL schemas + migrations | Model versions + migrations | Object schema + migrations | Schema-less KV |
 | **Concurrency** | Single-process embedded; transactions; MVCC exists but is not the default claim | Multi-connection locking / WAL rules | Context-based | Product-specific | MVCC (mmap) |
-| **Performance** | See measured [Benchmarks](../Benchmarks/README.md) — no “Apple Silicon optimized” slogan here | Mature; workload-dependent | Object-graph overhead varies | Workload-dependent | Very fast mmap KV |
+| **Performance** | See measured [Benchmarks](../Benchmarks/README.md): no “Apple Silicon optimized” slogan here | Mature; workload-dependent | Object-graph overhead varies | Workload-dependent | Very fast mmap KV |
 | **Query Language** | Fluent Swift API (no SQL string engine) | SQL | NSPredicate / SwiftUI fetch patterns | Object query API | Key-value only |
 | **Platform** | macOS/Linux runtime-tested; Apple platforms compile-tested; Android/KMM experimental | Universal (C) | Apple platforms | Cross-platform SDKs (verify current) | Universal (C) |
 | **Dependencies** | Swift package + Crypto where required | Zero (amalgamation) | Foundation / Cocoa | Realm runtime | Zero |
@@ -311,7 +311,7 @@ BlazeDB draws inspiration from several well-established systems while making dif
 | **Best For** | Encrypted Swift-native embedded storage + C ABI | General-purpose embedded SQL | Deep Apple-framework apps | Teams already on Realm | High-performance KV |
 | **Limitations** | Not a SQL engine; sync/server deferred from default OSS | No encryption by default | Apple-centric; migration complexity | Sync/licensing history is not a one-cell story | No rich query language |
 
-**When to choose BlazeDB:** Encryption by default, Swift-native typed access, local tooling, and C ABI embedding — on a support tier you accept ([COMPATIBILITY](../COMPATIBILITY.md)).
+**When to choose BlazeDB:** Encryption by default, Swift-native typed access, local tooling, and C ABI embedding, on a support tier you accept ([COMPATIBILITY](../COMPATIBILITY.md)).
 
 **When to choose SQLite:** Universal portability, SQL, or you do not need encryption-by-default.
 
@@ -524,7 +524,7 @@ graph TB
 Each transaction sees a consistent snapshot of the database at transaction start. Reads never block writes. Writes create new versions; old versions remain accessible to concurrent readers until garbage collection. Conflict detection prevents lost updates.
 
 **Performance Characteristics:**
-Observed 20–100× improvements over naive locking under read-heavy synthetic workloads. Concurrent reads scale linearly with available cores. Write performance depends on conflict rate and garbage collection frequency—in low-conflict scenarios, performance is strong.
+Observed 20–100× improvements over naive locking under read-heavy synthetic workloads. Concurrent reads scale linearly with available cores. Write performance depends on conflict rate and garbage collection frequency. In low-conflict scenarios, performance is strong.
 
 **Garbage Collection:**
 Obsolete versions are collected when no active transactions reference them. Long-running read transactions can delay collection, but in practice this hasn't been an issue. Automatic collection runs periodically; manual triggers available.
@@ -604,10 +604,10 @@ graph TB
 ```
 
 **Key Derivation:**
-User password hashed using Argon2id (memory-hard function) to prevent fast brute force attacks. HKDF expands derived key material to 256-bit encryption key. Key material never stored on disk—if password is lost, data is unrecoverable. This is by design.
+User password hashed using Argon2id (memory-hard function) to prevent fast brute force attacks. HKDF expands derived key material to 256-bit encryption key. Key material never stored on disk. If password is lost, data is unrecoverable. This is by design.
 
 **Encryption:**
-AES-256-GCM provides authenticated encryption. Each page uses a unique nonce to ensure cryptographic safety. Authentication tags detect tampering—modified encrypted pages fail decryption. Replay prevention enforced by rejecting stale or duplicated ciphertexts at record or page level.
+AES-256-GCM provides authenticated encryption. Each page uses a unique nonce to ensure cryptographic safety. Authentication tags detect tampering: modified encrypted pages fail decryption. Replay prevention enforced by rejecting stale or duplicated ciphertexts at record or page level.
 
 GCM mode chosen for speed and single-pass authentication. Per-page nonces ensure identical plaintext produces different ciphertext.
 
@@ -740,7 +740,7 @@ graph TB
 
 ## Cryptographic Architecture
 
-BlazeDB implements two parallel cryptographic pipelines with distinct key lifecycles and threat models. The first pipeline protects data at rest—local database files encrypted on disk using page-level AES-256-GCM. The second pipeline protects data in transit—network sync operations encrypted over secure channels established via ephemeral ECDH key exchange. Both pipelines use well-established primitives: Argon2id for password-based key derivation, HKDF for key expansion and separation, AES-256-GCM for authenticated encryption, and ECDH P-256 for shared secret establishment. On Apple platforms, Secure Enclave provides hardware-backed protection for long-lived storage keys, but not for ephemeral session secrets.
+BlazeDB implements two parallel cryptographic pipelines with distinct key lifecycles and threat models. The first pipeline protects data at rest: local database files encrypted on disk using page-level AES-256-GCM. The second pipeline protects data in transit: network sync operations encrypted over secure channels established via ephemeral ECDH key exchange. Both pipelines use well-established primitives: Argon2id for password-based key derivation, HKDF for key expansion and separation, AES-256-GCM for authenticated encryption, and ECDH P-256 for shared secret establishment. On Apple platforms, Secure Enclave provides hardware-backed protection for long-lived storage keys, but not for ephemeral session secrets.
 
 This separation follows standard secure storage and secure channel patterns. Data at rest keys are derived from user passwords and persist across sessions; data in transit keys are ephemeral, generated per-session, and provide perfect forward secrecy. The design ensures that compromise of one pipeline does not automatically compromise the other, and that different threat surfaces (physical access vs. network interception) are addressed with appropriate cryptographic controls.
 
@@ -752,7 +752,7 @@ Local database encryption protects stored data from physical access, device thef
 
 1. **User Input:** User password or application-provided secret serves as the initial entropy source. This secret is never stored on disk in any form.
 
-2. **Per-Database Salt:** Each database instance uses a unique salt generated at creation time. The salt is stored in the database metadata file (`.meta`) in plaintext—this is safe because salts are public values that prevent rainbow table attacks but do not weaken encryption if exposed.
+2. **Per-Database Salt:** Each database instance uses a unique salt generated at creation time. The salt is stored in the database metadata file (`.meta`) in plaintext. This is safe because salts are public values that prevent rainbow table attacks but do not weaken encryption if exposed.
 
 3. **Argon2id KDF:** The password and salt are fed into Argon2id, a memory-hard key derivation function. Argon2id parameters are tuned to balance security (resistance to GPU/ASIC attacks) with acceptable unlock latency. The output is a strong key material stream, typically 256 bits or more.
 
@@ -781,7 +781,7 @@ Local database encryption protects stored data from physical access, device thef
 
 3. **GCM Decryption:** AES-256-GCM decryption is performed using `db_enc_key`, nonce, ciphertext, and tag.
 
-4. **Tag Verification:** GCM automatically verifies the authentication tag during decryption. If the tag does not match (indicating corruption or tampering), decryption fails immediately with a clear error. This provides integrity protection—modified pages cannot be decrypted.
+4. **Tag Verification:** GCM automatically verifies the authentication tag during decryption. If the tag does not match (indicating corruption or tampering), decryption fails immediately with a clear error. This provides integrity protection: modified pages cannot be decrypted.
 
 5. **Failure Behavior:** Tag mismatches trigger automatic corruption detection. The system attempts metadata rebuild from data pages if possible, or fails with a clear error message if corruption is unrecoverable.
 
@@ -865,7 +865,7 @@ Network sync encryption protects data during transmission between BlazeDB nodes.
 - HKDF-Expand: Derives `sess_enc_key` and `sess_auth_key` using different info parameters
 - These session keys are 256 bits each and are used only for the current session
 
-5. **Key Lifecycle:** Session keys are ephemeral—they exist only in memory for the duration of the connection. They are never written to disk and are cleared from memory when the session ends. This provides perfect forward secrecy: compromise of long-term storage keys does not reveal past session traffic.
+5. **Key Lifecycle:** Session keys are ephemeral: they exist only in memory for the duration of the connection. They are never written to disk and are cleared from memory when the session ends. This provides perfect forward secrecy: compromise of long-term storage keys does not reveal past session traffic.
 
 **Frame Encryption:**
 
@@ -984,7 +984,7 @@ This dual-pipeline architecture provides defense in depth: even if one pipeline 
 
 ## Transaction Model
 
-ACID transaction guarantees with write-ahead logging. Durability was non-negotiable—data integrity must survive process crashes.
+ACID transaction guarantees with write-ahead logging. Durability was non-negotiable: data integrity must survive process crashes.
 
 ### Write-Ahead Logging
 
@@ -1019,7 +1019,7 @@ sequenceDiagram
 ```
 
 **WAL Behavior:**
-All writes go through write-ahead log before page store. WAL entries are fsync'd before commit acknowledgment—this is the durability guarantee. After commits, WAL is truncated or checkpointed when safe, according to configured durability thresholds. WAL replay recovers all committed transactions after crashes.
+All writes go through write-ahead log before page store. WAL entries are fsync'd before commit acknowledgment. This is the durability guarantee. After commits, WAL is truncated or checkpointed when safe, according to configured durability thresholds. WAL replay recovers all committed transactions after crashes.
 
 Checkpoint/truncate logic balances durability and performance. Too aggressive loses durability; too conservative hurts performance.
 
@@ -1031,7 +1031,7 @@ Checkpoint/truncate logic balances durability and performance. Too aggressive lo
 
 **Isolation:** Snapshot isolation via MVCC ensures each transaction sees a consistent snapshot. Concurrent transactions don't interfere. Tested with 50 concurrent readers and 10 writers.
 
-**Durability:** Committed data is fsync'd before acknowledgment. WAL replay recovers all committed transactions after crashes. Tested with crash simulation—power loss, WAL corruption, etc.
+**Durability:** Committed data is fsync'd before acknowledgment. WAL replay recovers all committed transactions after crashes. Tested with crash simulation: power loss, WAL corruption, etc.
 
 **Test Coverage:** 907 unit tests validate ACID compliance, crash recovery, and transaction durability across 223 test files.
 

--- a/Docs/Architecture/ARCHITECTURE_DETAILED.md
+++ b/Docs/Architecture/ARCHITECTURE_DETAILED.md
@@ -141,7 +141,7 @@ BlazeDB makes explicit tradeoffs to optimize for its target use cases:
 
 **Distributed Consensus:** No distributed consensus, automatic sharding, or multi-master replication. BlazeDB is a single primary database with optional sync capabilities. This is intentional—distributed consensus is a different problem space.
 
-**Platform Optimization:** Primarily optimized for Apple Silicon. Linux support exists but performance characteristics may differ. Best performance requires Apple Silicon hardware.
+**Platform support:** macOS and Linux are runtime-tested in CI; other Apple platforms are compile-tested; Android/KMM is experimental. Do not treat “optimized for Apple Silicon” as a measured claim — see [Benchmarks](../Benchmarks/README.md) and [COMPATIBILITY](../COMPATIBILITY.md).
 
 **MVCC Storage Overhead:** Multi-version concurrency control can increase storage requirements, especially with long-running read transactions that delay garbage collection. In practice, this hasn't been an issue for typical workloads, but it's a tradeoff to be aware of.
 
@@ -296,28 +296,30 @@ BlazeDB draws inspiration from several well-established systems while making dif
 
 ## Why Not SQLite / Core Data / Realm / LMDB?
 
+> **Authority:** Prefer [`Docs/GettingStarted/WHY_NOT_SQLITE.md`](../GettingStarted/WHY_NOT_SQLITE.md) and [`Docs/COMPATIBILITY.md`](../COMPATIBILITY.md) over this summary. The table below is a short orientation only — not a stopwatch or licensing brief.
+
 | Feature | BlazeDB | SQLite | Core Data | Realm | LMDB |
 |---------|---------|--------|----------|-------|------|
-| **Encryption** | AES-256-GCM per page (default) | Optional extension | No | Optional | No |
-| **Schema** | Dynamic, no migrations | Static, requires migrations | Static, complex migrations | Static, migrations | Schema-less |
-| **Concurrency** | MVCC snapshot isolation | File-level locking | Context-based | MVCC | MVCC |
-| **Performance** | Predictable, optimized for Apple Silicon | Variable under load | Variable, object graph overhead | Fast, but licensing | Very fast, memory-mapped |
-| **Query Language** | Fluent Swift API | SQL | NSPredicate | Fluent API | Key-value only |
-| **Platform** | macOS/iOS/Linux (Swift) | Universal (C) | macOS/iOS only | Cross-platform | Universal (C) |
-| **Dependencies** | Zero | Zero | Foundation | Realm runtime | Zero |
-| **License** | MIT | Public Domain | Apple | Commercial/MIT | OpenLDAP |
-| **Best For** | Encrypted local storage, AI agents | General-purpose embedded DB | Apple ecosystem apps | Mobile apps | High-performance key-value |
-| **Limitations** | Rule-based planner, no distributed consensus | File-level locking, no encryption by default | Complex migrations, Apple-only | Licensing, object model overhead | Key-value only, no query language |
+| **Encryption** | AES-256-GCM per page at rest (password on public open APIs) | Optional extension | No built-in at-rest cipher | Optional / product-dependent | No |
+| **Schema** | Flexible by default; optional validation + migration APIs | Static SQL schemas + migrations | Model versions + migrations | Object schema + migrations | Schema-less KV |
+| **Concurrency** | Single-process embedded; transactions; MVCC exists but is not the default claim | Multi-connection locking / WAL rules | Context-based | Product-specific | MVCC (mmap) |
+| **Performance** | See measured [Benchmarks](../Benchmarks/README.md) — no “Apple Silicon optimized” slogan here | Mature; workload-dependent | Object-graph overhead varies | Workload-dependent | Very fast mmap KV |
+| **Query Language** | Fluent Swift API (no SQL string engine) | SQL | NSPredicate / SwiftUI fetch patterns | Object query API | Key-value only |
+| **Platform** | macOS/Linux runtime-tested; Apple platforms compile-tested; Android/KMM experimental | Universal (C) | Apple platforms | Cross-platform SDKs (verify current) | Universal (C) |
+| **Dependencies** | Swift package + Crypto where required | Zero (amalgamation) | Foundation / Cocoa | Realm runtime | Zero |
+| **License** | MIT | Public domain dedication | Apple frameworks | **Verify current upstream** (DB/sync terms have changed over time) | OpenLDAP |
+| **Best For** | Encrypted Swift-native embedded storage + C ABI | General-purpose embedded SQL | Deep Apple-framework apps | Teams already on Realm | High-performance KV |
+| **Limitations** | Not a SQL engine; sync/server deferred from default OSS | No encryption by default | Apple-centric; migration complexity | Sync/licensing history is not a one-cell story | No rich query language |
 
-**When to choose BlazeDB:** You need encryption by default, schema flexibility without migrations, predictable performance on Apple platforms, and a Swift-native API.
+**When to choose BlazeDB:** Encryption by default, Swift-native typed access, local tooling, and C ABI embedding — on a support tier you accept ([COMPATIBILITY](../COMPATIBILITY.md)).
 
-**When to choose SQLite:** You need universal portability, SQL queries, or don't need encryption.
+**When to choose SQLite:** Universal portability, SQL, or you do not need encryption-by-default.
 
-**When to choose Core Data:** You're building Apple-only apps and need deep integration with Cocoa frameworks.
+**When to choose Core Data:** Apple-only apps that want deep Cocoa / framework integration.
 
-**When to choose Realm:** You're building mobile apps and can accept the licensing model.
+**When to choose Realm:** You specifically want the Realm ecosystem; check current license and sync product status yourself.
 
-**When to choose LMDB:** You need maximum performance for key-value workloads and don't need encryption or query language.
+**When to choose LMDB:** Maximum performance for key-value workloads without encryption or a query language.
 
 ---
 

--- a/Docs/GettingStarted/WHY_NOT_SQLITE.md
+++ b/Docs/GettingStarted/WHY_NOT_SQLITE.md
@@ -41,11 +41,11 @@ These rows describe the **default open-source package**, not roadmap aspirations
 | Live queries and SwiftUI integration | **Shipped (Apple platforms)** | Observation helpers are Apple-oriented; portable observe APIs exist in core |
 | Local inspection (`blazedb` CLI/REPL, maintenance tools) | **Shipped** | |
 | Documented C ABI (`BlazeDBC`) | **Shipped** | Go via cgo is a recipe, not an official Go module |
-| Optional schema validation and migrations | **Shipped (opt-in)** | Flexible by default; **migrations exist** when you opt in — not “schema-less / no migrations” |
-| Concurrency model | **Shipped (qualified)** | Single-process embedded engine. Transactions provide consistency. **MVCC / snapshot isolation exists in the codebase but is not the default path** — do not market “MVCC snapshot isolation” as the everyday guarantee. |
+| Optional schema validation and migrations | **Shipped (opt-in)** | Flexible by default; **migrations exist** when you opt in, not “schema-less / no migrations” |
+| Concurrency model | **Shipped (qualified)** | Single-process embedded engine. Transactions provide consistency. **MVCC / snapshot isolation exists in the codebase but is not the default path**. Do not market “MVCC snapshot isolation” as the everyday guarantee. |
 | Optional Secure Enclave-assisted key storage | **Platform optional** | Not required for default password-derived encryption |
 | Android / KMM consumption | **Experimental** | Engineering validation; not a production SDK claim |
-| Multi-device sync / discovery / network server | **Deferred** | Not part of the default OSS package — see [DISTRIBUTED_TRANSPORT_DEFERRED.md](../Status/DISTRIBUTED_TRANSPORT_DEFERRED.md) |
+| Multi-device sync / discovery / network server | **Deferred** | Not part of the default OSS package. See [DISTRIBUTED_TRANSPORT_DEFERRED.md](../Status/DISTRIBUTED_TRANSPORT_DEFERRED.md) |
 | SQL string dialect | **Not shipped** | Use SQLite if you need SQL |
 
 ---
@@ -82,12 +82,12 @@ Older comparison tables in the repo sometimes claimed mythology. Prefer this pag
 | **Performance** | Cite [Benchmarks](../Benchmarks/README.md) only. Do **not** use “predictable, optimized for Apple Silicon” or free-floating “% faster than SQLite” slogans. |
 | **Encryption** | At-rest pages: **AES-256-GCM** with password-derived keys on public open APIs. SQLite encryption remains optional/extension-based (e.g. SQLCipher). |
 | **Platforms** | macOS/Linux runtime-tested; other Apple platforms compile-tested; Android/KMM experimental. |
-| **Sync** | Deferred from the default OSS package — not a selection reason today. |
+| **Sync** | Deferred from the default OSS package, not a selection reason today. |
 
 ### Brief notes on Core Data and Realm
 
-- **Core Data** — Apple-framework ORM/persistence with deep Cocoa integration and its own migration story. Prefer it when you want framework integration over a standalone encrypted document engine.
-- **Realm** — Mobile-oriented object database with a long commercial/sync history; **licensing and sync product status have changed over time** — verify current upstream terms rather than citing a one-word “Commercial/MIT” cell. Prefer Realm when you specifically want that ecosystem; prefer BlazeDB when you want MIT-licensed, encryption-default, Swift-native embedded storage without a sync product claim.
+- **Core Data**: Apple-framework ORM/persistence with deep Cocoa integration and its own migration story. Prefer it when you want framework integration over a standalone encrypted document engine.
+- **Realm**: Mobile-oriented object database with a long commercial/sync history; **licensing and sync product status have changed over time**. Verify current upstream terms rather than citing a one-word “Commercial/MIT” cell. Prefer Realm when you specifically want that ecosystem; prefer BlazeDB when you want MIT-licensed, encryption-default, Swift-native embedded storage without a sync product claim.
 
 This page does **not** maintain a full BlazeDB vs Core Data vs Realm feature matrix. Those one-liners go stale quickly.
 
@@ -131,7 +131,7 @@ Distributed sync, discovery, and a networked BlazeDB server are **not** reasons 
 
 ## Recommendation
 
-Choose **BlazeDB** for encrypted Swift-native embedded storage, typed records, live queries, local inspection tooling, and native embedding through the C ABI — on platforms whose support tier matches your risk tolerance.
+Choose **BlazeDB** for encrypted Swift-native embedded storage, typed records, live queries, local inspection tooling, and native embedding through the C ABI, on platforms whose support tier matches your risk tolerance.
 
 Choose **SQLite** when SQL compatibility, ecosystem maturity, third-party tooling, broad language support, or lower insert and cold-open latency matter more.
 

--- a/Docs/GettingStarted/WHY_NOT_SQLITE.md
+++ b/Docs/GettingStarted/WHY_NOT_SQLITE.md
@@ -2,7 +2,7 @@
 
 Honest comparison for choosing between BlazeDB and SQLite as an embedded store.
 
-This page is about **product fit**, not stopwatch marketing. Measured latency and throughput belong in the benchmark docs linked below.
+This page is about **product fit**, not stopwatch marketing. Measured latency and throughput belong in the benchmark docs linked below. Authority for platform tiers: [COMPATIBILITY.md](../COMPATIBILITY.md) and [android-status.md](../android-status.md).
 
 ---
 
@@ -16,27 +16,43 @@ This page is about **product fit**, not stopwatch marketing. Measured latency an
 
 ---
 
-## Shipped vs deferred
+## Platform support
+
+| | BlazeDB |
+|--|---------|
+| **Platform support** | macOS and Linux **runtime-tested**; Apple platforms (iOS / watchOS / tvOS) **compile-tested**; Android / KMM **experimental** |
+
+Do not treat Android or KMM as the same maturity as macOS/Linux. Details: [COMPATIBILITY.md](../COMPATIBILITY.md), [android-status.md](../android-status.md).
+
+SQLite’s C API remains the broader “runs everywhere” option when you need one binary story across many languages and hosts.
+
+---
+
+## Shipped core vs deferred
+
+These rows describe the **default open-source package**, not roadmap aspirations.
 
 | Capability | BlazeDB today | Notes |
 |------------|---------------|-------|
-| Encrypted embedded storage (AES-GCM, password on public open APIs) | **Shipped** | Default path for public open APIs |
+| Encrypted embedded storage | **Shipped** | Public open APIs require a password; pages at rest use **AES-256-GCM** (password-derived 256-bit key via PBKDF2-SHA256 + per-database salt). See [KEY_MANAGEMENT_AND_COMPATIBILITY.md](../Status/KEY_MANAGEMENT_AND_COMPATIBILITY.md). |
 | Typed Swift records (`BlazeStorable`) and raw / byte key-value APIs | **Shipped** | |
 | Fluent Swift queries (no SQL string engine) | **Shipped** | |
 | Transactional write APIs and WAL-backed recovery | **Shipped** | See durability docs for modes and caveats |
-| Live queries and SwiftUI integration (Apple platforms) | **Shipped** | |
+| Live queries and SwiftUI integration | **Shipped (Apple platforms)** | Observation helpers are Apple-oriented; portable observe APIs exist in core |
 | Local inspection (`blazedb` CLI/REPL, maintenance tools) | **Shipped** | |
 | Documented C ABI (`BlazeDBC`) | **Shipped** | Go via cgo is a recipe, not an official Go module |
-| Optional schema validation and migrations | **Shipped (advanced)** | Flexible by default; migrations exist when you opt in |
+| Optional schema validation and migrations | **Shipped (opt-in)** | Flexible by default; **migrations exist** when you opt in — not “schema-less / no migrations” |
+| Concurrency model | **Shipped (qualified)** | Single-process embedded engine. Transactions provide consistency. **MVCC / snapshot isolation exists in the codebase but is not the default path** — do not market “MVCC snapshot isolation” as the everyday guarantee. |
 | Optional Secure Enclave-assisted key storage | **Platform optional** | Not required for default password-derived encryption |
-| Multi-device sync / discovery / network server | **Deferred** | Not part of the default OSS package |
+| Android / KMM consumption | **Experimental** | Engineering validation; not a production SDK claim |
+| Multi-device sync / discovery / network server | **Deferred** | Not part of the default OSS package — see [DISTRIBUTED_TRANSPORT_DEFERRED.md](../Status/DISTRIBUTED_TRANSPORT_DEFERRED.md) |
 | SQL string dialect | **Not shipped** | Use SQLite if you need SQL |
 
 ---
 
 ## When BlazeDB is a good fit
 
-- You are building Swift applications or in-process Swift services (including Vapor embedding).
+- You are building Swift applications or in-process Swift services (including Vapor embedding) on supported platforms.
 - You want encryption at rest without bolting on a separate cipher extension.
 - You prefer typed documents and fluent Swift queries over SQL strings.
 - You want in-process live queries and Apple-platform SwiftUI observation.
@@ -55,11 +71,33 @@ This page is about **product fit**, not stopwatch marketing. Measured latency an
 
 ---
 
+## Capability corrections (read these before citing old tables)
+
+Older comparison tables in the repo sometimes claimed mythology. Prefer this page + Compatibility over archive / architecture one-liners.
+
+| Topic | Verified wording |
+|-------|------------------|
+| **Schema** | Flexible by default; **optional validation and real migration APIs** exist. Not “dynamic, no migrations.” |
+| **Concurrency** | Single-process embedded design; multi-process writers unsupported; network filesystems not recommended. Do not claim absolute “MVCC snapshot isolation” as the default product behavior. |
+| **Performance** | Cite [Benchmarks](../Benchmarks/README.md) only. Do **not** use “predictable, optimized for Apple Silicon” or free-floating “% faster than SQLite” slogans. |
+| **Encryption** | At-rest pages: **AES-256-GCM** with password-derived keys on public open APIs. SQLite encryption remains optional/extension-based (e.g. SQLCipher). |
+| **Platforms** | macOS/Linux runtime-tested; other Apple platforms compile-tested; Android/KMM experimental. |
+| **Sync** | Deferred from the default OSS package — not a selection reason today. |
+
+### Brief notes on Core Data and Realm
+
+- **Core Data** — Apple-framework ORM/persistence with deep Cocoa integration and its own migration story. Prefer it when you want framework integration over a standalone encrypted document engine.
+- **Realm** — Mobile-oriented object database with a long commercial/sync history; **licensing and sync product status have changed over time** — verify current upstream terms rather than citing a one-word “Commercial/MIT” cell. Prefer Realm when you specifically want that ecosystem; prefer BlazeDB when you want MIT-licensed, encryption-default, Swift-native embedded storage without a sync product claim.
+
+This page does **not** maintain a full BlazeDB vs Core Data vs Realm feature matrix. Those one-liners go stale quickly.
+
+---
+
 ## Tradeoffs (without invented percentages)
 
 ### Encryption
 
-BlazeDB public open APIs require a password; stored pages use AES-GCM. SQLite encryption is optional and typically comes from an extension (for example SQLCipher). Prefer BlazeDB when encryption-by-default is a primary requirement.
+BlazeDB public open APIs require a password; stored pages use **AES-256-GCM**. SQLite encryption is optional and typically comes from an extension (for example SQLCipher). Prefer BlazeDB when encryption-by-default is a primary requirement.
 
 ### Query model
 
@@ -71,11 +109,11 @@ BlazeDB models are often flexible day-to-day, with **optional** schema validatio
 
 ### Concurrency and process model
 
-BlazeDB is designed as a **single-process** embedded engine. Multi-process writers are not supported; network filesystems are not recommended. SQLite has a long history of multi-connection patterns (with its own locking and WAL rules). Do not treat BlazeDB as a drop-in multi-writer file server.
+BlazeDB is designed as a **single-process** embedded engine. Multi-process writers are not supported; network filesystems are not recommended. SQLite has a long history of multi-connection patterns (with its own locking and WAL rules). Do not treat BlazeDB as a drop-in multi-writer file server, and do not equate “transactions exist” with “MVCC snapshot isolation is always on.”
 
 ### Performance
 
-Do **not** trust free-floating “X% faster than SQLite” slogans on this page or elsewhere in the repo without measured methodology.
+Do **not** trust free-floating “X% faster than SQLite” slogans on this page or elsewhere in the repo without measured methodology. Do not cite vague “optimized for Apple Silicon” language as evidence.
 
 Authoritative measured comparisons:
 
@@ -93,17 +131,19 @@ Distributed sync, discovery, and a networked BlazeDB server are **not** reasons 
 
 ## Recommendation
 
-Choose **BlazeDB** for encrypted Swift-native embedded storage, typed records, live queries, local inspection tooling, and native embedding through the C ABI.
+Choose **BlazeDB** for encrypted Swift-native embedded storage, typed records, live queries, local inspection tooling, and native embedding through the C ABI — on platforms whose support tier matches your risk tolerance.
 
 Choose **SQLite** when SQL compatibility, ecosystem maturity, third-party tooling, broad language support, or lower insert and cold-open latency matter more.
 
-Both are strong embedded databases for different jobs. Pick the product whose shipped shape matches your constraints.
+Both are strong embedded databases for different jobs. Pick the product whose **shipped** shape matches your constraints.
 
 ---
 
 ## Related docs
 
 - [Getting Started](README.md)
+- [Compatibility](../COMPATIBILITY.md)
+- [Android / KMM status](../android-status.md)
 - [Architecture](../Architecture/README.md)
 - [Key management](../Status/KEY_MANAGEMENT_AND_COMPATIBILITY.md)
 - [Durability Mode Support](../Status/DURABILITY_MODE_SUPPORT.md)


### PR DESCRIPTION
## Summary
- Finish `WHY_NOT_SQLITE.md` after Batch A (#389): add platform tiers (macOS/Linux runtime-tested; Apple platforms compile-tested; Android/KMM experimental), keep migrations as opt-in shipped, qualify MVCC (not default), drop Apple Silicon fluff, tighten at-rest encryption to AES-256-GCM + password-derived keys, and separate shipped core from deferred sync more clearly.
- Align `ARCHITECTURE_DETAILED.md` “Why Not SQLite / Core Data / Realm / LMDB?” table and the nearby platform-optimization blurb so the same mythology does not survive one link away. Realm licensing points to “verify current upstream” instead of a stale Commercial/MIT cell.
- README product-first stash remains frozen until this comparison surface is trustworthy.

## Test plan
- [x] Diff limited to comparison docs (`WHY_NOT_SQLITE.md`, `ARCHITECTURE_DETAILED.md`)
- [x] No `Dynamic, no migrations` / absolute default `MVCC snapshot isolation` / `optimized for Apple Silicon` marketing claims remain in those tables
- [x] Platform row includes Android/KMM as **experimental**
- [x] Encryption wording matches password-derived AES-256-GCM at rest
- [ ] Skim PR for accidental README/Batch A reopen