### PR TITLE
docs(query): document missing-field notEquals semantics

### DIFF
--- a/BlazeDBTests/Tier0Core/CoreCorrectness/QueryNotEqualsMissingFieldTests.swift
+++ b/BlazeDBTests/Tier0Core/CoreCorrectness/QueryNotEqualsMissingFieldTests.swift
@@ -1,6 +1,6 @@
 //
 //  QueryNotEqualsMissingFieldTests.swift
-//  BlazeDBTests — #327: where(notEquals:) treats missing field as non-match
+//  BlazeDBTests — #327/#343: where(notEquals:) treats missing field as a match
 //
 //  A missing field must match `notEquals`, consistent with `whereNil`
 //  semantics: absent is "not equal" to any given value. This mirrors

--- a/Docs/Guides/NULL_HANDLING.md
+++ b/Docs/Guides/NULL_HANDLING.md
@@ -76,36 +76,36 @@ let records = try db.query()
 
 ### `notEquals` and missing fields (intentional)
 
-`where(_:notEquals:)` means: return every record **except** those whose field equals the given value. A record where the field is **absent** also matches. The same rule applies to the string sync API, the Apple async API, and KeyPath queries.
-
-| Record | `where("status", notEquals: .string("archived"))` |
-|--------|---------------------------------------------------|
-| `{}` (no `status`) | match |
-| `{ status: "active" }` | match |
-| `{ status: "archived" }` | no match |
-
-This is deliberately asymmetric with `equals`, which treats a missing field as a non-match.
+`notEquals` treats an absent field as **not equal** to the requested value. Comparison and field existence are separate primitives: use `whereNotNil` when existence is required. The same rules apply to the string sync API, the Apple async API, and KeyPath queries.
 
 ```swift
-// Includes records with no status, and status != "archived"
+// Includes records where status is missing
 try db.query()
     .where("status", notEquals: .string("archived"))
     .execute()
 
-// Still only matches records that have status == "archived"
-try db.query()
-    .where("status", equals: .string("archived"))
-    .execute()
-```
-
-For “must have the field **and** not equal this value,” compose with existence:
-
-```swift
+// Only records where status exists and is not archived
 try db.query()
     .whereNotNil("status")
     .where("status", notEquals: .string("archived"))
     .execute()
 ```
+
+| Record | `notEquals: "archived"` | `whereNotNil` + `notEquals` |
+|--------|:-----------------------:|:---------------------------:|
+| `{}` (no `status`) | match | no match |
+| `{ status: "active" }` | match | match |
+| `{ status: "archived" }` | no match | no match |
+
+`equals` is deliberately asymmetric: it only matches when the field **exists** and equals the value (a missing field is a non-match).
+
+| Field state | `equals: "archived"` | `notEquals: "archived"` |
+|-------------|----------------------|-------------------------|
+| missing | false | true |
+| `"active"` | false | true |
+| `"archived"` | true | false |
+
+Do not invent a second “allNotEquals” API — compose `whereNotNil` with `notEquals` for the stricter reading.
 
 ## Migration Behavior
 
@@ -228,7 +228,7 @@ for user in allUsers {
 - **BlazeDB doesn't store null** - Missing fields represent null
 - **Access returns nil** - `record.storage["field"]` returns `nil` if missing
 - **Queries support null checks** - Use `whereNil()` and `whereNotNil()`
-- **`notEquals` includes missing fields** - Absent field matches `notEquals`; `equals` does not. Same rule for string, async, and KeyPath APIs.
+- **`notEquals` includes missing fields** — Absent field matches `notEquals`; `equals` does not. Compose `whereNotNil` + `notEquals` when existence is required. Same rule for string, async, and KeyPath APIs.
 - **Migration skips null** - NULL values from SQLite/Core Data are not stored
 - **Use optionals** - Always use optional access when reading fields
 

--- a/Docs/Guides/NULL_HANDLING.md
+++ b/Docs/Guides/NULL_HANDLING.md
@@ -74,6 +74,39 @@ let records = try db.query()
 .execute()
 ```
 
+### `notEquals` and missing fields (intentional)
+
+`where(_:notEquals:)` means: return every record **except** those whose field equals the given value. A record where the field is **absent** also matches. The same rule applies to the string sync API, the Apple async API, and KeyPath queries.
+
+| Record | `where("status", notEquals: .string("archived"))` |
+|--------|---------------------------------------------------|
+| `{}` (no `status`) | match |
+| `{ status: "active" }` | match |
+| `{ status: "archived" }` | no match |
+
+This is deliberately asymmetric with `equals`, which treats a missing field as a non-match.
+
+```swift
+// Includes records with no status, and status != "archived"
+try db.query()
+    .where("status", notEquals: .string("archived"))
+    .execute()
+
+// Still only matches records that have status == "archived"
+try db.query()
+    .where("status", equals: .string("archived"))
+    .execute()
+```
+
+For “must have the field **and** not equal this value,” compose with existence:
+
+```swift
+try db.query()
+    .whereNotNil("status")
+    .where("status", notEquals: .string("archived"))
+    .execute()
+```
+
 ## Migration Behavior
 
 ### SQLite Migration
@@ -195,6 +228,7 @@ for user in allUsers {
 - **BlazeDB doesn't store null** - Missing fields represent null
 - **Access returns nil** - `record.storage["field"]` returns `nil` if missing
 - **Queries support null checks** - Use `whereNil()` and `whereNotNil()`
+- **`notEquals` includes missing fields** - Absent field matches `notEquals`; `equals` does not. Same rule for string, async, and KeyPath APIs.
 - **Migration skips null** - NULL values from SQLite/Core Data are not stored
 - **Use optionals** - Always use optional access when reading fields
 


### PR DESCRIPTION
## Summary

- Document the intentional `notEquals` / missing-field rule in `Docs/Guides/NULL_HANDLING.md` (matrix + composition with `whereNotNil`).
- Correct the sync `QueryNotEqualsMissingFieldTests` file header that still said “non-match” (pre-#343 bug phrasing). Async/KeyPath headers were already fixed in #420/#421 follow-ups.

## Canonical semantics (intentional)

- **`notEquals` includes** records where the field is absent.
- **`equals` excludes** records where the field is absent.
- Use **`whereNotNil` before `notEquals`** to require field existence.

This is the document-style reading established by #343 and aligned across APIs by #420 (async) and #421 (KeyPath). Putting it in the null/missing guide makes it discoverable so the next reader does not assume the guard was inverted by accident.

## Related

- #343 — sync string `notEquals`
- #420 — async parity (merged)
- #421 — KeyPath parity (merged)

## Test plan

- [ ] Skim `NULL_HANDLING.md` section for clarity
- [ ] Confirm no code behavior change (docs + comment-only test header)