### PR TITLE
fix(docs,ci): Android CI tier accuracy and badge cancel poison

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,9 @@ on:
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Cancel superseded PR runs only. Cancelling main pushes paints the workflow
+  # badge "failing" even when nothing failed (GitHub treats cancelled ≈ failed).
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/Docs/COMPATIBILITY.md
+++ b/Docs/COMPATIBILITY.md
@@ -56,9 +56,9 @@ Use these words consistently:
 | Term | Meaning |
 |------|---------|
 | **Declared** | Appears in `Package.swift` `platforms:` |
-| **CI-tested (runtime)** | Automated tests run on that OS in CI |
-| **CI-tested (compile)** | Cross-compile succeeds in CI without claiming full runtime coverage |
-| **Experimental** | Engineering validation exists; not a production SDK claim (Android / KMM paths) |
+| **CI-tested (runtime)** | Automated engine tests run on that OS in CI (host Tier0 / Tier1) |
+| **CI-tested (compile)** | Cross-compile succeeds in CI without claiming full engine XCTest coverage |
+| **CI-validated (experimental)** | PR-gate jobs prove a path works; not a published production SDK |
 
 The root README summarizes this table. This document remains the detailed matrix.
 
@@ -78,8 +78,14 @@ The root README summarizes this table. This document remains the detailed matrix
 - **Notes:** Some advanced features disabled (`BLAZEDB_LINUX_CORE`). CI baseline lane targets Swift 6.0 for core + Tier 0 stability checks.
 
 ### Android
-- **Status:** Core path only — **not yet officially supported** for app integration
-- **Notes:** Same compile-time mode as Linux (`BLAZEDB_LINUX_CORE`). Cross-compilation requires **OSS Swift 6.3.2+** (matching the Android SDK bundle), the [Swift SDK for Android](https://swift.org/documentation/articles/swift-sdk-for-android-getting-started.html), and NDK r27d+. PR CI cross-compiles `BlazeDBAndroidBridge` on Linux and compiles the KMM `:shared` Android target (`:shared:compileDebugKotlinAndroid`).
+- **Status:** **CI-validated (experimental packaging)**: not “unsupported,” and not the same product tier as macOS/Linux
+- **What PR CI proves today:**
+  - Cross-compile `BlazeDBCore` / `BlazeDBAndroidBridge` for Android ABIs (`Android — Cross-Compile`)
+  - KMM `:shared:compileDebugKotlinAndroid`
+  - KMM x86_64 emulator instrumentation smoke (`KMM Android — x86_64 Emulator Runtime`: `open` / `put` / `query`)
+  - Local packaging scripts / PR packaging job (AAR / native libs; **not** published to Maven Central)
+- **What it is not:** Linux-style host `BlazeDB_Tier0` / `BlazeDB_Tier1` on an Android device; not a `Package.swift` `platforms:` entry; not a shipped consumer SDK
+- **Notes:** Same compile-time core mode as Linux (`BLAZEDB_LINUX_CORE`). Cross-compilation requires **OSS Swift 6.3.2+** (matching the Android SDK bundle), the [Swift SDK for Android](https://swift.org/documentation/articles/swift-sdk-for-android-getting-started.html), and NDK r27d+.
 - **Detail:** [android-status.md](android-status.md)
 
 #### OSS Swift vs Xcode Swift (Android cross-compile)
@@ -100,7 +106,7 @@ compiled module was created by an older version of the compiler; rebuild 'Founda
 
 That is a toolchain mismatch, not a BlazeDB bug. Install OSS Swift 6.3.2+ (for example via [swiftly](https://www.swift.org/install/)) and ensure `swift --version` does **not** report `Apple Swift`. Use `./Scripts/ci-android-cross-compile.sh` on CI or locally.
 
-**KMM:** Kotlin Multiplatform integration is **in progress** — `expect class BlazeDB` in `Examples/android/shared` with iOS simulator runtime in PR CI and Android emulator runtime verified locally. BlazeDB does **not** claim full “Kotlin Multiplatform supported” until Android runtime is in CI and consumer packaging (AAR/XCFramework) exists. See [android-status.md](android-status.md).
+**KMM:** Kotlin Multiplatform sample (`expect class BlazeDB` in `Examples/android/shared`) has **iOS simulator and Android emulator runtime in the PR gate**, plus local packaging scripts. That is **CI-validated experimental** integration: not a published KMM SDK (no Maven Central / CocoaPods trunk). See [android-status.md](android-status.md).
 
 ---
 
@@ -196,7 +202,7 @@ See `CONTRIBUTING.md` for bug report templates and guidelines.
 
 ## Summary
 
-**Core:** Swift 6 compliant. **macOS** and **Linux** have runtime CI for the embedded core; **iOS / watchOS / tvOS / visionOS** are declared and compile-tested (not BlazeDBCore XCTest runtime on device/simulator in the PR gate). Android / KMM remain experimental — see [android-status.md](android-status.md).
+**Core:** Swift 6 compliant. **macOS** and **Linux** have host runtime CI for the embedded core (Tier0 / Tier1). **iOS / watchOS / tvOS / visionOS** are declared and compile-tested (not BlazeDBCore XCTest runtime on device/simulator in the PR gate). **Android / KMM** are **CI-validated (experimental packaging)**: PR-gate cross-compile + KMM emulator smoke, not a published SDK and not Linux-equivalent host Tier0. See [android-status.md](android-status.md).
 **Distributed:** Deferred / excluded from default OSS packaging
 **Storage:** Format intended to be stable; prior-release open fixtures exist under `Tests/CompatibilityFixtures/` but are not yet a CI release gate (see [ROADMAP.md](../ROADMAP.md))
 **APIs:** Core APIs stable within the documented surface; experimental APIs must stay clearly marked

--- a/Docs/GettingStarted/WHY_NOT_SQLITE.md
+++ b/Docs/GettingStarted/WHY_NOT_SQLITE.md
@@ -20,9 +20,9 @@ This page is about **product fit**, not stopwatch marketing. Measured latency an
 
 | | BlazeDB |
 |--|---------|
-| **Platform support** | macOS and Linux **runtime-tested**; Apple platforms (iOS / watchOS / tvOS) **compile-tested**; Android / KMM **experimental** |
+| **Platform support** | macOS and Linux **runtime-tested** (host engine tests); Apple platforms (iOS / watchOS / tvOS) **compile-tested**; Android / KMM **CI-validated** (cross-compile + emulator smoke) with **experimental packaging** |
 
-Do not treat Android or KMM as the same maturity as macOS/Linux. Details: [COMPATIBILITY.md](../COMPATIBILITY.md), [android-status.md](../android-status.md).
+Do not treat Android or KMM as the same maturity as macOS/Linux host Tier0, and do not call them unsupported: the PR gate cross-compiles the bridge and runs a KMM emulator smoke. Details: [COMPATIBILITY.md](../COMPATIBILITY.md), [android-status.md](../android-status.md).
 
 SQLite’s C API remains the broader “runs everywhere” option when you need one binary story across many languages and hosts.
 
@@ -44,7 +44,7 @@ These rows describe the **default open-source package**, not roadmap aspirations
 | Optional schema validation and migrations | **Shipped (opt-in)** | Flexible by default; **migrations exist** when you opt in, not “schema-less / no migrations” |
 | Concurrency model | **Shipped (qualified)** | Single-process embedded engine. Transactions provide consistency. **MVCC / snapshot isolation exists in the codebase but is not the default path**. Do not market “MVCC snapshot isolation” as the everyday guarantee. |
 | Optional Secure Enclave-assisted key storage | **Platform optional** | Not required for default password-derived encryption |
-| Android / KMM consumption | **Experimental** | Engineering validation; not a production SDK claim |
+| Android / KMM consumption | **CI-validated (experimental packaging)** | PR-gate cross-compile + emulator smoke; not a published SDK; not Linux host Tier0 |
 | Multi-device sync / discovery / network server | **Deferred** | Not part of the default OSS package. See [DISTRIBUTED_TRANSPORT_DEFERRED.md](../Status/DISTRIBUTED_TRANSPORT_DEFERRED.md) |
 | SQL string dialect | **Not shipped** | Use SQLite if you need SQL |
 
@@ -81,7 +81,7 @@ Older comparison tables in the repo sometimes claimed mythology. Prefer this pag
 | **Concurrency** | Single-process embedded design; multi-process writers unsupported; network filesystems not recommended. Do not claim absolute “MVCC snapshot isolation” as the default product behavior. |
 | **Performance** | Cite [Benchmarks](../Benchmarks/README.md) only. Do **not** use “predictable, optimized for Apple Silicon” or free-floating “% faster than SQLite” slogans. |
 | **Encryption** | At-rest pages: **AES-256-GCM** with password-derived keys on public open APIs. SQLite encryption remains optional/extension-based (e.g. SQLCipher). |
-| **Platforms** | macOS/Linux runtime-tested; other Apple platforms compile-tested; Android/KMM experimental. |
+| **Platforms** | macOS/Linux runtime-tested (host engine tests); other Apple platforms compile-tested; Android/KMM CI-validated with experimental packaging. |
 | **Sync** | Deferred from the default OSS package, not a selection reason today. |
 
 ### Brief notes on Core Data and Realm

--- a/Docs/Testing/CI_AND_TEST_TIERS.md
+++ b/Docs/Testing/CI_AND_TEST_TIERS.md
@@ -370,10 +370,10 @@ All other `Tier1Core` directories and files (Aggregation, API, Query, Integratio
 - `./Scripts/run-tier2.sh`
 - `./Scripts/run-tier3.sh`
 
-- KMM runtime proof (local; iOS also in PR gate):
+- KMM runtime proof (PR gate + local):
 - `./Scripts/build-kmm-ios-bridge.sh` — static Swift bridge for iOS device + simulator
-- `./Scripts/prove-kmm-ios-runtime.sh` — iOS simulator `iosSimulatorArm64Test`
-- `./Scripts/prove-kmm-android-runtime.sh` — Android emulator via sample app (`KMM RUNTIME OK`)
+- `./Scripts/prove-kmm-ios-runtime.sh` — iOS simulator `iosSimulatorArm64Test` (also in macOS PR job)
+- `./Scripts/prove-kmm-android-runtime.sh` — Android emulator via sample app (`KMM RUNTIME OK`; CI uses `ci-kmm-android-emulator-smoke.sh` on Linux x86_64)
 - `./Scripts/prove-kmm-runtime.sh` — both platforms
 
 ## Interpreting CI failures (first artifact, not last passer)

--- a/Docs/android-status.md
+++ b/Docs/android-status.md
@@ -6,7 +6,7 @@ The question “can BlazeDB be consumed from Kotlin Multiplatform?” is **answe
 This document describes **what is verified today**, not a shipped product surface.  
 For platform matrices and API stability, see [COMPATIBILITY.md](COMPATIBILITY.md).
 
-**Not officially supported:** Android app integration and KMM remain **experimental** engineering targets — not production SDK claims.
+**Not a published SDK:** Android app integration and KMM remain **CI-validated experimental packaging**. PR-gate jobs prove the path; Maven Central / CocoaPods trunk are not product claims.
 
 The `:shared` module (`expect class BlazeDB`) is **runtime-verified in CI** (iOS simulator + Android instrumentation) with local packaging scripts. That is **validation scaffolding** in `Examples/android/` — not “Kotlin Multiplatform supported” product wording.
 
@@ -35,7 +35,7 @@ Prove each layer before adding the next. Wrapping an unverified stack in KMM onl
 |---|-------|------------|-------|
 | 1 | Swift library (`BlazeDBCore`) | 🟢 | OSS Swift 6.3.2 + NDK r27d; NDK clang/libc++ header path fixes in CI |
 | 2 | C ABI (`BlazeDBAndroidBridge`) | 🟢 | `blazedb_bridge_*` exports cross-compile in CI |
-| 3 | JNI (C shim → Kotlin `external`) | 🟢 compile / 🟡 runtime | Android `actual` — compile in CI; runtime verified locally |
+| 3 | JNI (C shim → Kotlin `external`) | 🟢 compile / 🟢 runtime (sample) | Android `actual` — compile + emulator instrumentation in PR gate |
 | 4 | KMM `commonMain` API | 🟡 | `expect class BlazeDB` — `open` / `put` / `get` / `query` / `close` |
 | 5 | iOS simulator runtime | 🟢 | `BlazeDBRuntimeSmokeTest` in PR CI |
 | 6 | Android emulator runtime | 🟢 | `ci-kmm-android-emulator-smoke.sh` in macOS PR job + local prove script |
@@ -68,7 +68,7 @@ For the full design of ``BlazeLiveQuery`` (lifecycle, threading, adapters, evide
 | Swift-on-Android cross-compile | 🟢 | hello-world + `BlazeDBCore` + `BlazeDBAndroidBridge` in PR gate |
 | Requires **OSS Swift** (not Xcode `swift`) | 🟢 | Apple Swift fails with Foundation module mismatch |
 | C ABI + JNI + Kotlin sample **source** | 🟢 compile | `Examples/BlazeDBAndroidBridge`, `Examples/android/` |
-| JNI + KMM sample | 🟢 compile / 🟡 runtime | `Examples/android/` — Android runtime local; iOS runtime in CI |
+| JNI + KMM sample | 🟢 compile / 🟢 runtime | `Examples/android/` — Android + iOS runtime in PR gate |
 | KMM integration | 🟡 | Same `commonMain` API on both platforms — **not** “KMM supported” product wording yet |
 | Default Android database directory | — | Not defined; use `BlazeDB.open(at:password:)` with app-scoped path |
 
@@ -79,7 +79,7 @@ For the full design of ``BlazeLiveQuery`` (lifecycle, threading, adapters, evide
 These are **not** the same thing.
 
 - **Swift-on-Android:** BlazeDB Swift source cross-compiled to native Android libraries. Kotlin/Java call in via JNI. This is the realistic near-term path — and the path the sample follows.
-- **KMM (Kotlin Multiplatform):** Shared Kotlin (`Examples/android/shared`) calling BlazeDB through platform `actual` implementations — Android via JNI, iOS via cinterop → same Swift C ABI. **Runtime verified** on iOS simulator (CI) and Android emulator (local). BlazeDB does **not** claim full “Kotlin Multiplatform supported” until Android runtime is in CI and consumer packaging exists.
+- **KMM (Kotlin Multiplatform):** Shared Kotlin (`Examples/android/shared`) calling BlazeDB through platform `actual` implementations — Android via JNI, iOS via cinterop → same Swift C ABI. **Runtime verified** on iOS simulator and Android emulator **in the PR gate**. Packaging scripts exist locally; registry publish is not a product claim.
 
 Do **not** rush KMM. “Supports KMM” is a buzzword; wrapping an unproven runtime path makes debugging miserable because you cannot tell which layer is lying.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BlazeDB
 
-BlazeDB is an encrypted, in-process database engine written in Swift for applications and in-process services. It provides typed document APIs, raw key-value access, transactional write APIs, WAL-backed recovery, live queries, SwiftUI integration on Apple platforms, local inspection tools, Linux runtime support, a documented C ABI for native embeds, and experimental Android/KMM paths. Go and other languages can call the C ABI through cgo or FFI; no official language SDKs are published.
+BlazeDB is an encrypted, in-process database engine written in Swift for applications and in-process services. It provides typed document APIs, raw key-value access, transactional write APIs, WAL-backed recovery, live queries, SwiftUI integration on Apple platforms, local inspection tools, Linux runtime support, a documented C ABI for native embeds, and CI-validated Android/KMM paths (experimental packaging). Go and other languages can call the C ABI through cgo or FFI; no official language SDKs are published.
 
 It runs inside your process. No separate database server is required.
 
@@ -15,11 +15,11 @@ It runs inside your process. No separate database server is required.
 
 | Tier | Platforms |
 |------|-----------|
-| **Runtime CI** | macOS, Linux |
+| **Runtime CI** (host engine tests) | macOS, Linux |
 | **Declared and compile-tested** | iOS, watchOS, tvOS, visionOS |
-| **Experimental** | Android cross-compilation, KMM sample |
+| **CI-validated (experimental packaging)** | Android cross-compile + KMM sample runtime in the PR gate |
 
-Details: [Compatibility](Docs/COMPATIBILITY.md) · [android-status.md](Docs/android-status.md).
+Android is **not unsupported**: the PR gate cross-compiles the bridge and runs a KMM emulator smoke. It is also **not the same tier as Linux** (no host `BlazeDB_Tier0` on Android; not in `Package.swift` `platforms:`; no published consumer SDK). Details: [Compatibility](Docs/COMPATIBILITY.md) · [android-status.md](Docs/android-status.md).
 
 ---
 
@@ -70,7 +70,7 @@ CI also verifies the README snippets: `swift run ReadmeSamples`.
 - **Inspection tooling:** Explore databases with the shipped `blazedb` CLI/REPL; companion macOS apps and maintenance executables are listed below.
 - **Linux runtime:** Core engine is exercised in Linux CI alongside macOS. [Linux getting started](Docs/GettingStarted/LINUX_GETTING_STARTED.md).
 - **Native embeds:** The same engine is reachable through `BlazeDBC` (`blazedb.h`). [C ABI contract](Docs/Architecture/C_ABI_BYTE_KV.md).
-- **Experimental Android/KMM:** Cross-compile and sample paths exist; not a production mobile SDK. [android-status.md](Docs/android-status.md).
+- **Android / KMM (CI-validated, experimental packaging):** PR-gate cross-compile + KMM emulator smoke exist; not a published mobile SDK and not Linux-equivalent host Tier0. [android-status.md](Docs/android-status.md).
 
 ---
 
@@ -87,7 +87,7 @@ CI also verifies the README snippets: `swift run ReadmeSamples`.
 | Encryption and vulnerability reporting | [Key management](Docs/Status/KEY_MANAGEMENT_AND_COMPATIBILITY.md) · [SECURITY.md](SECURITY.md) |
 | Live queries / SwiftUI | [Live query architecture](Docs/Architecture/LIVE_QUERY_ARCHITECTURE.md) · [SwiftUI patterns](Docs/GettingStarted/SWIFTUI_DATABASE_PATTERNS.md) |
 | Linux setup | [LINUX_GETTING_STARTED.md](Docs/GettingStarted/LINUX_GETTING_STARTED.md) |
-| Android / KMM (experimental) | [android-status.md](Docs/android-status.md) |
+| Android / KMM (CI-validated; experimental packaging) | [android-status.md](Docs/android-status.md) |
 | Platform support tiers | [Compatibility](Docs/COMPATIBILITY.md) |
 | Benchmarks and methodology | [Docs/Benchmarks](Docs/Benchmarks/README.md) |
 | Contribute | [Contributing](#contributing) · [CONTRIBUTING.md](CONTRIBUTING.md) |
@@ -166,7 +166,7 @@ It is not a standalone network database server and not a multi-device sync produ
 - Distributed sync, discovery, server, and full telemetry packaging are deferred from the default OSS product ([Distributed Transport Deferred](Docs/Status/DISTRIBUTED_TRANSPORT_DEFERRED.md)).
 - Multi-process writers are not supported.
 - Network filesystems are not recommended.
-- Android and KMM remain experimental.
+- Android and KMM are CI-validated in the PR gate but remain experimental packaging (not a published SDK; not Linux host Tier0).
 - The C ABI enables native embeds; there are no official Go, Rust, or Python SDKs.
 
 Direction (not release guarantees): [ROADMAP.md](ROADMAP.md).
@@ -267,7 +267,7 @@ Full catalog with support-state labels: [Examples/README.md](Examples/README.md)
 | [VaporServer](Examples/VaporServer/) | Conditional | Embed sample; not a Package product |
 | [Go preview](Examples/Go/README.md) | Preview | cgo recipe; no checked-in `.go` module |
 | [SwiftUIExample.swift](Examples/SwiftUIExample.swift) | Sample file | Advanced raw-row patterns; default SwiftUI path is [SWIFTUI_DATABASE_PATTERNS](Docs/GettingStarted/SWIFTUI_DATABASE_PATTERNS.md) |
-| Android / KMM samples | Experimental | [android-status.md](Docs/android-status.md) |
+| Android / KMM samples | CI-validated; experimental packaging | [android-status.md](Docs/android-status.md) |
 
 Sync and telemetry samples are deferred or conditional. They are not default onboarding.
 


### PR DESCRIPTION
## Summary
- **Badge:** The “PR Gate failing” badge was a false alarm. Rapid merges to `main` cancelled in-progress runs (`cancel-in-progress: true`); GitHub treats **cancelled** workflow runs as badge-red. Restrict cancel-in-progress to pull requests only.
- **Android tier:** Android/KMM is **not unsupported**. PR gate already runs cross-compile, Kotlin compile, and x86_64 emulator smoke. It is also **not the same as Linux**: no host `BlazeDB_Tier0` on Android, not in `Package.swift` `platforms:`, no published SDK. Docs + README platform table now say **CI-validated (experimental packaging)**.

## Test plan
- [x] Diff covers `ci.yml` concurrency + support docs + minimal README platform wording
- [ ] Next successful `main` PR Gate run should restore a green/passing badge (after the currently queued #392 run finishes)
- [ ] Confirm Android jobs still listed in the PR Gate workflow