### PR TITLE
docs: replace README issue shelf with label-driven contribute entry

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,12 +33,14 @@ Bridge: **codebase → learning path → issue → tests → PR**. Do not open s
 
 ## Finding work
 
-Start with the curated shelf in the root [README.md](README.md) (**Want to contribute? Start here**), then broaden with labels. Pick issues that match the **supported** product (Swift engine, CLI, dynamic BlazeDBC). See [Docs/Contributing/ISSUE_GUIDE.md](Docs/Contributing/ISSUE_GUIDE.md) for claim etiquette and what requires maintainer review.
+Do **not** rely on a hard-coded issue number list in docs — issue shelves rot as soon as tickets close or grow. Prefer **label-driven** filters (they stay current with the tracker).
+
+Pick issues that match the **supported** product (Swift engine, CLI, dynamic BlazeDBC). See [Docs/Contributing/ISSUE_GUIDE.md](Docs/Contributing/ISSUE_GUIDE.md) for claim etiquette and what requires maintainer review. Comment on an issue before starting substantial work.
 
 | Filter | Use for |
 |--------|---------|
-| [good first issue](https://github.com/Mikedan37/BlazeDB/labels/good%20first%20issue) | Docs, help text, safe tooling — no WAL/crypto/ABI/auth redesign |
-| [help wanted](https://github.com/Mikedan37/BlazeDB/labels/help%20wanted) | Maintainer-backed contributions (includes the README shelf) |
+| [Good first issues](https://github.com/Mikedan37/BlazeDB/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) | Docs, help text, safe tooling — no WAL/crypto/ABI/auth redesign |
+| [Help wanted](https://github.com/Mikedan37/BlazeDB/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) | Maintainer-backed outside contributions |
 | [ROADMAP.md](ROADMAP.md) Now | Compatibility fixtures, Go smoke, BlazeDBC release, schema guide, CLI honesty |
 | `durability` / `concurrency` / `reliability` / `needs design` | Correctness and durability — usually not beginner; see [ISSUE_CODE_INDEX](Docs/Contributing/ISSUE_CODE_INDEX.md) |
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ From a package checkout:
 ./dev tier0
 ```
 
-`./dev` owns repeatable test/tier/experiment workflows. It reuses `.build/debug/blazedb` when possible and rebuilds when `BlazeShell`, `BlazedbCLI`, or `Package.swift` are newer than that binary. Xcode schemes stay lean for interactive Run / Profile / Analyze / Archive — see [Docs/Build/XCODE_SCHEMES.md](Docs/Build/XCODE_SCHEMES.md).
+`./dev` owns repeatable test/tier/experiment workflows. It reuses `.build/debug/blazedb` when possible and rebuilds when `BlazeShell`, `BlazedbCLI`, or `Package.swift` are newer than that binary. Xcode schemes stay lean for interactive Run / Profile / Analyze / Archive. See [Docs/Build/XCODE_SCHEMES.md](Docs/Build/XCODE_SCHEMES.md).
 
 Storage-format, WAL, encryption, and recovery changes: follow [Docs/Contributing/STORAGE_CHANGE_CHECKLIST.md](Docs/Contributing/STORAGE_CHANGE_CHECKLIST.md).
 
@@ -33,20 +33,20 @@ Bridge: **codebase → learning path → issue → tests → PR**. Do not open s
 
 ## Finding work
 
-Do **not** rely on a hard-coded issue number list in docs — issue shelves rot as soon as tickets close or grow. Prefer **label-driven** filters (they stay current with the tracker).
+Do **not** rely on a hard-coded issue number list in docs. Issue shelves rot as soon as tickets close or grow. Prefer **label-driven** filters (they stay current with the tracker).
 
 Pick issues that match the **supported** product (Swift engine, CLI, dynamic BlazeDBC). See [Docs/Contributing/ISSUE_GUIDE.md](Docs/Contributing/ISSUE_GUIDE.md) for claim etiquette and what requires maintainer review. Comment on an issue before starting substantial work.
 
 | Filter | Use for |
 |--------|---------|
-| [Good first issues](https://github.com/Mikedan37/BlazeDB/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) | Docs, help text, safe tooling — no WAL/crypto/ABI/auth redesign |
+| [Good first issues](https://github.com/Mikedan37/BlazeDB/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) | Docs, help text, safe tooling: no WAL/crypto/ABI/auth redesign |
 | [Help wanted](https://github.com/Mikedan37/BlazeDB/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) | Maintainer-backed outside contributions |
 | [ROADMAP.md](ROADMAP.md) Now | Compatibility fixtures, Go smoke, BlazeDBC release, schema guide, CLI honesty |
-| `durability` / `concurrency` / `reliability` / `needs design` | Correctness and durability — usually not beginner; see [ISSUE_CODE_INDEX](Docs/Contributing/ISSUE_CODE_INDEX.md) |
+| `durability` / `concurrency` / `reliability` / `needs design` | Correctness and durability: usually not beginner; see [ISSUE_CODE_INDEX](Docs/Contributing/ISSUE_CODE_INDEX.md) |
 
 **Focused tests:** `./dev tests [search]` then `./dev test <filter>`. On Apple Silicon, prefer `arch -arm64 ./dev …` if you hit arch loader mismatches ([#289](https://github.com/Mikedan37/BlazeDB/issues/289)).
 
-**Security reports:** do not file a public issue — follow [SECURITY.md](SECURITY.md).
+**Security reports:** do not file a public issue. Follow [SECURITY.md](SECURITY.md).
 
 ## PR expectations
 
@@ -68,7 +68,7 @@ For **most** PRs:
 | [`Docs/Testing/CI_AND_TEST_TIERS.md`](Docs/Testing/CI_AND_TEST_TIERS.md) | Changes to **test lanes**, **tier** meaning, or **CI** job behavior |
 | [`Examples/ReadmeSamples/README.md`](Examples/ReadmeSamples/README.md) | New/changed **executable README samples** or L3 verification scope |
 
-**If two docs disagree about CI** (blocking jobs, tier scope, workflows), treat **[`Docs/Testing/CI_AND_TEST_TIERS.md`](Docs/Testing/CI_AND_TEST_TIERS.md)** plus **`.github/workflows/*.yml`** as the detailed source of truth—not this paragraph alone.
+**If two docs disagree about CI** (blocking jobs, tier scope, workflows), treat **[`Docs/Testing/CI_AND_TEST_TIERS.md`](Docs/Testing/CI_AND_TEST_TIERS.md)** plus **`.github/workflows/*.yml`** as the detailed source of truth, not this paragraph alone.
 
 Forks, billing limits, and hosted CI availability can prevent Actions from running; use the same commands locally if needed ([Hosted CI status](Docs/Status/OPEN_SOURCE_READINESS_CHECKLIST.md#hosted-ci-status)).
 
@@ -80,7 +80,7 @@ BlazeDBCore and `BlazeDBAndroidBridge` can be cross-compiled for Android from a 
 
 **Requirements:**
 
-- **OSS Swift 6.3.2+** — do **not** use Xcode’s `swift` on macOS
+- **OSS Swift 6.3.2+**: do **not** use Xcode’s `swift` on macOS
 - Swift SDK for Android (`swift sdk install …`) matching the host Swift version
 - Android NDK r27d+
 
@@ -108,7 +108,7 @@ The `:shared` module in `Examples/android/shared` exposes `expect class BlazeDB`
 ./Scripts/prove-kmm-runtime.sh          # both
 ```
 
-Do **not** describe this as full product “KMM supported” until Android runtime is in CI and consumer packaging exists. Details: [Docs/android-status.md](Docs/android-status.md), [CI and test tiers — KMM CI](Docs/Testing/CI_AND_TEST_TIERS.md#kmm-ci-android--ios).
+Do **not** describe this as full product “KMM supported” until Android runtime is in CI and consumer packaging exists. Details: [Docs/android-status.md](Docs/android-status.md), [CI and test tiers: KMM CI](Docs/Testing/CI_AND_TEST_TIERS.md#kmm-ci-android--ios).
 
 **Status and roadmap:** [Docs/android-status.md](Docs/android-status.md)
 
@@ -122,9 +122,9 @@ The PR workflow is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Sched
 
 | Level | What | Script / target |
 |-------|------|-----------------|
-| **L1 — Quickstart** | `swift run HelloBlazeDB` from clean worktree | `./Scripts/verify-readme-quickstart.sh` |
-| **L2 — Public API** | Core exported APIs | `BlazeDB_Tier0` → `PublicAPIVerificationTests` |
-| **L3 — README samples** | Runnable README Swift patterns | `./Scripts/verify-readme-samples.sh` → `ReadmeSamples` |
+| **L1: Quickstart** | `swift run HelloBlazeDB` from clean worktree | `./Scripts/verify-readme-quickstart.sh` |
+| **L2: Public API** | Core exported APIs | `BlazeDB_Tier0` → `PublicAPIVerificationTests` |
+| **L3: README samples** | Runnable README Swift patterns | `./Scripts/verify-readme-samples.sh` → `ReadmeSamples` |
 
 Coverage mapping and contributor rules: [`Examples/ReadmeSamples/README.md`](Examples/ReadmeSamples/README.md).  
 If you change executable README samples, update the harness **and** the coverage table, or document the section as **Manual** / **Out of scope** there.
@@ -158,7 +158,7 @@ swift test --filter BlazeDB_Tier0
 
 ### Tier 1: Canonical confidence target (`BlazeDB_Tier1`)
 
-**Canonical Tier1 gate — `BlazeDB_Tier1`:** `BlazeDBTests/Tier1Core/` — deterministic correctness; no `measure()`, no timing-dependent sleeps, no benchmark-shaped workloads.
+**Canonical Tier1 gate: `BlazeDB_Tier1`:** `BlazeDBTests/Tier1Core/`: deterministic correctness; no `measure()`, no timing-dependent sleeps, no benchmark-shaped workloads.
 
 `BlazeDB_Tier1Extended` and `BlazeDB_Tier1Perf` target names were retired; their suites now run under Tier2/Tier3 ownership via **transitional companion targets** (`BlazeDB_Tier2_Extended`, `BlazeDB_Tier3_Heavy_Perf`) pending PR4 normalization.
 

--- a/Docs/Contributing/ISSUE_CODE_INDEX.md
+++ b/Docs/Contributing/ISSUE_CODE_INDEX.md
@@ -8,7 +8,7 @@ Evidence: `Proven` | `Strongly supported` | `Investigation`
 
 Hub: [LEARNING_PATHS](LEARNING_PATHS.md) · [CODEBASE_MAP](../Architecture/CODEBASE_MAP.md) · [ISSUE_GUIDE](ISSUE_GUIDE.md)
 
-Label filters used: `good first issue`, `durability`, `performance`, `concurrency`, `needs design`, plus roadmap-sized Now items and correctness defects. There is **no** `roadmap` GitHub label today — roadmap Now work is listed explicitly. **`help wanted`:** none currently open with that label. Prefer specific risk labels over a generic priority tag.
+Label filters used: `good first issue`, `durability`, `performance`, `concurrency`, `needs design`, plus roadmap-sized Now items and correctness defects. There is **no** `roadmap` GitHub label today: roadmap Now work is listed explicitly. **`help wanted`:** none currently open with that label. Prefer specific risk labels over a generic priority tag.
 
 ---
 
@@ -26,7 +26,7 @@ Label filters used: `good first issue`, `durability`, `performance`, `concurrenc
 | #273 | starter | Proven | `SECURITY.md`; `KeyManager` PBKDF2 iterations | `KeyManagerTests` | n/a | `rg -n "PBKDF2|600|10000|Argon2" SECURITY.md BlazeDB/Crypto/KeyManager.swift` | no (docs) |
 | #286 | starter | Proven | migration/API docs vs `BlazeDBClient` RLS | `RLSEnforcementClientTests` | n/a | `./dev test RLSEnforcementClientTests` (behavior unchanged) | no |
 | #287 | starter | Proven | `MIGRATION_GUIDE` vs `Package.swift` excludes | n/a | n/a | `rg -n "SQLiteMigrator|CoreDataMigrator" Package.swift` | no |
-| #288 | starter | Proven | `BlazeDB/Exports/BlazeDBClient+RLS.swift` (`enableRLS`); `BlazeDB/Exports/BlazeDBClient.swift` (`shouldEnforceRLS`) | `testRLSEnabledWithoutPoliciesDoesNotBlock` | n/a | `./dev test RLSEnforcementClientTests.testRLSEnabledWithoutPoliciesDoesNotBlock` | **docs only** — no auth changes |
+| #288 | starter | Proven | `BlazeDB/Exports/BlazeDBClient+RLS.swift` (`enableRLS`); `BlazeDB/Exports/BlazeDBClient.swift` (`shouldEnforceRLS`) | `testRLSEnabledWithoutPoliciesDoesNotBlock` | n/a | `./dev test RLSEnforcementClientTests.testRLSEnabledWithoutPoliciesDoesNotBlock` | **docs only**: no auth changes |
 | #289 | starter | Strongly supported | `dev`; `BlazeShell/DeveloperCommands.swift` | `DeveloperCommandsTests` | arch mismatch case | `./dev help` | low |
 | #290 | starter | Strongly supported | `BlazeDump/main.swift`, `BlazeInfo/main.swift` | none focused | JSON golden | `swift run BlazeInfo …` | low |
 | #292 | starter | Proven | `Docs/Features/QUERY_PLANNER.md` | n/a | n/a | `rg -n "O\\(log" Docs/Features/QUERY_PLANNER.md` | no |
@@ -42,7 +42,7 @@ Label filters used: `good first issue`, `durability`, `performance`, `concurrenc
 | #276 | advanced | Proven | `BlazeDBClient.performSafeWrite`, `beginTransaction`; `DynamicCollection.insert`; `PageStore.synchronize`; `WriteAheadLog` | `WriteProfileCollectorTests`; `TransactionDurabilityTests` | commit-boundary fsync count after amortize | write_profile bench + durability tests | **yes**; optimize blocked on #291 |
 | #277 | maintainer-sensitive | Proven | `createDurableTransactionBackups`, `commitTransaction`, `restoreDurableTransactionBackupIfPresent` | `testStartupRestoresInterruptedTransactionBackup`; crash survival suites | crash **after** commit persist / **before** backup clear | Tier0 durability + new regression | **yes** |
 | #281 | advanced | Proven | `DynamicCollection+Batch.insertBatch` (secondary indexes vs `synchronize`) | batch/persistence suites (partial) | sync-failure index desync | focused batch + fault injection | **yes** |
-| #283 | advanced | Proven | `BlazeDB/Storage/PageStore+Overflow.swift` overflow write helpers (`_writeOverflowPage` / Linux queue.sync vs `.barrier` — confirm on current Linux path) | overflow / persistence tests | Linux-specific race | Linux + barrier review | **yes** |
+| #283 | advanced | Proven | `BlazeDB/Storage/PageStore+Overflow.swift` overflow write helpers (`_writeOverflowPage` / Linux queue.sync vs `.barrier`: confirm on current Linux path) | overflow / persistence tests | Linux-specific race | Linux + barrier review | **yes** |
 
 ---
 
@@ -85,12 +85,12 @@ Label filters used: `good first issue`, `durability`, `performance`, `concurrenc
 
 | Issue | Reason |
 |-------|--------|
-| #30 | Broad alignment audit; residual sites need fresh Linux repro — map after locating remaining `load(fromByteOffset:)` call sites |
-| #43 | Compression portability enhancement; backend choice needs design — files span `PageStore` compression paths; treat as design-first |
-| #51 | Linux Tier1 CI contract — workflow/docs heavy; exact failing suites change over time |
-| #73 | Move `SecureConnectionTests` — file excluded from Tier1; target destination is distributed/transport (deferred product) |
-| #268 | `stats()`/`profile` cacheHit fields — need exact dead property sites confirmed in current Metrics types before coding |
-| #285 | `transactionPagesWritten` dead metric — confirm all write sites still empty before remove-vs-fix |
+| #30 | Broad alignment audit; residual sites need fresh Linux repro: map after locating remaining `load(fromByteOffset:)` call sites |
+| #43 | Compression portability enhancement; backend choice needs design: files span `PageStore` compression paths; treat as design-first |
+| #51 | Linux Tier1 CI contract: workflow/docs heavy; exact failing suites change over time |
+| #73 | Move `SecureConnectionTests`: file excluded from Tier1; target destination is distributed/transport (deferred product) |
+| #268 | `stats()`/`profile` cacheHit fields: need exact dead property sites confirmed in current Metrics types before coding |
+| #285 | `transactionPagesWritten` dead metric: confirm all write sites still empty before remove-vs-fix |
 
 If you ground one of these, update this table in the same PR as the investigation notes.
 

--- a/Docs/Contributing/ISSUE_GUIDE.md
+++ b/Docs/Contributing/ISSUE_GUIDE.md
@@ -28,7 +28,7 @@ Release-oriented focus is summarized in [`ROADMAP.md`](../../ROADMAP.md) (**Main
 |----------|---------|
 | [`good first issue`](https://github.com/Mikedan37/BlazeDB/labels/good%20first%20issue) | Safe, bounded, usually docs/tooling. No storage-format, ABI, crypto behavior, auth semantics, or concurrency redesign. |
 | [`help wanted`](https://github.com/Mikedan37/BlazeDB/labels/help%20wanted) | Maintainer wants help; may still need review on approach. |
-| [`durability`](https://github.com/Mikedan37/BlazeDB/labels/durability) / [`concurrency`](https://github.com/Mikedan37/BlazeDB/labels/concurrency) / [`needs design`](https://github.com/Mikedan37/BlazeDB/labels/needs%20design) | Correctness-sensitive work — usually **not** beginner. Prefer these over a generic priority museum label. |
+| [`durability`](https://github.com/Mikedan37/BlazeDB/labels/durability) / [`concurrency`](https://github.com/Mikedan37/BlazeDB/labels/concurrency) / [`needs design`](https://github.com/Mikedan37/BlazeDB/labels/needs%20design) | Correctness-sensitive work: usually **not** beginner. Prefer these over a generic priority museum label. |
 | Roadmap Now items | Linked from [`ROADMAP.md`](../../ROADMAP.md) (fixtures, Go smoke, BlazeDBC, schema guide, CLI honesty). |
 
 **Start here (safe docs/tooling):** issues labeled `good first issue` + `documentation`.  
@@ -40,7 +40,7 @@ Release-oriented focus is summarized in [`ROADMAP.md`](../../ROADMAP.md) (**Main
 - **Subsystem:** `storage-engine`, `reliability`, `concurrency`, `api-correctness`, `typed-store`, `linux`, `Portability`
 - **Contributor:** `good first issue`, `help wanted`
 
-Security vulnerabilities: **do not** open a public issue — follow [`SECURITY.md`](../../SECURITY.md).
+Security vulnerabilities: **do not** open a public issue: follow [`SECURITY.md`](../../SECURITY.md).
 
 ## How to claim an issue
 

--- a/Docs/Contributing/LEARNING_PATHS.md
+++ b/Docs/Contributing/LEARNING_PATHS.md
@@ -1,6 +1,6 @@
 # Learning paths
 
-Pick a path that matches your background. Each path ends at **existing** open issues — this guide does not create tickets.
+Pick a path that matches your background. Each path ends at **existing** open issues: this guide does not create tickets.
 
 Hub: [CODEBASE_MAP](../Architecture/CODEBASE_MAP.md) · [ISSUE_CODE_INDEX](ISSUE_CODE_INDEX.md) · [ISSUE_GUIDE](ISSUE_GUIDE.md) · [Tours](../Architecture/TOURS/)
 
@@ -13,8 +13,8 @@ Hub: [CODEBASE_MAP](../Architecture/CODEBASE_MAP.md) · [ISSUE_CODE_INDEX](ISSUE
 
 ### Read
 
-1. [README.md](../../README.md) — supported product
-2. [Docs/README.md](../README.md) — doc authority map
+1. [README.md](../../README.md): supported product
+2. [Docs/README.md](../README.md): doc authority map
 3. [ISSUE_GUIDE.md](ISSUE_GUIDE.md)
 4. Tour: none required; optionally [01_OPEN_AND_RECOVERY](../Architecture/TOURS/01_OPEN_AND_RECOVERY.md) for vocabulary
 
@@ -53,7 +53,7 @@ Product boundaries, which docs are canonical vs historical, how to ground claims
 
 ### Read
 
-1. `BlazedbCLI/BlazedbEntry.swift` — `@main` routing
+1. `BlazedbCLI/BlazedbEntry.swift`: `@main` routing
 2. `BlazeShell/CLIHelp.swift`, `BlazeShell/DeveloperCommands.swift`
 3. `BlazeDoctor/main.swift`, `BlazeDump/main.swift`, `BlazeInfo/main.swift` (separate tools)
 4. Tour: [06_CLI](../Architecture/TOURS/06_CLI.md)
@@ -94,22 +94,22 @@ Destructive restore/repair, password-on-argv handling, anything that mutates DB 
 
 ### Read
 
-1. `BlazeDB/Query/QueryBuilder.swift` — `execute` / `_executeStandard`
+1. `BlazeDB/Query/QueryBuilder.swift`: `execute` / `_executeStandard`
 2. `BlazeDB/Query/QueryExplain.swift`
-3. `BlazeDB/Core/DynamicCollection.swift` — `fetchAll`, `runQuery*`
-4. `BlazeDB/Core/DynamicCollection+Optimized.swift` — fetchAll cache
+3. `BlazeDB/Core/DynamicCollection.swift`: `fetchAll`, `runQuery*`
+4. `BlazeDB/Core/DynamicCollection+Optimized.swift`: fetchAll cache
 5. Tour: [03_QUERY_PATH](../Architecture/TOURS/03_QUERY_PATH.md)
 
 ### Related issues
 
 | Issue | Kind |
 |-------|------|
-| #261, #292 | **Docs** — O(log n) honesty |
-| #274 | **Enhancement / design** — wire indexes or honest explain |
-| #280 | **Correctness** — stale fetchAll cache |
-| #279 | **Correctness** — nested `queue.sync` deadlock (not beginner) |
+| #261, #292 | **Docs**: O(log n) honesty |
+| #274 | **Enhancement / design**: wire indexes or honest explain |
+| #280 | **Correctness**: stale fetchAll cache |
+| #279 | **Correctness**: nested `queue.sync` deadlock (not beginner) |
 
-Default public execution is **`fetchAll` + in-memory filter** — do not assume indexed execution.
+Default public execution is **`fetchAll` + in-memory filter**: do not assume indexed execution.
 
 ### Validation
 
@@ -175,7 +175,7 @@ BLAZEDB_BENCH_MODE=write_profile BLAZEDB_WRITE_PROFILE_RECORDS=10 \
 1. `BlazeDBC/include/blazedb.h`
 2. `BlazeDBC/BlazeDBC.swift`
 3. [C_ABI_BYTE_KV](../Architecture/C_ABI_BYTE_KV.md)
-4. `Examples/C/hello_blazedb.c`, `Examples/Go/README.md` (Go sources not checked in yet — #264)
+4. `Examples/C/hello_blazedb.c`, `Examples/Go/README.md` (Go sources not checked in yet: #264)
 5. Tour: [05_BLAZEDBC](../Architecture/TOURS/05_BLAZEDBC.md)
 6. `BlazeDBTests/Tier1Core/API/BlazeDBCSmokeTests.swift`
 
@@ -221,7 +221,7 @@ swift build -c release --product BlazeDBC
 | Issue | Notes |
 |-------|-------|
 | #270 | Platform PBKDF2 (keep 600k iterations) |
-| #271 | `engine_only` cold open still pays KDF — attribution |
+| #271 | `engine_only` cold open still pays KDF: attribution |
 | #275 | LiveQuery refresh cost |
 | #291 | Widen write-profile + external fsync validation |
 | #276 | Optimize only after #291 |

--- a/README.md
+++ b/README.md
@@ -41,32 +41,23 @@ BlazeDB’s public database-opening APIs require a password, and persisted data 
 
 Near-term work is packaging and documentation honesty for contributors, with maintainer attention ordered as: security correctness (RLS) → continuous verification → durability invariants → performance (after measurement). See [ROADMAP.md](ROADMAP.md).
 
-The [issue tracker](https://github.com/Mikedan37/BlazeDB/issues) mixes verified defects, contributor tasks, documentation work, and deferred platform improvements. **Not every open issue is a release blocker**, and the full catalog is not the onboarding path. Prefer the shelf below, then labels:
-
-| Label / filter | Meaning |
-|----------------|---------|
-| [`good first issue`](https://github.com/Mikedan37/BlazeDB/labels/good%20first%20issue) | Bounded docs/tooling/tests for new contributors |
-| [`help wanted`](https://github.com/Mikedan37/BlazeDB/labels/help%20wanted) | Maintainer-backed outside contributions (curated shelf below) |
-| [`durability`](https://github.com/Mikedan37/BlazeDB/labels/durability) / [`concurrency`](https://github.com/Mikedan37/BlazeDB/labels/concurrency) / [`High Priority`](https://github.com/Mikedan37/BlazeDB/labels/High%20Priority) | Maintainer-owned correctness |
-| [`needs design`](https://github.com/Mikedan37/BlazeDB/labels/needs%20design) | Contract decision before coding |
-| Experimental / later | Android, KMM, deferred sync — see [Compatibility](Docs/COMPATIBILITY.md) and [ROADMAP](ROADMAP.md) |
+The [issue tracker](https://github.com/Mikedan37/BlazeDB/issues) mixes verified defects, contributor tasks, documentation work, and deferred platform improvements. **Not every open issue is a release blocker**, and the full catalog is not the onboarding path. Prefer the contributor entry below (label filters), then [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ### Want to contribute? Start here
 
-A small shelf of scoped issues — not the full tracker. Claim one, comment on the issue, follow [CONTRIBUTING.md](CONTRIBUTING.md).
+BlazeDB welcomes focused contributions across documentation, developer tooling,
+tests, platform support, and core correctness.
 
-| Theme | Issue | Scope |
-|-------|-------|-------|
-| Documentation | [#329](https://github.com/Mikedan37/BlazeDB/issues/329) | Document that `close()` rolls back an open transaction |
-| Documentation | [#332](https://github.com/Mikedan37/BlazeDB/issues/332) | Remove or qualify unsupported distributed architecture claims |
-| Developer experience | [#259](https://github.com/Mikedan37/BlazeDB/issues/259) | Stop advertising `blazedb doctor` as a top-level CLI subcommand |
-| Tooling | [#330](https://github.com/Mikedan37/BlazeDB/issues/330) | Crypto/security-change checklist (+ PR checkbox). Sibling: [#333](https://github.com/Mikedan37/BlazeDB/issues/333) (benchmark checklist) |
-| Small correctness | [#320](https://github.com/Mikedan37/BlazeDB/issues/320) | `deleteBatch` should clear fetch-all cache. Sibling: [#321](https://github.com/Mikedan37/BlazeDB/issues/321) (insertMany RLS order) |
-| Small correctness | [#327](https://github.com/Mikedan37/BlazeDB/issues/327) | `where(notEquals:)` vs missing fields |
-| Tests / compatibility | [#326](https://github.com/Mikedan37/BlazeDB/issues/326) | Assert rollback restores secondary indexes |
-| CLI polish | [#258](https://github.com/Mikedan37/BlazeDB/issues/258) | `blazedb --version` prints release SemVer |
+Start with:
 
-More filters and claim etiquette: [ISSUE_GUIDE](Docs/Contributing/ISSUE_GUIDE.md). Roadmap and audits: [ROADMAP.md](ROADMAP.md) · [Docs/Product/](Docs/Product/) · [Docs/Audit/](Docs/Audit/).
+- [Good first issues](https://github.com/Mikedan37/BlazeDB/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
+- [Help wanted](https://github.com/Mikedan37/BlazeDB/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)
+- [Contribution guide](CONTRIBUTING.md)
+- [Issue guide](Docs/Contributing/ISSUE_GUIDE.md)
+- [Learning paths](Docs/Contributing/LEARNING_PATHS.md)
+- [Roadmap](ROADMAP.md)
+
+Comment on an issue before starting substantial work so scope and ownership are clear.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 BlazeDB is an encrypted embedded database with a stable native interface, broad platform support, active correctness work, and several carefully scoped ways to contribute.
 
-It is Swift-native for local applications: typed models, transactions, WAL recovery, CLI tooling, and a documented C ABI — single-process by design. It runs inside your process, stores data on-device, and does not require a separate database server or network connection. “Local” means in-process persistence, not multiplayer sync or distributed replicas.
+It is Swift-native for local applications: typed models, transactions, WAL recovery, CLI tooling, and a documented C ABI: single-process by design. It runs inside your process, stores data on-device, and does not require a separate database server or network connection. “Local” means in-process persistence, not multiplayer sync or distributed replicas.
 
 You can use BlazeDB from Swift, from the `blazedb` CLI, or through its C ABI. The primary open-source product is the embedded Swift engine; the C ABI reaches that same engine and is not a separate product story.
 


### PR DESCRIPTION
## Summary
- Replace the hard-coded “Want to contribute?” issue table in `README.md` with live label filters (`good first issue`, `help wanted`) plus contributor/docs links.
- Drop `Docs/Audit/` from the main contributor callout (audits stay available from roadmap/maintainer paths).
- Update `CONTRIBUTING.md` Finding work so it no longer points at a README shelf — same label-driven guidance.

## Test plan
- [x] Diff is `README.md` + `CONTRIBUTING.md` only
- [x] No hard-coded issue numbers (`#329`, `#327`, etc.) in the contribute entry
- [x] Good first / help wanted links are open-issue label queries
- [ ] Spot-check that those GitHub label queries still resolve