### PR TITLE
fix(query): async notEquals treats a missing field as a match

### DIFF
--- a/BlazeDB/Query/QueryBuilder+Async.swift
+++ b/BlazeDB/Query/QueryBuilder+Async.swift
@@ -29,13 +29,19 @@ extension QueryBuilder {
         return self
     }
     
-    /// Filter records where field does not equal value (async)
+    /// Filter records where field does not equal value (async).
+    ///
+    /// A missing field is treated as matching `notEquals` — i.e. a record
+    /// with no `field` at all counts as "not equal to `value`", consistent
+    /// with the synchronous `where(_:notEquals:)` semantics. This is the
+    /// deliberate asymmetry with `where(_:equals:)`, which treats a missing
+    /// field as a non-match.
     @discardableResult
     public func `where`(_ field: String, notEquals value: BlazeDocumentField) async -> QueryBuilder {
         // Inline sync version logic to avoid recursion with async method
         BlazeLogger.debug("Query: WHERE \(field) != \(value)")
         filters.append { record in
-            guard let fieldValue = record.storage[field] else { return false }
+            guard let fieldValue = record.storage[field] else { return true }
             return !fieldsEqual(fieldValue, value)
         }
         return self

--- a/BlazeDBTests/Tier0Core/CoreCorrectness/AsyncNotEqualsMissingFieldTests.swift
+++ b/BlazeDBTests/Tier0Core/CoreCorrectness/AsyncNotEqualsMissingFieldTests.swift
@@ -1,0 +1,100 @@
+//
+//  AsyncNotEqualsMissingFieldTests.swift
+//  BlazeDBTests — #344: async where(notEquals:) treats missing field as non-match
+//
+//  The async query path (QueryBuilder+Async.swift) inlines a copy of the
+//  sync predicate. It must match the sync semantics fixed in #343: a
+//  missing field counts as "not equal" to any given value, while
+//  `where(_:equals:)` (correct, unchanged) treats a missing field as a
+//  non-match — the two are deliberately asymmetric.
+//
+//  The async query path is Apple-only (`#if !BLAZEDB_LINUX_CORE`), so these
+//  tests compile and run only where that path exists.
+//
+
+import XCTest
+#if canImport(BlazeDBCore)
+@testable import BlazeDBCore
+#else
+@testable import BlazeDB
+#endif
+
+#if !BLAZEDB_LINUX_CORE
+final class AsyncNotEqualsMissingFieldTests: XCTestCase {
+    private var dbURL: URL!
+    private var db: BlazeDBClient!
+
+    override func setUp() {
+        super.setUp()
+        dbURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("AsyncNotEqualsMissing-\(UUID().uuidString).blazedb")
+        db = try! BlazeDBClient(
+            name: "AsyncNotEqualsMissing",
+            fileURL: dbURL,
+            password: "AsyncNotEqualsMissing-Pass_123!"
+        )
+    }
+
+    override func tearDown() {
+        try? db.close()
+        let base = dbURL.deletingPathExtension()
+        for ext in ["blazedb", "meta", "wal", "salt", "indexes"] {
+            try? FileManager.default.removeItem(at: base.appendingPathExtension(ext))
+        }
+        try? FileManager.default.removeItem(at: dbURL)
+        db = nil
+        dbURL = nil
+        super.tearDown()
+    }
+
+    /// #344 reproduction: a record with no `status` field at all must match
+    /// async `notEquals: .string("archived")`, alongside a record whose
+    /// `status` is present but unequal. A record whose `status` equals the
+    /// given value must still be excluded.
+    func testAsyncNotEquals_MissingField_MatchesAlongsidePresentUnequal() async throws {
+        _ = try await db.insert(BlazeDataRecord(["name": .string("a")])) // no status field
+        _ = try await db.insert(BlazeDataRecord(["name": .string("b"), "status": .string("archived")]))
+        _ = try await db.insert(BlazeDataRecord(["name": .string("c"), "status": .string("active")]))
+
+        let query = await db.query()
+            .where("status", notEquals: .string("archived"))
+        let rows = try await query.execute()
+
+        let names = Set(try rows.records.compactMap { $0.storage["name"]?.stringValue })
+        XCTAssertEqual(names, ["a", "c"])
+    }
+
+    func testAsyncNotEquals_PresentEqualValue_IsExcluded() async throws {
+        _ = try await db.insert(BlazeDataRecord(["name": .string("archived-one"), "status": .string("archived")]))
+
+        let query = await db.query()
+            .where("status", notEquals: .string("archived"))
+        let rows = try await query.execute()
+
+        XCTAssertTrue(rows.isEmpty)
+    }
+
+    func testAsyncNotEquals_PresentUnequalValue_IsIncluded() async throws {
+        _ = try await db.insert(BlazeDataRecord(["name": .string("active-one"), "status": .string("active")]))
+
+        let query = await db.query()
+            .where("status", notEquals: .string("archived"))
+        let rows = try await query.execute()
+
+        XCTAssertEqual(rows.count, 1)
+        XCTAssertEqual(try rows.records.first?.storage["name"]?.stringValue, "active-one")
+    }
+
+    /// Scope guard: async `equals` missing-field behavior is unchanged by
+    /// this fix (still a non-match).
+    func testAsyncEquals_MissingField_IsStillExcluded() async throws {
+        _ = try await db.insert(BlazeDataRecord(["name": .string("no-status")])) // no status field
+
+        let query = await db.query()
+            .where("status", equals: .string("archived"))
+        let rows = try await query.execute()
+
+        XCTAssertTrue(rows.isEmpty)
+    }
+}
+#endif // !BLAZEDB_LINUX_CORE

--- a/BlazeDBTests/Tier0Core/CoreCorrectness/AsyncNotEqualsMissingFieldTests.swift
+++ b/BlazeDBTests/Tier0Core/CoreCorrectness/AsyncNotEqualsMissingFieldTests.swift
@@ -1,6 +1,6 @@
 //
 //  AsyncNotEqualsMissingFieldTests.swift
-//  BlazeDBTests — #344: async where(notEquals:) treats missing field as non-match
+//  BlazeDBTests — #344: async where(notEquals:) treats missing field as a match
 //
 //  The async query path (QueryBuilder+Async.swift) inlines a copy of the
 //  sync predicate. It must match the sync semantics fixed in #343: a


### PR DESCRIPTION
## Summary

- **What changed?** The async `where(_:notEquals:)` now treats a record with no value for the queried field as a match, instead of excluding it.
- **Why was it needed?** Fixes #344 — the same defect #343 fixed on the synchronous path, in the async twin.

## Scope

- **In scope:** the missing-field guard in `QueryBuilder+Async.swift` and its doc comment, plus tests.
- **Out of scope:** the async `equals` / `greaterThan` / `lessThan` guards, which correctly return `false` for a missing field. One of the new tests asserts `equals` still excludes it, so that boundary is pinned rather than assumed.

## Validation

```bash
swift build --target BlazeDBCore                              # rc=0
BLAZEDB_TEST_SCOPE=tier0 swift test --filter BlazeDB_Tier0    # rc=0, 215 tests, 0 failures
swift test --filter BlazeDB_CLITests                          # rc=0, 65 tests, 0 failures
swift build --product blazedb / --target BlazeDoctor / BlazeDump / BlazeInfo   # all rc=0
```

The new tests live in `BlazeDBTests/Tier0Core/CoreCorrectness/`, alongside #343's.

**Honest caveat on where these run:** the async path is `#if !BLAZEDB_LINUX_CORE`, so the test class is compiled out on Linux and only executes on the macos-15 job. To prove it isn't vacuous I temporarily flipped only those two `#if` lines to `#if true` (production + test, both restored, absent from the diff) and reverted just the guard — verbatim:

```
AsyncNotEqualsMissingFieldTests.swift:64: error: XCTAssertEqual failed: ("["c"]") is not equal to ("["a", "c"]")
Executed 4 tests, with 1 failure
```

With the fix, 4/4 pass. Apple CI is the real gate for these.

## Checklist

- [x] One branch = one concern
- [x] `git status` / `git diff` reviewed for containment — 2 files
- [x] Docs updated in this PR if behavior or public usage changed — the doc comment now states the missing-field behaviour explicitly
- [x] `Docs/SYSTEM_MAP.md` / `Docs/Testing/CI_AND_TEST_TIERS.md` — not triggered; a bug fix that changes no shipped surface, no tier or lane change
- [x] Storage/WAL/encryption/recovery — not applicable
- [ ] CI checks pass — fork PR, will confirm once the run is approved

Generated by Claude Opus 5 (brief, review), Kimi K3 (implementation)
