### PR TITLE
fix(ci): run-core-tests.sh propagates swift test failures instead of masking them (#368)

### DIFF
--- a/Scripts/run-core-tests.sh
+++ b/Scripts/run-core-tests.sh
@@ -2,7 +2,7 @@
 # Run core tests only (excludes distributed modules)
 # This script filters tests to avoid distributed module build failures
 
-set -e
+set -eu
 
 echo "Checking frozen core..."
 ./Scripts/check-freeze.sh HEAD^ || {
@@ -15,19 +15,41 @@ swift build --target BlazeDB
 
 echo "Running core tests..."
 
-# Run tests individually to avoid distributed module issues
-swift test --filter QueryErgonomicsTests 2>&1 | grep -v "Distributed\|Telemetry\|InMemoryRelay\|BlazeTopology\|TCPRelay" || true
-swift test --filter SchemaMigrationTests 2>&1 | grep -v "Distributed\|Telemetry\|InMemoryRelay\|BlazeTopology\|TCPRelay" || true
-swift test --filter ImportExportTests 2>&1 | grep -v "Distributed\|Telemetry\|InMemoryRelay\|BlazeTopology\|TCPRelay" || true
-swift test --filter OperationalConfidenceTests 2>&1 | grep -v "Distributed\|Telemetry\|InMemoryRelay\|BlazeTopology\|TCPRelay" || true
-swift test --filter LinuxCompatibilityTests 2>&1 | grep -v "Distributed\|Telemetry\|InMemoryRelay\|BlazeTopology\|TCPRelay" || true
-swift test --filter CrashRecoveryTests 2>&1 | grep -v "Distributed\|Telemetry\|InMemoryRelay\|BlazeTopology\|TCPRelay" || true
-swift test --filter ErrorSurfaceTests 2>&1 | grep -v "Distributed\|Telemetry\|InMemoryRelay\|BlazeTopology\|TCPRelay" || true
-swift test --filter LifecycleTests 2>&1 | grep -v "Distributed\|Telemetry\|InMemoryRelay\|BlazeTopology\|TCPRelay" || true
-swift test --filter LockingTests 2>&1 | grep -v "Distributed\|Telemetry\|InMemoryRelay\|BlazeTopology\|TCPRelay" || true
-swift test --filter ResourceLimitsTests 2>&1 | grep -v "Distributed\|Telemetry\|InMemoryRelay\|BlazeTopology\|TCPRelay" || true
-swift test --filter CompatibilityTests 2>&1 | grep -v "Distributed\|Telemetry\|InMemoryRelay\|BlazeTopology\|TCPRelay" || true
-swift test --filter GoldenPathIntegrationTests 2>&1 | grep -v "Distributed\|Telemetry\|InMemoryRelay\|BlazeTopology\|TCPRelay" || true
-swift test --filter CLISmokeTests 2>&1 | grep -v "Distributed\|Telemetry\|InMemoryRelay\|BlazeTopology\|TCPRelay" || true
+# Aggregate failures instead of masking them. Each filter is piped to grep to hide
+# distributed-module noise, but that pipe (and the old `|| true`) previously discarded
+# swift test's real exit status, so the script always exited 0 = false green (#368).
+# Fix: read swift test's status via PIPESTATUS[0], collect failures, exit non-zero if any.
+set +e   # run every filter; aggregate rather than stop at the first failure
+FILTER_NOISE="Distributed\|Telemetry\|InMemoryRelay\|BlazeTopology\|TCPRelay"
+FAILED=()
 
+run_filter() {
+    local name="$1"
+    swift test --filter "$name" 2>&1 | grep -v "$FILTER_NOISE"
+    local status=${PIPESTATUS[0]}   # swift test's exit code, NOT grep's
+    if [ "$status" -ne 0 ]; then
+        echo "❌ FAILED: $name (exit $status)"
+        FAILED+=("$name")
+    fi
+}
+
+# Run tests individually to avoid distributed module issues
+run_filter QueryErgonomicsTests
+run_filter SchemaMigrationTests
+run_filter ImportExportTests
+run_filter OperationalConfidenceTests
+run_filter LinuxCompatibilityTests
+run_filter CrashRecoveryTests
+run_filter ErrorSurfaceTests
+run_filter LifecycleTests
+run_filter LockingTests
+run_filter ResourceLimitsTests
+run_filter CompatibilityTests
+run_filter GoldenPathIntegrationTests
+run_filter CLISmokeTests
+
+if [ "${#FAILED[@]}" -ne 0 ]; then
+    echo "Core tests FAILED (${#FAILED[@]}): ${FAILED[*]}"
+    exit 1
+fi
 echo "Core tests completed"

--- a/Scripts/run-core-tests.sh
+++ b/Scripts/run-core-tests.sh
@@ -2,7 +2,7 @@
 # Run core tests only (excludes distributed modules)
 # This script filters tests to avoid distributed module build failures
 
-set -eu
+set -e
 
 echo "Checking frozen core..."
 ./Scripts/check-freeze.sh HEAD^ || {


### PR DESCRIPTION
## Summary
`Scripts/run-core-tests.sh` reported success even when `swift test` failed, producing a false green (#368).

Two masking layers were removed:
1. Every `swift test … | grep -v …` was followed by `|| true`, discarding the exit status.
2. Even without `|| true`, the pipe returns **grep**'s status, not `swift test`'s.

## Fix
- Read `swift test`'s real exit via `PIPESTATUS[0]` (the noise-filtering `grep -v` no longer hides it).
- Aggregate failures across all filters and exit non-zero once if any failed (matches the issue's Expected/Constraints: run all, then fail).
- Removed all `|| true`.

## Verification (mocked `swift`, no toolchain needed)
- A failing filter → script exits **1**, prints `Core tests FAILED (1): LockingTests`.
- All filters pass → exits **0**, prints `Core tests completed`.

Closes #368.
