### PR TITLE
fix: abort batch overflow allocation on committed-page conflict

### DIFF
--- a/BlazeDB/Core/DynamicCollection+Batch.swift
+++ b/BlazeDB/Core/DynamicCollection+Batch.swift
@@ -307,9 +307,16 @@ extension DynamicCollection {
 
                 // Overflow pages: never delete committed indexMap entries on collision.
                 // Batch-local collisions may retry; committed conflicts fail closed immediately.
+                // allocatePage normally progresses (pops free/deleted or bumps nextPageIndex), but
+                // keep an explicit bound so a pathological free-list cannot spin forever.
                 func allocateUnreservedOverflowPage() throws -> Int {
-                    while true {
+                    let maxAttempts = max(batchAllocatedPages.count + layout.deletedPages.count + 64, 128)
+                    var attempts = 0
+                    var lastPage: Int?
+                    while attempts < maxAttempts {
+                        attempts += 1
                         let page = self.allocatePage(layout: &layout)
+                        lastPage = page
                         let committedConflict = self.indexMap.values.contains { $0.contains(page) }
                         guard !committedConflict else {
                             BlazeLogger.error(
@@ -324,6 +331,9 @@ extension DynamicCollection {
                         batchAllocatedPages.insert(page)
                         return page
                     }
+                    let exhausted = lastPage ?? -1
+                    BlazeLogger.error("❌ [INSERT] Batch: Exhausted \(maxAttempts) overflow page allocation attempts without an unreserved page (last=\(exhausted))")
+                    throw BlazeDBError.pageAllocationConflict(page: exhausted)
                 }
 
                 let pageIndices = try store.writePageWithOverflowUnsynchronized(

--- a/BlazeDB/Core/DynamicCollection+Batch.swift
+++ b/BlazeDB/Core/DynamicCollection+Batch.swift
@@ -304,35 +304,34 @@ extension DynamicCollection {
                 // Must use overflow-aware path so insertMany accepts the same sizes as insert().
                 let value = document["value"]?.intValue ?? -1
                 BlazeLogger.debug("💾 [INSERT] Batch: Writing record \(id.uuidString.prefix(8)) (value: \(value)) to page \(currentPageIndex)")
+
+                // Overflow pages: never delete committed indexMap entries on collision.
+                // Batch-local collisions may retry; committed conflicts fail closed immediately.
+                func allocateUnreservedOverflowPage() throws -> Int {
+                    while true {
+                        let page = self.allocatePage(layout: &layout)
+                        let committedConflict = self.indexMap.values.contains { $0.contains(page) }
+                        guard !committedConflict else {
+                            BlazeLogger.error(
+                                "❌ [INSERT] Batch: Overflow page \(page) already referenced by a committed indexMap entry — failing closed"
+                            )
+                            throw BlazeDBError.pageAllocationConflict(page: page)
+                        }
+                        guard !batchAllocatedPages.contains(page) else {
+                            BlazeLogger.error("❌ [INSERT] Batch: Overflow page \(page) already allocated in this batch — allocating another")
+                            continue
+                        }
+                        batchAllocatedPages.insert(page)
+                        return page
+                    }
+                }
+
                 let pageIndices = try store.writePageWithOverflowUnsynchronized(
                     index: currentPageIndex,
                     plaintext: encoded,
                     allocatePage: {
                         // insertBatch already owns `self` for this synchronous barrier call.
-                        var candidate = self.allocatePage(layout: &layout)
-                        // Pending batch pages are not in indexMap yet — keep allocating until free.
-                        var batchCollisionAttempts = 0
-                        while batchAllocatedPages.contains(candidate) {
-                            batchCollisionAttempts += 1
-                            guard batchCollisionAttempts <= 10_000 else {
-                                BlazeLogger.error("❌ [INSERT] Batch: Exhausted attempts resolving batch-local overflow page collisions")
-                                throw BlazeDBError.pageAllocationConflict(page: candidate)
-                            }
-                            BlazeLogger.error("❌ [INSERT] Batch: Overflow page \(candidate) already allocated in this batch — allocating another")
-                            candidate = self.allocatePage(layout: &layout)
-                        }
-                        // Committed pages in indexMap must never be "repaired" by deleting entries.
-                        let overflowConflicts = self.indexMap
-                            .filter { $0.value.contains(candidate) }
-                            .map(\.key)
-                        guard overflowConflicts.isEmpty else {
-                            BlazeLogger.error(
-                                "❌ [INSERT] Batch: Overflow page \(candidate) already in use by committed record(s): \(overflowConflicts.map { String($0.uuidString.prefix(8)) }.joined(separator: ", ")) — failing closed"
-                            )
-                            throw BlazeDBError.pageAllocationConflict(page: candidate)
-                        }
-                        batchAllocatedPages.insert(candidate)
-                        return candidate
+                        try allocateUnreservedOverflowPage()
                     }
                 )
                 for page in pageIndices {

--- a/BlazeDB/Core/DynamicCollection+Batch.swift
+++ b/BlazeDB/Core/DynamicCollection+Batch.swift
@@ -307,33 +307,32 @@ extension DynamicCollection {
                 let pageIndices = try store.writePageWithOverflowUnsynchronized(
                     index: currentPageIndex,
                     plaintext: encoded,
-                    allocatePage: { [weak self] in
-                        guard let self = self else {
-                            throw NSError(
-                                domain: "DynamicCollection",
-                                code: 1,
-                                userInfo: [NSLocalizedDescriptionKey: "Collection deallocated"]
-                            )
-                        }
-                        let overflowPage = self.allocatePage(layout: &layout)
-                        let overflowConflicts = self.indexMap
-                            .filter { $0.value.contains(overflowPage) }
-                            .keys
-                        if !overflowConflicts.isEmpty {
-                            BlazeLogger.error("Overflow page \(overflowPage) conflict - removing stale entries")
-                            for conflictID in overflowConflicts {
-                                self.indexMap.removeValue(forKey: conflictID)
+                    allocatePage: {
+                        // insertBatch already owns `self` for this synchronous barrier call.
+                        var candidate = self.allocatePage(layout: &layout)
+                        // Pending batch pages are not in indexMap yet — keep allocating until free.
+                        var batchCollisionAttempts = 0
+                        while batchAllocatedPages.contains(candidate) {
+                            batchCollisionAttempts += 1
+                            guard batchCollisionAttempts <= 10_000 else {
+                                BlazeLogger.error("❌ [INSERT] Batch: Exhausted attempts resolving batch-local overflow page collisions")
+                                throw BlazeDBError.pageAllocationConflict(page: candidate)
                             }
+                            BlazeLogger.error("❌ [INSERT] Batch: Overflow page \(candidate) already allocated in this batch — allocating another")
+                            candidate = self.allocatePage(layout: &layout)
                         }
-                        // Pending batch pages are not in indexMap yet — still avoid reuse within this batch.
-                        if batchAllocatedPages.contains(overflowPage) {
-                            BlazeLogger.error("❌ [INSERT] Batch: Overflow page \(overflowPage) already allocated in this batch — allocating another")
-                            let replacement = self.allocatePage(layout: &layout)
-                            batchAllocatedPages.insert(replacement)
-                            return replacement
+                        // Committed pages in indexMap must never be "repaired" by deleting entries.
+                        let overflowConflicts = self.indexMap
+                            .filter { $0.value.contains(candidate) }
+                            .map(\.key)
+                        guard overflowConflicts.isEmpty else {
+                            BlazeLogger.error(
+                                "❌ [INSERT] Batch: Overflow page \(candidate) already in use by committed record(s): \(overflowConflicts.map { String($0.uuidString.prefix(8)) }.joined(separator: ", ")) — failing closed"
+                            )
+                            throw BlazeDBError.pageAllocationConflict(page: candidate)
                         }
-                        batchAllocatedPages.insert(overflowPage)
-                        return overflowPage
+                        batchAllocatedPages.insert(candidate)
+                        return candidate
                     }
                 )
                 for page in pageIndices {

--- a/BlazeDB/Core/DynamicCollection.swift
+++ b/BlazeDB/Core/DynamicCollection.swift
@@ -1109,17 +1109,16 @@ public final class DynamicCollection {
                 let pageIndices = try store.writePageWithOverflowUnsynchronized(
                     index: mainPageIndex,
                     plaintext: encoded,
-                    allocatePage: { [weak self] in
-                        guard let self = self else { throw NSError(domain: "DynamicCollection", code: 1, userInfo: [NSLocalizedDescriptionKey: "Collection deallocated"]) }
-                        // Reuse deleted pages for overflow pages too
+                    allocatePage: {
+                        // insert() owns `self` for this synchronous barrier call.
                         let overflowPage = self.allocatePage(layout: &layout)
-                        // Check for conflicts on overflow pages too
-                        let overflowConflicts = self.indexMap.filter { $0.value.contains(overflowPage) }.keys
-                        if !overflowConflicts.isEmpty {
-                            BlazeLogger.error("Overflow page \(overflowPage) conflict - removing stale entries")
-                            for conflictID in overflowConflicts {
-                                self.indexMap.removeValue(forKey: conflictID)
-                            }
+                        // Never delete committed indexMap entries to "clear" an allocator collision.
+                        let committedConflict = self.indexMap.values.contains { $0.contains(overflowPage) }
+                        guard !committedConflict else {
+                            BlazeLogger.error(
+                                "❌ [INSERT] Overflow page \(overflowPage) already referenced by a committed indexMap entry — failing closed"
+                            )
+                            throw BlazeDBError.pageAllocationConflict(page: overflowPage)
                         }
                         return overflowPage
                     }

--- a/BlazeDB/Core/PageReuseGC.swift
+++ b/BlazeDB/Core/PageReuseGC.swift
@@ -16,6 +16,29 @@ extension DynamicCollection {
     private func loadPageReuseLayout() throws -> StorageLayout {
         try loadLayoutForMutation()
     }
+
+    #if DEBUG
+    private static let allocatePageFaultLock = NSLock()
+    /// One-shot fault: after skipping `skips` normal allocations, return `page` once.
+    nonisolated(unsafe) private static var forceAllocateAfterSkips: Int? = nil
+    nonisolated(unsafe) private static var forceAllocatePage: Int? = nil
+
+    /// Test-only: force `allocatePage` to return `page` after `skips` normal allocations.
+    /// Used to prove committed-page conflicts fail closed instead of deleting indexMap entries.
+    internal static func _forceAllocatedPageAfterSkippingForTests(skips: Int, page: Int) {
+        allocatePageFaultLock.lock()
+        forceAllocateAfterSkips = skips
+        forceAllocatePage = page
+        allocatePageFaultLock.unlock()
+    }
+
+    internal static func _clearForcedAllocatedPageForTests() {
+        allocatePageFaultLock.lock()
+        forceAllocateAfterSkips = nil
+        forceAllocatePage = nil
+        allocatePageFaultLock.unlock()
+    }
+    #endif
     
     // MARK: - Page Allocation with Reuse
     
@@ -31,6 +54,24 @@ extension DynamicCollection {
     /// - Automatic (no maintenance)
     /// - Handles 95% of cases
     internal func allocatePage(layout: inout StorageLayout) -> Int {
+        #if DEBUG
+        Self.allocatePageFaultLock.lock()
+        if var skips = Self.forceAllocateAfterSkips, let forced = Self.forceAllocatePage {
+            if skips > 0 {
+                Self.forceAllocateAfterSkips = skips - 1
+                Self.allocatePageFaultLock.unlock()
+            } else {
+                Self.forceAllocateAfterSkips = nil
+                Self.forceAllocatePage = nil
+                Self.allocatePageFaultLock.unlock()
+                BlazeLogger.error("🧪 [TEST] Forced allocatePage → \(forced)")
+                return forced
+            }
+        } else {
+            Self.allocatePageFaultLock.unlock()
+        }
+        #endif
+
         if mvccEnabled, let reusablePage = versionManager.pageGC.getFreePage() {
             BlazeLogger.trace("♻️  Reusing MVCC free page \(reusablePage)")
             return reusablePage
@@ -203,6 +244,19 @@ extension DynamicCollection {
         try layout.saveSecure(to: metaURL, signingKey: encryptionKey)
         
         unsavedChanges += 1
+    }
+}
+
+// MARK: - Page allocation errors
+
+extension BlazeDBError {
+    /// Allocator returned a page still referenced by a committed `indexMap` entry.
+    /// Callers must abort rather than deleting the existing record to "make room."
+    public static func pageAllocationConflict(page: Int) -> BlazeDBError {
+        .corruptedData(
+            location: "page \(page)",
+            reason: "allocatePage returned a page already referenced by a committed indexMap entry; refusing to delete the existing record"
+        )
     }
 }
 

--- a/BlazeDBTests/Tier0Core/CoreCorrectness/InsertManyOverflowParityTests.swift
+++ b/BlazeDBTests/Tier0Core/CoreCorrectness/InsertManyOverflowParityTests.swift
@@ -223,8 +223,9 @@ final class InsertManyOverflowParityTests: XCTestCase {
     }
 
     func testInsertMany_overflowCommittedPageConflict_failsWithoutDeletingExisting() throws {
-        // Allocator invariant: colliding with a committed indexMap page must fail the batch,
+        // Allocator invariant: colliding with a committed indexMap page must fail closed,
         // not silently remove the existing record's index entry.
+        // Linux insertMany falls back to per-record insert(); both paths must honor this.
         #if DEBUG
         var db = try openDB()
         let existingPayload = String(repeating: "z", count: 64)
@@ -241,7 +242,7 @@ final class InsertManyOverflowParityTests: XCTestCase {
         let victimPage = try XCTUnwrap(committedPages.first)
         let rejectedPayload = String(repeating: "x", count: 6_000)
 
-        // Skip the head-page allocatePage for the batch record; force the overflow allocate to the victim.
+        // Skip the head-page allocatePage; force the overflow allocate to the victim.
         DynamicCollection._forceAllocatedPageAfterSkippingForTests(skips: 1, page: victimPage)
         defer { DynamicCollection._clearForcedAllocatedPageForTests() }
 

--- a/BlazeDBTests/Tier0Core/CoreCorrectness/InsertManyOverflowParityTests.swift
+++ b/BlazeDBTests/Tier0Core/CoreCorrectness/InsertManyOverflowParityTests.swift
@@ -221,4 +221,39 @@ final class InsertManyOverflowParityTests: XCTestCase {
         throw XCTSkip("synchronize fault injection is DEBUG-only")
         #endif
     }
+
+    func testInsertMany_overflowCommittedPageConflict_failsWithoutDeletingExisting() throws {
+        // Allocator invariant: colliding with a committed indexMap page must fail the batch,
+        // not silently remove the existing record's index entry.
+        #if DEBUG
+        var db = try openDB()
+        let existingID = try db.insert(record(index: 0, payloadBytes: 64, filler: "z"))
+        try db.persist()
+
+        let committedPages = try XCTUnwrap(db.collection.indexMap[existingID])
+        let victimPage = try XCTUnwrap(committedPages.first)
+
+        // Skip the head-page allocatePage for the batch record; force the overflow allocate to the victim.
+        DynamicCollection._forceAllocatedPageAfterSkippingForTests(skips: 1, page: victimPage)
+        defer { DynamicCollection._clearForcedAllocatedPageForTests() }
+
+        XCTAssertThrowsError(try db.insertMany([record(index: 1, payloadBytes: 6_000, filler: "x")])) { error in
+            guard case BlazeDBError.corruptedData(let location, let reason) = error else {
+                return XCTFail("expected pageAllocationConflict (corruptedData), got \(error)")
+            }
+            XCTAssertEqual(location, "page \(victimPage)")
+            XCTAssertTrue(reason.contains("refusing to delete"), reason)
+        }
+        try? db.persist()
+        try db.close()
+
+        db = try openDB()
+        let surviving = try XCTUnwrap(db.fetch(id: existingID), "committed record must survive allocator conflict")
+        XCTAssertEqual(surviving.storage["payload"]?.stringValue?.first, "z")
+        XCTAssertEqual(try db.fetchAll().count, 1)
+        try db.close()
+        #else
+        throw XCTSkip("allocatePage fault injection is DEBUG-only")
+        #endif
+    }
 }

--- a/BlazeDBTests/Tier0Core/CoreCorrectness/InsertManyOverflowParityTests.swift
+++ b/BlazeDBTests/Tier0Core/CoreCorrectness/InsertManyOverflowParityTests.swift
@@ -227,30 +227,62 @@ final class InsertManyOverflowParityTests: XCTestCase {
         // not silently remove the existing record's index entry.
         #if DEBUG
         var db = try openDB()
-        let existingID = try db.insert(record(index: 0, payloadBytes: 64, filler: "z"))
+        let existingPayload = String(repeating: "z", count: 64)
+        let existingID = try db.insert(
+            BlazeDataRecord([
+                "index": .int(0),
+                "payload": .string(existingPayload),
+                "marker": .string("seed-committed"),
+            ])
+        )
         try db.persist()
 
         let committedPages = try XCTUnwrap(db.collection.indexMap[existingID])
         let victimPage = try XCTUnwrap(committedPages.first)
+        let rejectedPayload = String(repeating: "x", count: 6_000)
 
         // Skip the head-page allocatePage for the batch record; force the overflow allocate to the victim.
         DynamicCollection._forceAllocatedPageAfterSkippingForTests(skips: 1, page: victimPage)
         defer { DynamicCollection._clearForcedAllocatedPageForTests() }
 
-        XCTAssertThrowsError(try db.insertMany([record(index: 1, payloadBytes: 6_000, filler: "x")])) { error in
+        XCTAssertThrowsError(
+            try db.insertMany([
+                BlazeDataRecord([
+                    "index": .int(1),
+                    "payload": .string(rejectedPayload),
+                    "marker": .string("should-not-commit"),
+                ])
+            ])
+        ) { error in
             guard case BlazeDBError.corruptedData(let location, let reason) = error else {
                 return XCTFail("expected pageAllocationConflict (corruptedData), got \(error)")
             }
             XCTAssertEqual(location, "page \(victimPage)")
             XCTAssertTrue(reason.contains("refusing to delete"), reason)
         }
+
+        // Before reopen: committed seed remains fetchable; rejected overflow batch is absent.
+        let beforeReopen = try XCTUnwrap(db.fetch(id: existingID), "committed record must remain fetchable before reopen")
+        XCTAssertEqual(beforeReopen.storage["payload"]?.stringValue, existingPayload)
+        XCTAssertEqual(beforeReopen.storage["marker"]?.stringValue, "seed-committed")
+        XCTAssertEqual(try db.fetchAll().count, 1)
+        XCTAssertTrue(
+            try db.fetchAll().allSatisfy { $0.storage["marker"]?.stringValue != "should-not-commit" },
+            "rejected batch overflow record must be absent before reopen"
+        )
+
         try? db.persist()
         try db.close()
 
         db = try openDB()
-        let surviving = try XCTUnwrap(db.fetch(id: existingID), "committed record must survive allocator conflict")
-        XCTAssertEqual(surviving.storage["payload"]?.stringValue?.first, "z")
+        let afterReopen = try XCTUnwrap(db.fetch(id: existingID), "committed record must survive reopen")
+        XCTAssertEqual(afterReopen.storage["payload"]?.stringValue, existingPayload)
+        XCTAssertEqual(afterReopen.storage["marker"]?.stringValue, "seed-committed")
         XCTAssertEqual(try db.fetchAll().count, 1)
+        XCTAssertNil(
+            try db.fetchAll().first(where: { $0.storage["marker"]?.stringValue == "should-not-commit" }),
+            "rejected batch overflow record must remain absent after reopen"
+        )
         try db.close()
         #else
         throw XCTSkip("allocatePage fault injection is DEBUG-only")


### PR DESCRIPTION
## Summary
Follow-up regression fix after #436 (`708a2e3c`): abort overflow allocation on committed-page conflict instead of deleting existing `indexMap` entries.

- Batch path: `allocateUnreservedOverflowPage()` — committed conflict throws immediately; batch-local collisions may retry with an explicit attempt bound
- Single-insert path (Linux `insertMany` fallback): same fail-closed overflow conflict handling
- `BlazeDBError.pageAllocationConflict(page:)` is a **factory** over existing `.corruptedData` — no new public enum case / no source break
- Conflict path runs before pending publication / secondary-index mutation for the failing record
- Regression covers seed → force victim page → conflict → fetchable before reopen → identical content after reopen → rejected record absent

Keep narrow: committed-conflict failure handling + regression. Deeper allocator-state root cause (non-DEBUG reproduction) is a separate issue.

## Test plan
- [x] `swift test --filter InsertManyOverflowParityTests` — 8/0 (macOS)
- [x] Linux Tier0 previously failed on this test via insert() remove-stale path; fixed by aligning single-insert overflow fail-closed
