### PR TITLE
ci: isolate main workflow concurrency per run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,12 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
-  # Cancel superseded PR runs only. Cancelling main pushes paints the workflow
-  # badge "failing" even when nothing failed (GitHub treats cancelled ≈ failed).
+  # PRs: one group per PR ref; cancel superseded PR runs.
+  # main/develop pushes: unique group per run so a newer push does not cancel a
+  # still-pending earlier push (GitHub cancels pending peers in a shared group
+  # even when cancel-in-progress is false). That pending-cancel was painting the
+  # workflow badge "failing" after rapid merges.
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:


### PR DESCRIPTION
## Summary
Follow-up to #393. `cancel-in-progress: false` on main still lets a newer push **cancel a pending earlier main run** in the same concurrency group (GitHub behavior). That is what cancelled the #393 main run when the next push arrived, leaving the badge red.

Use `github.run_id` in the concurrency group for non-PR events so each main push is independent. PR refs still share a group and still cancel superseded PR work.

## Test plan
- [ ] Merge after current main PR Gate is green
- [ ] Confirm subsequent main pushes do not cancel each other while queued