### PR TITLE
fix(query): KeyPath notEquals treats a missing field as a match

### DIFF
--- a/BlazeDB/Query/QueryBuilderKeyPath.swift
+++ b/BlazeDB/Query/QueryBuilderKeyPath.swift
@@ -82,13 +82,19 @@ public class TypeSafeQueryBuilder<T: BlazeStorable> {
         return self
     }
     
-    /// Filter by KeyPath (not equals)
+    /// Filter by KeyPath (not equals).
+    ///
+    /// A missing field is treated as matching `notEquals` — i.e. a record
+    /// with no value for the key path's field at all counts as "not equal
+    /// to `value`", matching the string-based `where(_:notEquals:)`
+    /// semantics. This is the deliberate asymmetry with KeyPath
+    /// `where(_:equals:)`, which treats a missing field as a non-match.
     @discardableResult
     public func `where`<V: Equatable>(_ keyPath: KeyPath<T, V>, notEquals value: V) -> Self {
         let fieldName = extractFieldName(from: keyPath)
         filters.append { record in
-            // Match string-based semantics: missing field returns false (not "not equal")
-            guard let fieldValue = record.storage[fieldName] else { return false }
+            // Match string-based semantics: a missing field counts as "not equal"
+            guard let fieldValue = record.storage[fieldName] else { return true }
 
             if let v = value as? String, let recordValue = fieldValue.stringValue {
                 return recordValue != v

--- a/BlazeDBTests/Tier0Core/CoreCorrectness/KeyPathNotEqualsMissingFieldTests.swift
+++ b/BlazeDBTests/Tier0Core/CoreCorrectness/KeyPathNotEqualsMissingFieldTests.swift
@@ -1,6 +1,6 @@
 //
 //  KeyPathNotEqualsMissingFieldTests.swift
-//  BlazeDBTests — #345: KeyPath where(notEquals:) treats missing field as non-match
+//  BlazeDBTests — #345: KeyPath where(notEquals:) treats missing field as a match
 //
 //  The KeyPath query builder must match the sync string semantics fixed in
 //  #343: a missing field counts as "not equal" to any given value, while

--- a/BlazeDBTests/Tier0Core/CoreCorrectness/KeyPathNotEqualsMissingFieldTests.swift
+++ b/BlazeDBTests/Tier0Core/CoreCorrectness/KeyPathNotEqualsMissingFieldTests.swift
@@ -1,0 +1,106 @@
+//
+//  KeyPathNotEqualsMissingFieldTests.swift
+//  BlazeDBTests — #345: KeyPath where(notEquals:) treats missing field as non-match
+//
+//  The KeyPath query builder must match the sync string semantics fixed in
+//  #343: a missing field counts as "not equal" to any given value, while
+//  KeyPath `where(_:equals:)` (correct, unchanged) treats a missing field
+//  as a non-match — the two are deliberately asymmetric.
+//
+//  The model uses an optional `status` so a task with `status == nil`
+//  encodes with NO `status` key at all (JSONEncoder omits nil optionals),
+//  giving a genuine missing-field record that still round-trips through
+//  `BlazeStorable` decoding.
+//
+
+import XCTest
+#if canImport(BlazeDBCore)
+@testable import BlazeDBCore
+#else
+@testable import BlazeDB
+#endif
+
+final class KeyPathNotEqualsMissingFieldTests: XCTestCase {
+    private var dbURL: URL!
+    private var db: BlazeDBClient!
+
+    struct Task: BlazeStorable {
+        var id: UUID = UUID()
+        var name: String
+        var status: String?
+    }
+
+    override func setUp() {
+        super.setUp()
+        dbURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("KeyPathNotEqualsMissing-\(UUID().uuidString).blazedb")
+        db = try! BlazeDBClient(
+            name: "KeyPathNotEqualsMissing",
+            fileURL: dbURL,
+            password: "KeyPathNotEqualsMissing-Pass_123!"
+        )
+    }
+
+    override func tearDown() {
+        try? db.close()
+        let base = dbURL.deletingPathExtension()
+        for ext in ["blazedb", "meta", "wal", "salt", "indexes"] {
+            try? FileManager.default.removeItem(at: base.appendingPathExtension(ext))
+        }
+        try? FileManager.default.removeItem(at: dbURL)
+        db = nil
+        dbURL = nil
+        super.tearDown()
+    }
+
+    /// #345 reproduction: a record with no `status` field at all must match
+    /// KeyPath `notEquals: "archived"`, alongside a record whose `status`
+    /// is present but unequal. A record whose `status` equals the given
+    /// value must still be excluded.
+    func testKeyPathNotEquals_MissingField_MatchesAlongsidePresentUnequal() throws {
+        _ = try db.insertMany([
+            Task(name: "a", status: nil),          // no status field after encoding
+            Task(name: "b", status: "archived"),
+            Task(name: "c", status: "active"),
+        ])
+
+        let matches = try db.query(Task.self)
+            .where(\.status, notEquals: "archived")
+            .all()
+
+        XCTAssertEqual(Set(matches.map { $0.name }), ["a", "c"])
+    }
+
+    func testKeyPathNotEquals_PresentEqualValue_IsExcluded() throws {
+        _ = try db.insert(Task(name: "archived-one", status: "archived"))
+
+        let matches = try db.query(Task.self)
+            .where(\.status, notEquals: "archived")
+            .all()
+
+        XCTAssertTrue(matches.isEmpty)
+    }
+
+    func testKeyPathNotEquals_PresentUnequalValue_IsIncluded() throws {
+        _ = try db.insert(Task(name: "active-one", status: "active"))
+
+        let matches = try db.query(Task.self)
+            .where(\.status, notEquals: "archived")
+            .all()
+
+        XCTAssertEqual(matches.count, 1)
+        XCTAssertEqual(matches.first?.name, "active-one")
+    }
+
+    /// Scope guard: KeyPath `equals` missing-field behavior is unchanged by
+    /// this fix (still a non-match).
+    func testKeyPathEquals_MissingField_IsStillExcluded() throws {
+        _ = try db.insert(Task(name: "no-status", status: nil)) // no status field
+
+        let matches = try db.query(Task.self)
+            .where(\.status, equals: "archived")
+            .all()
+
+        XCTAssertTrue(matches.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary

- **What changed?** The KeyPath `where(_:notEquals:)` now treats a record with no value for the key path's field as a match, and its comment — which documented the old behaviour — was corrected.
- **Why was it needed?** Fixes #345 — the same defect #343 fixed on the string-based path, in the KeyPath twin. The stale comment read "missing field returns false (not 'not equal')", which described exactly the bug.

## Scope

- **In scope:** the missing-field guard in `QueryBuilderKeyPath.swift`, its comment and doc comment, plus tests.
- **Out of scope:** the KeyPath `equals` / `gt` / `lt` / `gte` / `lte` / `contains` / `in` guards, which correctly return `false`. One new test asserts KeyPath `equals` still excludes a missing field, pinning that boundary.

## Validation

```bash
swift build --target BlazeDBCore                              # rc=0
BLAZEDB_TEST_SCOPE=tier0 swift test --filter BlazeDB_Tier0    # rc=0, 219 tests, 0 failures
swift test --filter BlazeDB_CLITests                          # rc=0, 65 tests, 0 failures
swift build --product blazedb / --target BlazeDoctor / BlazeDump / BlazeInfo   # all rc=0
```

Unlike #344's async tests, these are not platform-gated and run on Linux — 219 is the 215 baseline plus these 4.

Bite-proof, fix reverted and test kept, verbatim:

```
KeyPathNotEqualsMissingFieldTests.swift:71: error: XCTAssertEqual failed: ("["c"]") is not equal to ("["c", "a"]")
```

The fixture uses `status: String?` on a `BlazeStorable` model, because a nil optional is omitted by `JSONEncoder` — that produces a genuinely missing key rather than a null, which is the case under test.

## Checklist

- [x] One branch = one concern
- [x] `git status` / `git diff` reviewed for containment — 2 files
- [x] Docs updated in this PR if behavior or public usage changed — the misleading comment is corrected and the doc comment states the behaviour
- [x] `Docs/SYSTEM_MAP.md` / `Docs/Testing/CI_AND_TEST_TIERS.md` — not triggered
- [x] Storage/WAL/encryption/recovery — not applicable
- [ ] CI checks pass — fork PR, will confirm once the run is approved

Generated by Claude Opus 5 (brief, review), Kimi K3 (implementation)
