### PR TITLE
fix: support overflow records in batch inserts

### DIFF
--- a/BlazeDB/Core/DynamicCollection+Batch.swift
+++ b/BlazeDB/Core/DynamicCollection+Batch.swift
@@ -300,16 +300,48 @@ extension DynamicCollection {
                     }
                 }
                 
-                // Write page (WITHOUT fsync for batch performance!)
-                // Will be flushed in single fsync at end of batch
+                // Write page chain WITHOUT fsync (batch durability: one synchronize at end).
+                // Must use overflow-aware path so insertMany accepts the same sizes as insert().
                 let value = document["value"]?.intValue ?? -1
                 BlazeLogger.debug("💾 [INSERT] Batch: Writing record \(id.uuidString.prefix(8)) (value: \(value)) to page \(currentPageIndex)")
-                try store.writePageUnsynchronized(index: currentPageIndex, plaintext: encoded)
-                // CRITICAL: Track indexMap updates but DON'T apply until synchronize() succeeds
-                // This prevents indexMap from being out of sync if synchronize() fails
-                // Store in pendingIndexMapUpdates instead of updating indexMap directly
-                pendingIndexMapUpdates[id] = [currentPageIndex]  // Support overflow chains
-                BlazeLogger.debug("📝 [INSERT] Batch: Tracked indexMap[\(id.uuidString.prefix(8))] = [\(currentPageIndex)] (value: \(value)) - will apply after synchronize()")
+                let pageIndices = try store.writePageWithOverflowUnsynchronized(
+                    index: currentPageIndex,
+                    plaintext: encoded,
+                    allocatePage: { [weak self] in
+                        guard let self = self else {
+                            throw NSError(
+                                domain: "DynamicCollection",
+                                code: 1,
+                                userInfo: [NSLocalizedDescriptionKey: "Collection deallocated"]
+                            )
+                        }
+                        let overflowPage = self.allocatePage(layout: &layout)
+                        let overflowConflicts = self.indexMap
+                            .filter { $0.value.contains(overflowPage) }
+                            .keys
+                        if !overflowConflicts.isEmpty {
+                            BlazeLogger.error("Overflow page \(overflowPage) conflict - removing stale entries")
+                            for conflictID in overflowConflicts {
+                                self.indexMap.removeValue(forKey: conflictID)
+                            }
+                        }
+                        // Pending batch pages are not in indexMap yet — still avoid reuse within this batch.
+                        if batchAllocatedPages.contains(overflowPage) {
+                            BlazeLogger.error("❌ [INSERT] Batch: Overflow page \(overflowPage) already allocated in this batch — allocating another")
+                            let replacement = self.allocatePage(layout: &layout)
+                            batchAllocatedPages.insert(replacement)
+                            return replacement
+                        }
+                        batchAllocatedPages.insert(overflowPage)
+                        return overflowPage
+                    }
+                )
+                for page in pageIndices {
+                    batchAllocatedPages.insert(page)
+                }
+                // CRITICAL: Track full overflow chain; apply only after synchronize() succeeds.
+                pendingIndexMapUpdates[id] = pageIndices
+                BlazeLogger.debug("📝 [INSERT] Batch: Tracked indexMap[\(id.uuidString.prefix(8))] = \(pageIndices) (value: \(value)) - will apply after synchronize()")
                 
                 // Update secondary indexes (in-memory)
                 for (compound, _) in secondaryIndexes {

--- a/BlazeDB/Storage/PageStore.swift
+++ b/BlazeDB/Storage/PageStore.swift
@@ -203,6 +203,7 @@ public final class PageStore: @unchecked Sendable {
     private static let replayFaultLock = NSLock()
     nonisolated(unsafe) private static var replayFailAtEntryIndex: Int? = nil
     nonisolated(unsafe) private static var replayForceFsyncFailure: Bool = false
+    nonisolated(unsafe) private static var synchronizeForceFailure: Bool = false
     
     internal static func _setReplayFailureForTests(entryIndex: Int?) {
         replayFaultLock.lock()
@@ -213,6 +214,13 @@ public final class PageStore: @unchecked Sendable {
     internal static func _setReplayFsyncFailureForTests(_ enabled: Bool) {
         replayFaultLock.lock()
         replayForceFsyncFailure = enabled
+        replayFaultLock.unlock()
+    }
+
+    /// Test-only: force `synchronize()` to throw so batch paths can prove indexMap stays unpublished.
+    internal static func _setSynchronizeFailureForTests(_ enabled: Bool) {
+        replayFaultLock.lock()
+        synchronizeForceFailure = enabled
         replayFaultLock.unlock()
     }
     
@@ -226,6 +234,12 @@ public final class PageStore: @unchecked Sendable {
         replayFaultLock.lock()
         defer { replayFaultLock.unlock() }
         return replayForceFsyncFailure
+    }
+
+    private static func synchronizeFailureEnabledForTests() -> Bool {
+        replayFaultLock.lock()
+        defer { replayFaultLock.unlock() }
+        return synchronizeForceFailure
     }
     #endif
 
@@ -901,6 +915,13 @@ public final class PageStore: @unchecked Sendable {
     public func synchronize() throws {
         #if DEBUG
         dispatchPrecondition(condition: .notOnQueue(queue))
+        if Self.synchronizeFailureEnabledForTests() {
+            throw NSError(
+                domain: "PageStore.TestFault",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "Forced synchronize() failure for tests"]
+            )
+        }
         #endif
         try queue.sync(flags: .barrier) {
             try ensureOpenLocked()

--- a/BlazeDBTests/Tier0Core/CoreCorrectness/InsertManyOverflowParityTests.swift
+++ b/BlazeDBTests/Tier0Core/CoreCorrectness/InsertManyOverflowParityTests.swift
@@ -1,0 +1,167 @@
+//
+//  InsertManyOverflowParityTests.swift
+//  BlazeDB_Tier0 — insertMany must accept overflow-sized records that insert() accepts.
+//
+
+import XCTest
+#if canImport(BlazeDBCore)
+@testable import BlazeDBCore
+#else
+@testable import BlazeDB
+#endif
+
+final class InsertManyOverflowParityTests: XCTestCase {
+    private var dbURL: URL!
+    private var password: String { "OverflowParity-Pass_123!" }
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        dbURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("InsertManyOverflow-\(UUID().uuidString).blazedb")
+        try? FileManager.default.removeItem(at: dbURL)
+    }
+
+    override func tearDownWithError() throws {
+        if let dbURL {
+            let base = dbURL.deletingPathExtension()
+            for ext in ["blazedb", "meta", "wal", "salt", "indexes"] {
+                try? FileManager.default.removeItem(at: base.appendingPathExtension(ext))
+            }
+            try? FileManager.default.removeItem(at: dbURL)
+        }
+        try super.tearDownWithError()
+    }
+
+    private func openDB() throws -> BlazeDBClient {
+        try BlazeDBClient(name: "overflow_parity", fileURL: dbURL, password: password)
+    }
+
+    private func record(index: Int, payloadBytes: Int, filler: Character = "x") -> BlazeDataRecord {
+        BlazeDataRecord([
+            "index": .int(index),
+            "payload": .string(String(repeating: filler, count: payloadBytes)),
+        ])
+    }
+
+    func testInsertMany_singleRecordOver4KiB_roundTripsAndSurvivesReopen() throws {
+        let payloadBytes = 5_000
+        var db = try openDB()
+        let ids = try db.insertMany([record(index: 0, payloadBytes: payloadBytes)])
+        XCTAssertEqual(ids.count, 1)
+        try db.persist()
+
+        let fetched = try XCTUnwrap(db.fetch(id: ids[0]))
+        XCTAssertEqual(fetched.storage["payload"]?.stringValue?.count, payloadBytes)
+        try db.close()
+
+        db = try openDB()
+        let again = try XCTUnwrap(db.fetch(id: ids[0]))
+        XCTAssertEqual(again.storage["payload"]?.stringValue?.count, payloadBytes)
+        XCTAssertEqual(again.storage["index"]?.intValue, 0)
+        try db.close()
+    }
+
+    func testInsertMany_oneMegabyte_matchesInsertParityAndReopen() throws {
+        let payloadBytes = 1_048_576
+        var db = try openDB()
+
+        let insertID = try db.insert(record(index: 1, payloadBytes: payloadBytes, filler: "a"))
+        let manyIDs = try db.insertMany([record(index: 2, payloadBytes: payloadBytes, filler: "b")])
+        XCTAssertEqual(manyIDs.count, 1)
+        try db.persist()
+        try db.close()
+
+        db = try openDB()
+        let viaInsert = try XCTUnwrap(db.fetch(id: insertID))
+        let viaMany = try XCTUnwrap(db.fetch(id: manyIDs[0]))
+        XCTAssertEqual(viaInsert.storage["payload"]?.stringValue?.count, payloadBytes)
+        XCTAssertEqual(viaMany.storage["payload"]?.stringValue?.count, payloadBytes)
+        XCTAssertEqual(viaInsert.storage["payload"]?.stringValue?.first, "a")
+        XCTAssertEqual(viaMany.storage["payload"]?.stringValue?.first, "b")
+        try db.close()
+    }
+
+    func testInsertMany_mixedSmallAndOverflow_roundTripsAfterReopen() throws {
+        var db = try openDB()
+        let records = [
+            record(index: 0, payloadBytes: 64, filler: "s"),
+            record(index: 1, payloadBytes: 8_192, filler: "m"),
+            record(index: 2, payloadBytes: 128, filler: "t"),
+            record(index: 3, payloadBytes: 65_536, filler: "L"),
+        ]
+        let ids = try db.insertMany(records)
+        XCTAssertEqual(ids.count, 4)
+        try db.persist()
+        try db.close()
+
+        db = try openDB()
+        for (i, id) in ids.enumerated() {
+            let fetched = try XCTUnwrap(db.fetch(id: id))
+            XCTAssertEqual(fetched.storage["index"]?.intValue, i)
+            XCTAssertEqual(
+                fetched.storage["payload"]?.stringValue?.count,
+                records[i].storage["payload"]?.stringValue?.count
+            )
+        }
+        try db.close()
+    }
+
+    func testInsertMany_overflowRecord_canUpdateAndDeleteAfterReopen() throws {
+        let payloadBytes = 12_000
+        var db = try openDB()
+        let ids = try db.insertMany([record(index: 7, payloadBytes: payloadBytes, filler: "u")])
+        let id = try XCTUnwrap(ids.first)
+        try db.persist()
+        try db.close()
+
+        db = try openDB()
+        try db.update(
+            id: id,
+            with: BlazeDataRecord([
+                "index": .int(7),
+                "payload": .string(String(repeating: "v", count: payloadBytes)),
+                "status": .string("closed"),
+            ])
+        )
+        try db.persist()
+        try db.close()
+
+        db = try openDB()
+        let updated = try XCTUnwrap(db.fetch(id: id))
+        XCTAssertEqual(updated.storage["status"]?.stringValue, "closed")
+        XCTAssertEqual(updated.storage["payload"]?.stringValue?.first, "v")
+
+        try db.delete(id: id)
+        try db.persist()
+        try db.close()
+
+        db = try openDB()
+        XCTAssertNil(try db.fetch(id: id))
+        try db.close()
+    }
+
+    func testInsertMany_failureMidBatch_doesNotLeaveHalfVisibleOverflowChain() throws {
+        // First record is valid overflow-sized; second uses a duplicate id to force abort
+        // after the first page write path has run — index must not publish the failed batch.
+        var db = try openDB()
+        let shared = UUID()
+        let first = BlazeDataRecord([
+            "id": .uuid(shared),
+            "index": .int(0),
+            "payload": .string(String(repeating: "x", count: 6_000)),
+        ])
+        let duplicate = BlazeDataRecord([
+            "id": .uuid(shared),
+            "index": .int(1),
+            "payload": .string(String(repeating: "y", count: 6_000)),
+        ])
+
+        XCTAssertThrowsError(try db.insertMany([first, duplicate]))
+        try? db.persist()
+        try db.close()
+
+        db = try openDB()
+        XCTAssertNil(try db.fetch(id: shared), "failed batch must not leave a visible overflow record")
+        try db.close()
+    }
+}

--- a/BlazeDBTests/Tier0Core/CoreCorrectness/InsertManyOverflowParityTests.swift
+++ b/BlazeDBTests/Tier0Core/CoreCorrectness/InsertManyOverflowParityTests.swift
@@ -102,6 +102,35 @@ final class InsertManyOverflowParityTests: XCTestCase {
                 fetched.storage["payload"]?.stringValue?.count,
                 records[i].storage["payload"]?.stringValue?.count
             )
+            XCTAssertEqual(
+                fetched.storage["payload"]?.stringValue?.first,
+                records[i].storage["payload"]?.stringValue?.first
+            )
+        }
+        try db.close()
+    }
+
+    func testInsertMany_multipleOverflowRecords_roundTripAfterReopen() throws {
+        // Regression: one batch with several overflow-sized values (not a single oversized row).
+        let specs: [(Int, Int, Character)] = [
+            (0, 5_000, "A"),
+            (1, 12_000, "B"),
+            (2, 40_000, "C"),
+            (3, 8_192, "D"),
+        ]
+        var db = try openDB()
+        let records = specs.map { record(index: $0.0, payloadBytes: $0.1, filler: $0.2) }
+        let ids = try db.insertMany(records)
+        XCTAssertEqual(ids.count, specs.count)
+        try db.persist()
+        try db.close()
+
+        db = try openDB()
+        for (i, id) in ids.enumerated() {
+            let fetched = try XCTUnwrap(db.fetch(id: id), "missing overflow record \(i) after reopen")
+            XCTAssertEqual(fetched.storage["index"]?.intValue, specs[i].0)
+            XCTAssertEqual(fetched.storage["payload"]?.stringValue?.count, specs[i].1)
+            XCTAssertEqual(fetched.storage["payload"]?.stringValue?.first, specs[i].2)
         }
         try db.close()
     }
@@ -163,5 +192,33 @@ final class InsertManyOverflowParityTests: XCTestCase {
         db = try openDB()
         XCTAssertNil(try db.fetch(id: shared), "failed batch must not leave a visible overflow record")
         try db.close()
+    }
+
+    func testInsertMany_synchronizeFailure_doesNotPublishOverflowChainsIntoIndexMap() throws {
+        // Crash-ordering: pages may be staged, but indexMap must stay unpublished if synchronize() fails.
+        #if DEBUG
+        var db = try openDB()
+        let records = [
+            record(index: 0, payloadBytes: 6_000, filler: "p"),
+            record(index: 1, payloadBytes: 9_000, filler: "q"),
+        ]
+
+        PageStore._setSynchronizeFailureForTests(true)
+        defer { PageStore._setSynchronizeFailureForTests(false) }
+
+        XCTAssertThrowsError(try db.insertMany(records))
+        try? db.persist()
+        try db.close()
+
+        db = try openDB()
+        let surviving = try db.fetchAll()
+        XCTAssertTrue(
+            surviving.isEmpty,
+            "failed synchronize must not publish overflow page chains into indexMap; found \(surviving.count)"
+        )
+        try db.close()
+        #else
+        throw XCTSkip("synchronize fault injection is DEBUG-only")
+        #endif
     }
 }

--- a/BlazeDBTests/Tier1Core/Security/RLSEnforcementClientTests.swift
+++ b/BlazeDBTests/Tier1Core/Security/RLSEnforcementClientTests.swift
@@ -149,10 +149,10 @@ final class RLSEnforcementClientTests: XCTestCase {
         let db = try makeClient()
         let owner = UUID()
         let outsider = UUID()
-        let hiddenID = try db.insert(
+        let hiddenID = try await db.insert(
             BlazeDataRecord(["userId": .uuid(owner), "title": .string("hidden")])
         )
-        _ = try db.insert(
+        _ = try await db.insert(
             BlazeDataRecord(["userId": .uuid(outsider), "title": .string("visible")])
         )
 


### PR DESCRIPTION
## Summary
PR #436 fixes issue #434 with narrow overflow parity only (no size-scaling / benchmark methodology changes).

- Route insertBatch / insertMany through the same overflow-aware write path as insert().
- Stage the full page chain in pendingIndexMapUpdates; publish into indexMap only after synchronize() succeeds.
- Keep a single end-of-batch fsync (batch durability amortization from #424).
- Compile unblock: missing await in one RLS async test (unrelated to overflow).

Closes #434

## Diff scope
Only:
- BlazeDB/Core/DynamicCollection+Batch.swift
- BlazeDB/Storage/PageStore.swift (DEBUG synchronize fault hook for tests)
- BlazeDBTests/Tier0Core/CoreCorrectness/InsertManyOverflowParityTests.swift
- BlazeDBTests/Tier1Core/Security/RLSEnforcementClientTests.swift (await)

No benchmark methodology, payload sweep docs, or DB-size scaling work.

## Pre-merge checks
- [x] Diff contains no bench / size-scaling changes
- [x] Multi-overflow batch regression (testInsertMany_multipleOverflowRecords_roundTripAfterReopen)
- [x] Reopen reads every overflow value correctly (multi + mixed)
- [x] Failed synchronize cannot publish overflow chains (testInsertMany_synchronizeFailure_doesNotPublishOverflowChainsIntoIndexMap)
- [x] Mid-batch abort also leaves no visible overflow record
- [x] Tier1 testQueryCacheInvalidation failure reproduces on origin/main (with only the RLS await compile fix applied) — pre-existing / unrelated to overflow

## Verification
- swift test --filter InsertManyOverflowParityTests: 7 tests, 0 failures
- Earlier: Tier0 229/0; batch focused 40/0; payload insertMany_batch through 1 MiB reports real ops/s (no FAILED rows)

Out of scope: database-size write degradation (issue #435).

## Test plan
- [x] insertMany with one record >4 KiB (+ reopen)
- [x] insertMany with multiple overflow values in one batch (+ reopen, content check)
- [x] insertMany mixed small/overflow (+ reopen)
- [x] insertMany 1 MiB parity with insert (+ reopen)
- [x] update/delete of batch-inserted overflow after reopen
- [x] mid-batch failure leaves no visible overflow record
- [x] forced synchronize failure does not publish indexMap chains
- [x] payload sweep insertMany_batch path no longer FAILED at >=4 KiB
