### PR TITLE
docs: restructure the README for onboarding, add run and test guidance, and rework the SQLite comparison

### DIFF
--- a/Docs/GettingStarted/WHY_NOT_SQLITE.md
+++ b/Docs/GettingStarted/WHY_NOT_SQLITE.md
@@ -1,8 +1,8 @@
 # Why Not SQLite?
 
-Honest comparison for choosing between BlazeDB and SQLite as an embedded store.
+Honest fit comparison for choosing between BlazeDB and SQLite as an embedded store.
 
-This page is about **product fit**, not stopwatch marketing. Measured latency and throughput belong in the benchmark docs linked below. Authority for platform tiers: [COMPATIBILITY.md](../COMPATIBILITY.md) and [android-status.md](../android-status.md).
+This page is about **product fit**, not stopwatch marketing. Measured latency and throughput live in the [benchmark docs](../Benchmarks/README.md). Authority for platform tiers: [COMPATIBILITY.md](../COMPATIBILITY.md) and [android-status.md](../android-status.md).
 
 ---
 
@@ -16,15 +16,39 @@ This page is about **product fit**, not stopwatch marketing. Measured latency an
 
 ---
 
-## Platform support
+## Where SQLite wins
 
-| | BlazeDB |
-|--|---------|
-| **Platform support** | macOS and Linux **runtime-tested** (host engine tests); Apple platforms (iOS / watchOS / tvOS) **compile-tested**; Android / KMM **CI-validated** (cross-compile + emulator smoke) with **experimental packaging** |
+Stated early and plainly, because it is the question most readers arrive with.
 
-Do not treat Android or KMM as the same maturity as macOS/Linux host Tier0, and do not call them unsupported: the PR gate cross-compiles the bridge and runs a KMM emulator smoke. Details: [COMPATIBILITY.md](../COMPATIBILITY.md), [android-status.md](../android-status.md).
+In current measured comparison runs, **SQLite typically wins raw insert throughput and cold-open latency** on its unencrypted reference path. BlazeDB's default path includes encryption and carries different durability costs, and that difference is real rather than a tuning gap waiting to be closed.
 
-SQLite’s C API remains the broader “runs everywhere” option when you need one binary story across many languages and hosts.
+Some concurrent-read harness numbers favor BlazeDB. Treat those as workload-specific and not as a general "faster than SQLite" claim.
+
+Measured comparisons, with methodology:
+
+- [Benchmarks README](../Benchmarks/README.md) for how to run and how to read results
+- [COMPARISON.md](../Benchmarks/COMPARISON.md) for the headline BlazeDB vs SQLite table
+- [RESULTS.md](../Benchmarks/RESULTS.md) and [LATENCY.md](../Benchmarks/LATENCY.md)
+
+If a number appears anywhere without a link to methodology, it is not a supported claim.
+
+---
+
+## Fit comparison
+
+| Axis | BlazeDB | SQLite |
+|------|---------|--------|
+| Query model | Fluent Swift APIs, typed documents | SQL, complex joins, decades of SQL expertise |
+| Encryption at rest | Required on public open APIs, AES-256-GCM | Optional, usually via an extension such as SQLCipher |
+| Schema | Flexible by default, optional validation and real migration APIs | Explicit SQL schemas and migrations |
+| Process model | Single-process file ownership; multi-process writers not supported; network filesystems not recommended | Long history of multi-connection patterns with its own locking and WAL rules |
+| Live queries | In-process observation, SwiftUI integration on Apple platforms | Not built in |
+| Language reach | Swift natively, plus any language that can call the C ABI | C API essentially everywhere |
+| Insert throughput and cold open | Slower on the encrypted default path | Faster on the unencrypted reference path |
+| Ecosystem and tooling | Local CLI and REPL against the same engine | Very large third-party tooling surface |
+| Production history | Young | Decades of battle history |
+
+Neither product is migration-free for every schema evolution story.
 
 ---
 
@@ -34,108 +58,73 @@ These rows describe the **default open-source package**, not roadmap aspirations
 
 | Capability | BlazeDB today | Notes |
 |------------|---------------|-------|
-| Encrypted embedded storage | **Shipped** | Public open APIs require a password; pages at rest use **AES-256-GCM** (password-derived 256-bit key via PBKDF2-SHA256 + per-database salt). See [KEY_MANAGEMENT_AND_COMPATIBILITY.md](../Status/KEY_MANAGEMENT_AND_COMPATIBILITY.md). |
+| Encrypted embedded storage | **Shipped** | Public open APIs require a password; pages at rest use **AES-256-GCM** (password-derived 256-bit key via PBKDF2-SHA256 plus per-database salt). See [KEY_MANAGEMENT_AND_COMPATIBILITY.md](../Status/KEY_MANAGEMENT_AND_COMPATIBILITY.md). |
 | Typed Swift records (`BlazeStorable`) and raw / byte key-value APIs | **Shipped** | |
 | Fluent Swift queries (no SQL string engine) | **Shipped** | |
-| Transactional write APIs and WAL-backed recovery | **Shipped** | See durability docs for modes and caveats |
+| Transactional write APIs and WAL-backed recovery | **Shipped** | See [durability docs](../Status/DURABILITY_MODE_SUPPORT.md) for modes and caveats |
 | Live queries and SwiftUI integration | **Shipped (Apple platforms)** | Observation helpers are Apple-oriented; portable observe APIs exist in core |
-| Local inspection (`blazedb` CLI/REPL, maintenance tools) | **Shipped** | |
+| Local inspection (`blazedb` CLI and REPL, maintenance tools) | **Shipped** | |
 | Documented C ABI (`BlazeDBC`) | **Shipped** | Go via cgo is a recipe, not an official Go module |
-| Optional schema validation and migrations | **Shipped (opt-in)** | Flexible by default; **migrations exist** when you opt in, not “schema-less / no migrations” |
-| Concurrency model | **Shipped (qualified)** | Single-process embedded engine. Transactions provide consistency. **MVCC / snapshot isolation exists in the codebase but is not the default path**. Do not market “MVCC snapshot isolation” as the everyday guarantee. |
+| Optional schema validation and migrations | **Shipped (opt-in)** | Flexible by default; migrations exist when you opt in. This is not "schema-less, no migrations" |
+| Concurrency model | **Shipped (qualified)** | Single-process embedded engine; transactions provide consistency. **Multi-process writers are not supported and network filesystems are not recommended.** MVCC and snapshot isolation exist in the codebase but are **not the default path**, so snapshot isolation is not the everyday guarantee. BlazeDB is not a drop-in multi-writer file server |
 | Optional Secure Enclave-assisted key storage | **Platform optional** | Not required for default password-derived encryption |
-| Android / KMM consumption | **CI-validated (experimental packaging)** | PR-gate cross-compile + emulator smoke; not a published SDK; not Linux host Tier0 |
-| Multi-device sync / discovery / network server | **Deferred** | Not part of the default OSS package. See [DISTRIBUTED_TRANSPORT_DEFERRED.md](../Status/DISTRIBUTED_TRANSPORT_DEFERRED.md) |
+| Android / KMM consumption | **CI-validated (experimental packaging)** | PR-gate cross-compile plus emulator smoke; not a published SDK; not Linux host Tier0 |
+| Multi-device sync, discovery, network server | **Deferred** | Not part of the default OSS package. See [DISTRIBUTED_TRANSPORT_DEFERRED.md](../Status/DISTRIBUTED_TRANSPORT_DEFERRED.md) |
 | SQL string dialect | **Not shipped** | Use SQLite if you need SQL |
 
 ---
 
-## When BlazeDB is a good fit
+## Platform support
 
-- You are building Swift applications or in-process Swift services (including Vapor embedding) on supported platforms.
+BlazeDB is **runtime-tested** on macOS and Linux (host engine tests). Other Apple platforms (iOS, watchOS, tvOS, visionOS) are **compile-tested**. Android and KMM are **CI-validated** through a PR-gate cross-compile and a KMM emulator smoke, with **experimental packaging**.
+
+Android and KMM are not equivalent in maturity to macOS and Linux host Tier0, and they are also not unsupported. Details: [COMPATIBILITY.md](../COMPATIBILITY.md) and [android-status.md](../android-status.md).
+
+SQLite's C API remains the broader "runs everywhere" option when you need one binary story across many languages and hosts.
+
+---
+
+## Choose BlazeDB when
+
+- You are building Swift applications or in-process Swift services, including Vapor embedding, on supported platforms.
 - You want encryption at rest without bolting on a separate cipher extension.
 - You prefer typed documents and fluent Swift queries over SQL strings.
 - You want in-process live queries and Apple-platform SwiftUI observation.
-- You need a local CLI/REPL and related inspection tools against the same engine.
-- You may embed the engine from C (or languages that call C) through `BlazeDBC`.
+- You need a local CLI and REPL against the same engine for inspection.
+- You may embed the engine from C, or from a language that calls C, through `BlazeDBC`.
 
----
-
-## When SQLite is the better choice
+## Choose SQLite when
 
 - You need SQL compatibility, complex joins, or existing SQL tooling and expertise.
-- You need the broadest language and platform ecosystem (C API everywhere).
+- You need the broadest language and platform ecosystem.
 - You care most about raw insert throughput or cold-open latency on an unencrypted store.
-- You want decades of production battle history and a large third-party tooling surface.
-- You do not need encryption by default (or you already standardize on SQLCipher / similar).
+- You want decades of production history and a large third-party tooling surface.
+- You do not need encryption by default, or you already standardize on SQLCipher or similar.
+
+Multi-device sync, discovery, and a networked BlazeDB server are **not** reasons to choose BlazeDB today. They are deferred from the default open-source package.
 
 ---
 
-## Capability corrections (read these before citing old tables)
+## Core Data and Realm
 
-Older comparison tables in the repo sometimes claimed mythology. Prefer this page + Compatibility over archive / architecture one-liners.
+- **Core Data**: Apple-framework ORM and persistence layer with deep Cocoa integration and its own migration story. Prefer it when you want framework integration over a standalone encrypted document engine.
+- **Realm**: mobile-oriented object database with a long commercial and sync history. Licensing and sync product status have changed over time, so verify current upstream terms rather than trusting a one-word summary. Prefer Realm when you specifically want that ecosystem; prefer BlazeDB when you want MIT-licensed, encryption-default, Swift-native embedded storage without a sync product claim.
 
-| Topic | Verified wording |
-|-------|------------------|
-| **Schema** | Flexible by default; **optional validation and real migration APIs** exist. Not “dynamic, no migrations.” |
-| **Concurrency** | Single-process embedded design; multi-process writers unsupported; network filesystems not recommended. Do not claim absolute “MVCC snapshot isolation” as the default product behavior. |
-| **Performance** | Cite [Benchmarks](../Benchmarks/README.md) only. Do **not** use “predictable, optimized for Apple Silicon” or free-floating “% faster than SQLite” slogans. |
-| **Encryption** | At-rest pages: **AES-256-GCM** with password-derived keys on public open APIs. SQLite encryption remains optional/extension-based (e.g. SQLCipher). |
-| **Platforms** | macOS/Linux runtime-tested (host engine tests); other Apple platforms compile-tested; Android/KMM CI-validated with experimental packaging. |
-| **Sync** | Deferred from the default OSS package, not a selection reason today. |
-
-### Brief notes on Core Data and Realm
-
-- **Core Data**: Apple-framework ORM/persistence with deep Cocoa integration and its own migration story. Prefer it when you want framework integration over a standalone encrypted document engine.
-- **Realm**: Mobile-oriented object database with a long commercial/sync history; **licensing and sync product status have changed over time**. Verify current upstream terms rather than citing a one-word “Commercial/MIT” cell. Prefer Realm when you specifically want that ecosystem; prefer BlazeDB when you want MIT-licensed, encryption-default, Swift-native embedded storage without a sync product claim.
-
-This page does **not** maintain a full BlazeDB vs Core Data vs Realm feature matrix. Those one-liners go stale quickly.
+This page does not maintain a full BlazeDB vs Core Data vs Realm feature matrix. Those one-liners go stale quickly.
 
 ---
 
-## Tradeoffs (without invented percentages)
+## Note for maintainers and doc authors
 
-### Encryption
+This page is the authority for BlazeDB vs SQLite positioning. Prefer it and [COMPATIBILITY.md](../COMPATIBILITY.md) over older architecture or archive one-liners, several of which overstate the product.
 
-BlazeDB public open APIs require a password; stored pages use **AES-256-GCM**. SQLite encryption is optional and typically comes from an extension (for example SQLCipher). Prefer BlazeDB when encryption-by-default is a primary requirement.
+When citing capabilities elsewhere in the repo:
 
-### Query model
-
-BlazeDB uses fluent Swift APIs. SQLite uses SQL. Prefer SQLite for SQL-heavy workloads and existing SQL ecosystems; prefer BlazeDB for Swift-native typed access.
-
-### Schema
-
-BlazeDB models are often flexible day-to-day, with **optional** schema validation and a real migration surface when you need it. SQLite uses explicit SQL schemas and migrations. Neither product is “migration-free” for every evolution story.
-
-### Concurrency and process model
-
-BlazeDB is designed as a **single-process** embedded engine. Multi-process writers are not supported; network filesystems are not recommended. SQLite has a long history of multi-connection patterns (with its own locking and WAL rules). Do not treat BlazeDB as a drop-in multi-writer file server, and do not equate “transactions exist” with “MVCC snapshot isolation is always on.”
-
-### Performance
-
-Do **not** trust free-floating “X% faster than SQLite” slogans on this page or elsewhere in the repo without measured methodology. Do not cite vague “optimized for Apple Silicon” language as evidence.
-
-Authoritative measured comparisons:
-
-- [Docs/Benchmarks/README.md](../Benchmarks/README.md) (how to run and how to read results)
-- [Docs/Benchmarks/COMPARISON.md](../Benchmarks/COMPARISON.md) (headline BlazeDB vs SQLite table)
-- [Docs/Benchmarks/RESULTS.md](../Benchmarks/RESULTS.md) and [LATENCY.md](../Benchmarks/LATENCY.md)
-
-In current measured comparison runs, SQLite typically wins raw insert throughput and cold-open latency on the unencrypted reference path. BlazeDB’s secure default path includes encryption and different durability costs. Some concurrent-read harness numbers favor BlazeDB; treat those as workload-specific, not a general “faster than SQLite” claim.
-
-### Sync and servers
-
-Distributed sync, discovery, and a networked BlazeDB server are **not** reasons to choose BlazeDB today. They are deferred from the default open-source package. See [DISTRIBUTED_TRANSPORT_DEFERRED.md](../Status/DISTRIBUTED_TRANSPORT_DEFERRED.md).
-
----
-
-## Recommendation
-
-Choose **BlazeDB** for encrypted Swift-native embedded storage, typed records, live queries, local inspection tooling, and native embedding through the C ABI, on platforms whose support tier matches your risk tolerance.
-
-Choose **SQLite** when SQL compatibility, ecosystem maturity, third-party tooling, broad language support, or lower insert and cold-open latency matter more.
-
-Both are strong embedded databases for different jobs. Pick the product whose **shipped** shape matches your constraints.
+- Do not describe the schema story as "dynamic, no migrations". Optional validation and real migration APIs exist.
+- Do not present MVCC or snapshot isolation as the default product behavior. It exists in the codebase but is not the default path.
+- Do not use free-floating "percent faster than SQLite" figures, or "predictable, optimized for Apple Silicon" language, as evidence. Cite [Benchmarks](../Benchmarks/README.md) with methodology or say nothing.
+- Do not describe Android or KMM as shipped, and do not describe them as unsupported. The accurate word is experimental.
+- Do not cite deferred sync as a current selection reason.
 
 ---
 

--- a/Docs/Meta/README.md
+++ b/Docs/Meta/README.md
@@ -4,7 +4,7 @@ This directory contains internal documentation about the project itself, reorgan
 
 ## Metrics
 
-- **[REPOSITORY_METRICS.md](REPOSITORY_METRICS.md)** — generated repository scale snapshot (`./Scripts/repo-metrics.sh`). Compact public summary lives under [README Project status](../../README.md#repository-scale).
+- **[REPOSITORY_METRICS.md](REPOSITORY_METRICS.md)** - generated repository scale snapshot (`./Scripts/repo-metrics.sh`). This is the canonical home for scale numbers; the root [README](../../README.md) links here from Project status rather than restating counts.
 
 ## Reorganization
 

--- a/Docs/Tools/README.md
+++ b/Docs/Tools/README.md
@@ -15,9 +15,9 @@ Use these **exact** status words everywhere (README, this map, issues). Do not i
 | Tool | How to run | Role | Status |
 |------|------------|------|--------|
 | `blazedb` | `swift build --product blazedb` then `.build/debug/blazedb` | Interactive picker / REPL | **shipped** |
-| `BlazeDoctor` | `swift run BlazeDoctor` | Health checks (separate executable, not a `blazedb` subcommand) | **shipped** |
-| `BlazeDump` | `swift run BlazeDump` | Export / restore (separate executable) | **shipped** |
-| `BlazeInfo` | `swift run BlazeInfo` | Quick snapshot (separate executable) | **shipped** |
+| `BlazeDoctor` | `swift run BlazeDoctor <db-path> <password>` | Health checks (separate executable, not a `blazedb` subcommand) | **shipped** |
+| `BlazeDump` | `swift run BlazeDump <command> <args>` | Export / restore (separate executable) | **shipped** |
+| `BlazeInfo` | `swift run BlazeInfo <db-path> <password>` | Quick snapshot (separate executable) | **shipped** |
 | `./dev` | `./dev help` | Contributor tests, tiers, experiments, **benchmarks** (`dev bench`) | **shipped** |
 | `./bench` | `./bench` / `./bench honesty` | Benchmark front door (payload / DB-size sweeps, publish) | **shipped** |
 | `BlazeDBBenchmarks` | `swift run BlazeDBBenchmarks` or via `./bench` | Methodology workloads (not README vanity numbers) | **shipped** |
@@ -32,6 +32,8 @@ Use these **exact** status words everywhere (README, this map, issues). Do not i
 `BlazeShell/` holds implementation sources for the **`blazedb`** product (`BlazeCLICore` / `BlazedbCLI`). There is no separate "BlazeShell" executable to ship.
 
 Doctor, Dump, and Info are **shipped** SwiftPM executables. They are not `blazedb` subcommands today (see issues #259, #300).
+
+All three require arguments and exit 1 with a usage message when run bare, so `swift run BlazeDoctor` on its own is not a working invocation. Pass `--help` to see the full argument list, or read the per-tool docs linked below. This also means their Xcode Run schemes need arguments set to do anything useful.
 
 ### Benchmarks
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BlazeDB
 
-BlazeDB is an encrypted, in-process database engine written in Swift for applications and in-process services. It provides typed document APIs, raw key-value access, transactional write APIs, WAL-backed recovery, live queries, SwiftUI integration on Apple platforms, local inspection tools, Linux runtime support, a documented C ABI for native embeds, and CI-validated Android/KMM paths (experimental packaging). Go and other languages can call the C ABI through cgo or FFI; no official language SDKs are published.
+BlazeDB is an encrypted, embedded database for Swift applications and services, with typed records, transactional writes, WAL-backed recovery, live queries, and Linux support.
 
 It runs inside your process. No separate database server is required.
 
@@ -10,16 +10,6 @@ It runs inside your process. No separate database server is required.
 [![Swift](https://img.shields.io/badge/Swift-6.0+-orange.svg)](https://swift.org)
 
 **Current release:** [v2.8.1](RELEASE.md) · [Changelog](CHANGELOG.md) · [Docs index](Docs/README.md) · [Compatibility](Docs/COMPATIBILITY.md)
-
-### Platforms
-
-| Tier | Platforms |
-|------|-----------|
-| **Runtime CI** (host engine tests) | macOS, Linux |
-| **Declared and compile-tested** | iOS, watchOS, tvOS, visionOS |
-| **experimental** | Android cross-compile + KMM sample runtime in the PR gate (not a published SDK) |
-
-Android is **experimental**: the PR gate cross-compiles the bridge and runs a KMM emulator smoke. It is not **shipped** as a consumer SDK (no `Package.swift` platform entry; no published registry artifacts) and not equivalent to Linux host Tier0. Details: [Compatibility](Docs/COMPATIBILITY.md) · [android-status.md](Docs/android-status.md).
 
 ---
 
@@ -56,47 +46,35 @@ cd BlazeDB
 swift run HelloBlazeDB
 ```
 
-CI also verifies the README snippets: `swift run ReadmeSamples`.
+CI verifies the snippets above: `swift run ReadmeSamples`.
 
 ---
 
-## Why BlazeDB
+## Is BlazeDB the right choice
 
-- **Encryption by default:** Public database-opening APIs require a password; stored pages use AES-256-GCM. See [Key management](Docs/Status/KEY_MANAGEMENT_AND_COMPATIBILITY.md) and [Security architecture](Docs/Security/README.md).
-- **Typed Swift records:** Store ordinary structs with `BlazeStorable`, or use raw and byte APIs when you need them. [Getting Started](Docs/GettingStarted/README.md) · [API Reference](Docs/API/API_REFERENCE.md).
-- **WAL-backed recovery:** The default storage path uses a write-ahead log. Documented durability behavior and overflow caveats: [Durability Mode Support](Docs/Status/DURABILITY_MODE_SUPPORT.md).
-- **Transactional write APIs:** Public write paths support transactional work. See [Transactions](Docs/DEVELOPER_GUIDE.md#transactions) in the Developer Guide.
-- **Live queries and SwiftUI:** Observe result sets in-process with `BlazeLiveQuery` and SwiftUI-facing wrappers on supported Apple platforms. [Live query architecture](Docs/Architecture/LIVE_QUERY_ARCHITECTURE.md) · [SwiftUI patterns](Docs/GettingStarted/SWIFTUI_DATABASE_PATTERNS.md).
-- **Inspection tooling:** Explore databases with the shipped `blazedb` CLI/REPL; companion macOS apps and maintenance executables are listed below.
-- **Linux runtime:** Core engine is exercised in Linux CI alongside macOS. [Linux getting started](Docs/GettingStarted/LINUX_GETTING_STARTED.md).
-- **Native embeds:** The same engine is reachable through `BlazeDBC` (`blazedb.h`). [C ABI contract](Docs/Architecture/C_ABI_BYTE_KV.md).
-- **Android / KMM (experimental):** PR-gate cross-compile + KMM emulator smoke exist; not a published mobile SDK and not Linux-equivalent host Tier0. [android-status.md](Docs/android-status.md).
+| Choose BlazeDB when | Choose SQLite or GRDB when |
+|---------------------|----------------------------|
+| You want typed Swift document APIs | You need SQL |
+| Encryption by default matters | You need ecosystem maturity |
+| Live in-process Swift queries matter | You need broader third-party tooling |
+| You accept single-process file ownership | You need multi-process access |
 
----
+Longer fit comparison, including where SQLite wins on latency: [Why not SQLite?](Docs/GettingStarted/WHY_NOT_SQLITE.md)
 
-## Choose your path
+### Do not use BlazeDB when you need
 
-| If you want to… | Start here |
-|-----------------|------------|
-| Build a Swift app | [Try it](#try-it) · [Getting Started](Docs/GettingStarted/README.md) |
-| Embed in Vapor or server-side Swift | [HOW_TO_USE: Vapor embedding](Docs/GettingStarted/HOW_TO_USE_BLAZEDB.md#8-using-blazedb-in-a-server-vapor-example) |
-| Use the CLI / REPL | [CLI and tools](#cli-and-inspection-tools) · [Tools docs](Docs/Tools/README.md) |
-| Call from C | [Native interoperability](#native-interoperability) · [Examples/C](Examples/C/) |
-| Call from Go via cgo | [Examples/Go](Examples/Go/README.md) (recipe; no official Go module) |
-| Understand durability and recovery | [Durability Mode Support](Docs/Status/DURABILITY_MODE_SUPPORT.md) |
-| Encryption and vulnerability reporting | [Key management](Docs/Status/KEY_MANAGEMENT_AND_COMPATIBILITY.md) · [SECURITY.md](SECURITY.md) |
-| Live queries / SwiftUI | [Live query architecture](Docs/Architecture/LIVE_QUERY_ARCHITECTURE.md) · [SwiftUI patterns](Docs/GettingStarted/SWIFTUI_DATABASE_PATTERNS.md) |
-| Linux setup | [LINUX_GETTING_STARTED.md](Docs/GettingStarted/LINUX_GETTING_STARTED.md) |
-| Android / KMM (**experimental**) | [android-status.md](Docs/android-status.md) |
-| Platform support tiers | [Compatibility](Docs/COMPATIBILITY.md) |
-| Benchmarks and methodology | [Docs/Benchmarks](Docs/Benchmarks/README.md) |
-| Contribute | [Contributing](#contributing) · [CONTRIBUTING.md](CONTRIBUTING.md) |
+- Multi-process writers ([why single-writer](Docs/Guarantees/WHY_SINGLE_WRITER.md))
+- Networked or client-server access
+- Multi-device sync ([deferred from the default package](Docs/Status/DISTRIBUTED_TRANSPORT_DEFERRED.md))
+- SQL compatibility (fluent Swift queries only)
+- Storage on a network filesystem (not recommended)
+- A published mobile SDK for Android ([experimental only](Docs/android-status.md))
 
 ---
 
 ## Installation
 
-Requires Swift 6.0+ ([swift.org](https://www.swift.org/install/) or Xcode). Matches `swift-tools-version:6.0` in `Package.swift`.
+Requires Swift 6.0+ ([swift.org](https://www.swift.org/install/) or Xcode), matching `swift-tools-version:6.0` in `Package.swift`.
 
 ```swift
 .package(url: "https://github.com/Mikedan37/BlazeDB.git", from: "2.8.1")
@@ -104,215 +82,76 @@ Requires Swift 6.0+ ([swift.org](https://www.swift.org/install/) or Xcode). Matc
 
 Depend on the **`BlazeDB`** product and `import BlazeDB`.
 
-From a clone:
-
-```bash
-swift run HelloBlazeDB
-swift run ReadmeSamples
-swift build --product blazedb
-swift build -c release --product BlazeDBC
-```
-
-Release notes for this pin: [RELEASE.md](RELEASE.md) (v2.8.1). Longer walkthrough: [HOW_TO_USE_BLAZEDB.md](Docs/GettingStarted/HOW_TO_USE_BLAZEDB.md).
+Longer walkthrough: [HOW_TO_USE_BLAZEDB.md](Docs/GettingStarted/HOW_TO_USE_BLAZEDB.md) · Release notes for this pin: [RELEASE.md](RELEASE.md)
 
 ---
 
-## Core API overview
+## Guarantees
 
-| Task | Entry | Deeper docs |
-|------|-------|-------------|
-| Open | `BlazeDB.open(name:password:)` or `open(at:password:)` | [Getting Started](Docs/GettingStarted/README.md) |
-| Typed put / get / query | `BlazeStorable` + namespace queries | [API Reference](Docs/API/API_REFERENCE.md) |
-| Transactional writes | `beginTransaction` / `commitTransaction` / rollback | [Transactions](Docs/DEVELOPER_GUIDE.md#transactions) |
-| Live queries | `BlazeLiveQuery` / SwiftUI property wrappers | [LIVE_QUERY_ARCHITECTURE](Docs/Architecture/LIVE_QUERY_ARCHITECTURE.md) |
-| Raw / byte KV | Client byte APIs; C ABI mirrors this surface | [C_ABI_BYTE_KV](Docs/Architecture/C_ABI_BYTE_KV.md) |
-| Indexing and queries | Query builder, indexes, search tuning | [Developer Guide](Docs/DEVELOPER_GUIDE.md) · [Performance](Docs/Performance/README.md) |
-| Schema and migrations | Schema validation and migration APIs | [MIGRATION.md](Docs/MIGRATION.md) · [Advanced topics](Docs/README.md#advanced-but-supported) |
-| Backup, export, restore | Export/import and verification APIs | [HOW_TO_USE: Backups](Docs/GettingStarted/HOW_TO_USE_BLAZEDB.md#9-backups-restore-and-trust) |
-
-See the [documentation index](Docs/README.md) for support status and deeper guides.
-
----
-
-## Deployment model
-
-BlazeDB is embedded and runs inside the host process on a local database file.
-
-Common hosts include:
-
-- SwiftUI and other Apple-platform applications
-- macOS and Linux command-line tools
-- Vapor and other server-side Swift processes ([embedding guide](Docs/GettingStarted/HOW_TO_USE_BLAZEDB.md#8-using-blazedb-in-a-server-vapor-example))
-- Native applications linking `BlazeDBC`
-
-It is not a standalone network database server and not a multi-device sync product in the default package. Platform tiers (runtime, compile-tested, experimental): [Compatibility](Docs/COMPATIBILITY.md).
-
----
-
-## Guarantees and boundaries
-
-**Core guarantees:**
-
-- Public database-opening APIs require a password; stored pages use AES-256-GCM
-- Default storage path uses WAL-backed recovery ([documented durability behavior](Docs/Status/DURABILITY_MODE_SUPPORT.md))
-- Typed document APIs and raw key-value access
-- Transactional write APIs and in-process live queries
+- Public database-opening APIs require a password; stored pages use AES-256-GCM ([key management](Docs/Status/KEY_MANAGEMENT_AND_COMPATIBILITY.md))
+- Default storage path uses WAL-backed recovery ([documented durability behavior and overflow caveats](Docs/Status/DURABILITY_MODE_SUPPORT.md))
+- Typed document APIs and raw key-value access ([API reference](Docs/API/API_REFERENCE.md))
+- Transactional write APIs ([transactions](Docs/DEVELOPER_GUIDE.md#transactions)) and in-process live queries ([architecture](Docs/Architecture/LIVE_QUERY_ARCHITECTURE.md))
 - Single-process file ownership model
 
-**Boundaries (stated once):**
+**Deployment:** a SwiftUI or Apple-platform app, a macOS or Linux command-line tool, a Vapor or other server-side Swift process, or a native application linking `BlazeDBC`. In every case BlazeDB runs in the host process and owns a local file. Constraints are listed under [Do not use BlazeDB when you need](#do-not-use-blazedb-when-you-need) above.
 
-- Embedded and in-process. A Swift service may embed BlazeDB; BlazeDB is not a networked database server product.
-- No SQL string engine (fluent Swift queries only).
-- Distributed sync, discovery, server, and full telemetry packaging are deferred from the default OSS product ([Distributed Transport Deferred](Docs/Status/DISTRIBUTED_TRANSPORT_DEFERRED.md)).
-- Multi-process writers are not supported ([why single-writer](Docs/Guarantees/WHY_SINGLE_WRITER.md)).
-- Network filesystems are not recommended.
-- Android and KMM are **experimental** (PR-gate CI exists; not a published SDK; not Linux host Tier0).
-- The C ABI enables native embeds; there are no official Go, Rust, or Python SDKs.
-
-Direction (not release guarantees): [ROADMAP.md](ROADMAP.md).
+Direction, not release guarantees: [ROADMAP.md](ROADMAP.md)
 
 ---
 
-## CLI and inspection tools
+## Platforms
 
-Status words (use exactly): **shipped**, **beta**, **experimental**, **in-tree, not packaged**, **deferred**. Full map: [Docs/Tools/README.md](Docs/Tools/README.md).
+| Tier | Platforms |
+|------|-----------|
+| **Runtime CI** (host engine tests) | macOS, Linux |
+| **Declared and compile-tested** | iOS, watchOS, tvOS, visionOS |
+| **experimental** | Android cross-compile + KMM sample runtime in the PR gate (not a published SDK) |
 
-| Tool | Role | Status |
-|------|------|--------|
-| `blazedb` | Interactive picker, inspection, REPL (`swift build --product blazedb`) | **shipped** |
-| `BlazeDoctor` / `BlazeDump` / `BlazeInfo` | Maintenance utilities (`swift run BlazeDoctor`, etc.; not `blazedb` subcommands) | **shipped** |
-| [BlazeStudio](BlazeStudio/) | macOS visual / browser aid (`BlazeStudio.xcodeproj`) | **beta** |
-| [BlazeDBVisualizer](BlazeDBVisualizer/) | macOS storage inspection UI | **beta** |
-| `./bench` / `./dev bench` | Benchmark front door (honesty lint, payload / DB-size sweeps, publish) | **shipped** |
-| `BlazeDBBenchmarks` | Methodology workloads (not README vanity numbers) | **shipped** |
-| `./dev` | Contributor test / tier helper (`./dev help`) | **shipped** |
-| BlazeMCP | MCP design / sources under `BlazeMCP/` | **in-tree, not packaged** |
+Android is **experimental**: the PR gate cross-compiles the bridge and runs a KMM emulator smoke. It is not **shipped** as a consumer SDK (no `Package.swift` platform entry, no published registry artifacts) and not equivalent to Linux host Tier0.
+
+Authority for tiers: [Compatibility](Docs/COMPATIBILITY.md) · [android-status.md](Docs/android-status.md)
+
+---
+
+## Tools and native embedding
+
+The `blazedb` CLI and REPL ship with the package for local inspection:
 
 ```bash
 swift build --product blazedb
 .build/debug/blazedb --help
 .build/debug/blazedb          # interactive picker / REPL (not a network server)
-
-./dev help                    # contributor + benchmark commands
-./bench honesty               # or: ./dev bench honesty
-./bench smoke                 # short local sweeps → benchmark_results/
-# ./bench publish             # long release sweeps → Docs/Benchmarks/ (maintainers)
 ```
 
-Benchmarks are **not** normal XCTest CI. Methodology and honest framing: [Docs/Benchmarks/README.md](Docs/Benchmarks/README.md) · [HONEST_PERFORMANCE.md](Docs/Benchmarks/HONEST_PERFORMANCE.md).
-
-More: [Docs/Tools/README.md](Docs/Tools/README.md) · schemes: [XCODE_SCHEMES.md](Docs/Build/XCODE_SCHEMES.md).
-
----
-
-## Native interoperability
-
-`BlazeDBC` exposes a documented **byte-oriented** C ABI (`BlazeDBC/include/blazedb.h`). Published symbols and behavior follow [C_ABI_BYTE_KV.md](Docs/Architecture/C_ABI_BYTE_KV.md) (stability-governed signatures, not a forever-frozen binary drop-in).
-
-Excerpt from [Examples/C/hello_blazedb.c](Examples/C/hello_blazedb.c):
-
-```c
-BlazeDB *db = blazedb_open("hello.blaze", "DemoPass123!");
-const char *payload = "queued";
-BlazeDBResult rc = blazedb_put(db, "job:42", payload, strlen(payload));
-/* get, blazedb_free, delete, close: see hello_blazedb.c */
-```
+`BlazeDBC` exposes a documented byte-oriented C ABI (`BlazeDBC/include/blazedb.h`), so any language that can call C is able to embed the same engine. That is interoperability capability, not an official SDK per language. No Go, Rust, or Python SDKs are published.
 
 ```bash
 swift build -c release --product BlazeDBC
-# .build/release/libBlazeDBC.dylib (macOS) or libBlazeDBC.so (Linux)
 ```
 
-Languages that can call C (including Go via cgo, Rust, and Python) can use this surface. That is interoperability capability, not an official SDK for each language.
+Full tool catalog with support-state labels, visualizer apps, and the benchmark front door: [Docs/Tools/README.md](Docs/Tools/README.md) · C ABI contract: [C_ABI_BYTE_KV.md](Docs/Architecture/C_ABI_BYTE_KV.md) · Go via cgo recipe: [Examples/Go/README.md](Examples/Go/README.md)
 
-**Go:** Go can call the C ABI through cgo; no official Go module is currently published. Recipe and limits: [Examples/Go/README.md](Examples/Go/README.md). Dynamic packaging notes: [RELEASE.md](RELEASE.md).
-
----
-
-## Architecture map
-
-| Topic | Canonical doc |
-|-------|----------------|
-| Overview | [Docs/Architecture/README.md](Docs/Architecture/README.md) |
-| Encryption / keys | [Key management](Docs/Status/KEY_MANAGEMENT_AND_COMPATIBILITY.md) · [Security architecture](Docs/Security/README.md) |
-| WAL / recovery | [Durability Mode Support](Docs/Status/DURABILITY_MODE_SUPPORT.md) |
-| Codebase map | [CODEBASE_MAP](Docs/Architecture/CODEBASE_MAP.md) |
-| Live queries | [LIVE_QUERY_ARCHITECTURE](Docs/Architecture/LIVE_QUERY_ARCHITECTURE.md) |
-| C ABI | [C_ABI_BYTE_KV](Docs/Architecture/C_ABI_BYTE_KV.md) |
-| Indexing / queries | [Developer Guide](Docs/DEVELOPER_GUIDE.md) |
-| Schema / migrations | [MIGRATION.md](Docs/MIGRATION.md) |
-
-```text
-Swift apps / blazedb CLI
-        │
-        ▼
-   BlazeDB / BlazeDBCore
-        ├── typed and raw APIs
-        ├── queries, indexes, live queries
-        ├── transactional writes + WAL recovery
-        └── encrypted pages → disk
-
-C / FFI hosts ──► BlazeDBC ──► same engine
-```
+Benchmarks are not normal XCTest CI. Methodology and honest framing: [Docs/Benchmarks/README.md](Docs/Benchmarks/README.md)
 
 ---
 
-## Examples
+## Documentation
 
-Full catalog with support-state labels: [Examples/README.md](Examples/README.md).
+Start with the [documentation index](Docs/README.md), which carries support status for every area.
 
-### Examples by status
-
-| Example | Status | Notes |
-|---------|--------|-------|
-| [HelloBlazeDB](Examples/HelloBlazeDB/), [ReadmeSamples](Examples/ReadmeSamples/), [CorePathSmoke](Examples/CorePathSmoke/), [MVVMPattern](Examples/MVVMPattern/), [C/hello_blazedb.c](Examples/C/hello_blazedb.c) | **shipped** (sample paths) | Default onboarding |
-| [VaporServer](Examples/VaporServer/) | **in-tree, not packaged** | Embed sample; not a Package product |
-| [Go preview](Examples/Go/README.md) | **in-tree, not packaged** | cgo recipe; no checked-in `.go` module |
-| [SwiftUIExample.swift](Examples/SwiftUIExample.swift) | **beta** sample file | Default SwiftUI path: [SWIFTUI_DATABASE_PATTERNS](Docs/GettingStarted/SWIFTUI_DATABASE_PATTERNS.md) |
-| Android / KMM samples | **experimental** | [android-status.md](Docs/android-status.md) |
-| Sync / telemetry samples | **deferred** | [DISTRIBUTED_TRANSPORT_DEFERRED.md](Docs/Status/DISTRIBUTED_TRANSPORT_DEFERRED.md) |
-
----
-
-## Documentation map
-
-See the [documentation index](Docs/README.md) for canonical, advanced, conditional, and historical material.
-
-### Get started
-
-- [Getting Started](Docs/GettingStarted/README.md)
-- [HOW_TO_USE_BLAZEDB.md](Docs/GettingStarted/HOW_TO_USE_BLAZEDB.md) (includes Vapor embedding)
-- [LINUX_GETTING_STARTED.md](Docs/GettingStarted/LINUX_GETTING_STARTED.md)
-- [Examples/README.md](Examples/README.md)
-
-### Understand the engine
-
-- [Architecture](Docs/Architecture/README.md)
-- [Encryption and key management](Docs/Status/KEY_MANAGEMENT_AND_COMPATIBILITY.md)
-- [Durability and recovery](Docs/Status/DURABILITY_MODE_SUPPORT.md)
-- [Transactional writes](Docs/DEVELOPER_GUIDE.md#transactions)
-- [Developer Guide](Docs/DEVELOPER_GUIDE.md)
-- [API Reference](Docs/API/API_REFERENCE.md)
-- [Indexing and performance](Docs/Performance/README.md)
-- [Schema and migrations](Docs/MIGRATION.md)
-- [Backup, export, and restore](Docs/GettingStarted/HOW_TO_USE_BLAZEDB.md#9-backups-restore-and-trust)
-
-### Tools and integrations
-
-- [Tools](Docs/Tools/README.md)
-- [C ABI](Docs/Architecture/C_ABI_BYTE_KV.md)
-- [Go preview](Examples/Go/README.md)
-- [Benchmarks](Docs/Benchmarks/README.md) (methodology only; no raw vanity numbers here)
-- [Why not SQLite?](Docs/GettingStarted/WHY_NOT_SQLITE.md) (fit comparison; measured numbers live under Benchmarks)
-
-### Project information
-
-- [Compatibility](Docs/COMPATIBILITY.md)
-- [SECURITY.md](SECURITY.md) (reporting)
-- [RELEASE.md](RELEASE.md) · [CHANGELOG.md](CHANGELOG.md)
-- [ROADMAP.md](ROADMAP.md)
-- [CONTRIBUTING.md](CONTRIBUTING.md)
-- [Repository metrics](Docs/Meta/REPOSITORY_METRICS.md) (maintainer scale + health snapshot)
+| Area | Entry point |
+|------|-------------|
+| Get started | [Getting Started](Docs/GettingStarted/README.md) · [HOW_TO_USE_BLAZEDB.md](Docs/GettingStarted/HOW_TO_USE_BLAZEDB.md) · [Linux](Docs/GettingStarted/LINUX_GETTING_STARTED.md) |
+| API and queries | [API Reference](Docs/API/API_REFERENCE.md) · [Developer Guide](Docs/DEVELOPER_GUIDE.md) |
+| Engine internals | [Architecture](Docs/Architecture/README.md) · [Codebase map](Docs/Architecture/CODEBASE_MAP.md) |
+| Encryption and keys | [Key management](Docs/Status/KEY_MANAGEMENT_AND_COMPATIBILITY.md) · [Security architecture](Docs/Security/README.md) |
+| Durability and recovery | [Durability Mode Support](Docs/Status/DURABILITY_MODE_SUPPORT.md) |
+| Schema and migrations | [MIGRATION.md](Docs/MIGRATION.md) |
+| Backup and restore | [HOW_TO_USE: Backups](Docs/GettingStarted/HOW_TO_USE_BLAZEDB.md#9-backups-restore-and-trust) |
+| Performance | [Docs/Performance](Docs/Performance/README.md) · [Benchmarks](Docs/Benchmarks/README.md) |
+| Examples | [Examples/README.md](Examples/README.md) (catalog with support-state labels) |
+| SwiftUI | [SwiftUI patterns](Docs/GettingStarted/SWIFTUI_DATABASE_PATTERNS.md) |
 
 ---
 
@@ -320,18 +159,10 @@ See the [documentation index](Docs/README.md) for canonical, advanced, condition
 
 BlazeDB welcomes focused contributions across documentation, developer tooling, tests, platform support, and core correctness.
 
-Start with:
+- [Good first issues](https://github.com/Mikedan37/BlazeDB/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) · [Help wanted](https://github.com/Mikedan37/BlazeDB/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)
+- [Contribution guide](CONTRIBUTING.md) · [Issue guide](Docs/Contributing/ISSUE_GUIDE.md) · [Learning paths](Docs/Contributing/LEARNING_PATHS.md)
 
-- [Good first issues](https://github.com/Mikedan37/BlazeDB/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
-- [Help wanted](https://github.com/Mikedan37/BlazeDB/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)
-- [Contribution guide](CONTRIBUTING.md)
-- [Issue guide](Docs/Contributing/ISSUE_GUIDE.md)
-- [Learning paths](Docs/Contributing/LEARNING_PATHS.md)
-- [Roadmap](ROADMAP.md)
-
-Comment on an issue before starting substantial work so scope and ownership are clear.
-
-Setup, `./dev`, and PR expectations: [CONTRIBUTING.md](CONTRIBUTING.md). Codebase orientation: [CODEBASE_MAP](Docs/Architecture/CODEBASE_MAP.md).
+Comment on an issue before starting substantial work so scope and ownership are clear. Codebase orientation: [CODEBASE_MAP](Docs/Architecture/CODEBASE_MAP.md)
 
 ---
 
@@ -342,19 +173,7 @@ Setup, `./dev`, and PR expectations: [CONTRIBUTING.md](CONTRIBUTING.md). Codebas
 | Release | [v2.8.1](RELEASE.md) · [CHANGELOG](CHANGELOG.md) |
 | Platforms | [COMPATIBILITY.md](Docs/COMPATIBILITY.md) |
 | Roadmap | [ROADMAP.md](ROADMAP.md) (directional) |
-| Security | [SECURITY.md](SECURITY.md) |
+| Security | [SECURITY.md](SECURITY.md) (reporting) |
 | License | MIT ([LICENSE](LICENSE)) |
 
-### Repository scale
-
-Approximate tracked size:
-
-- ~101k source lines · ~229k test lines · ~200k documentation lines
-- ~2.3× test-to-source line ratio · ~7,200 `test*` methods · ~1,100 Swift files
-- ~66k lines in the `BlazeDB/` engine tree
-- 28 SwiftPM targets across seven major subsystems: engine core, storage/WAL, query, crypto, transactions, C ABI, and CLI (plus experimental Android/KMM packaging)
-- CI coverage on macOS, Linux, and Android/KMM paths
-
-Full counts, CI-lane coverage, and review candidates: [Docs/Meta/REPOSITORY_METRICS.md](Docs/Meta/REPOSITORY_METRICS.md) (`./Scripts/repo-metrics.sh`).
-
-Deferred packaging (sync / server / telemetry): [DISTRIBUTED_TRANSPORT_DEFERRED.md](Docs/Status/DISTRIBUTED_TRANSPORT_DEFERRED.md).
+Repository structure, test coverage, and CI lane metrics: [Docs/Meta/REPOSITORY_METRICS.md](Docs/Meta/REPOSITORY_METRICS.md)

--- a/README.md
+++ b/README.md
@@ -91,13 +91,48 @@ Longer walkthrough: [HOW_TO_USE_BLAZEDB.md](Docs/GettingStarted/HOW_TO_USE_BLAZE
 ```bash
 swift run HelloBlazeDB          # smallest working example
 swift run ReadmeSamples         # every snippet in this README, verified
-
-swift build --product blazedb   # the CLI
-.build/debug/blazedb --help
-.build/debug/blazedb            # interactive picker and REPL, not a network server
 ```
 
-The interactive REPL needs a real terminal. Run it from a shell, not from an IDE console.
+### Open your own database in the REPL
+
+`blazedb` is how you read and edit an existing `.blazedb` file without writing any code. Point it at a database and you get a prompt against the live engine.
+
+```bash
+swift build --product blazedb
+.build/debug/blazedb --help
+
+.build/debug/blazedb                      # scan for databases, pick one, open a REPL
+.build/debug/blazedb ./mydb.blazedb        # or open one directly
+.build/debug/blazedb ./mydb.blazedb <pass> # same, skipping the password prompt
+```
+
+From the prompt you can inspect, query, and modify records directly:
+
+```text
+> inspect                        # db info plus a table preview
+> schema                         # inferred fields and types, indexes
+> fetchAll                       # every record as a table
+> fetchAll --json                # or --ndjson / --raw to export
+> query age > 60                 # ops: = != > < >= <= contains
+> query age > 60 sort age desc limit 10
+> explain query age > 60         # execution plan and estimate
+> fetch <uuid>                   # inspector view for one record
+> insert {"title": "Hello"}      # also update <uuid>, delete, softDelete
+> begin / commit / rollback      # transactions
+> doctor                         # operator health checks
+> status                         # runtime health and performance
+> help                           # full command list
+```
+
+Manager mode (`blazedb --manager`) mounts several databases at once and switches between them with `list`, `mount`, `use`, and `current`. Full reference: [blazedb CLI docs](Docs/Tools/BLAZESHELL_DOCUMENTATION.md)
+
+The REPL is a local client against a file on disk, not a network server.
+
+The interactive picker (`blazedb` with no arguments) enters raw terminal mode, so it needs a real TTY and will fail in an IDE console with `tcgetattr failed`. Opening a path directly does not, which means you can also script it:
+
+```bash
+printf 'query age > 60 --json\nexit\n' | .build/debug/blazedb ./mydb.blazedb <pass>
+```
 
 ## Navigate the repo
 
@@ -171,7 +206,9 @@ Authority for tiers: [Compatibility](Docs/COMPATIBILITY.md) · [android-status.m
 
 ## Tools and native embedding
 
-The `blazedb` CLI and REPL ship with the package for local inspection. See [Run it from a clone](#run-it-from-a-clone) above for how to build and start it.
+The `blazedb` CLI and REPL ship with the package. They read and edit real databases against the same engine your app uses, so they are the fastest way to see what is actually in a file. See [Open your own database in the REPL](#open-your-own-database-in-the-repl) above.
+
+`BlazeDoctor`, `BlazeDump`, and `BlazeInfo` are separate shipped executables for health checks, export and restore, and a quick snapshot. Each requires arguments; pass `--help` for the shape.
 
 `BlazeDBC` exposes a documented byte-oriented C ABI (`BlazeDBC/include/blazedb.h`), so any language that can call C is able to embed the same engine. That is interoperability capability, not an official SDK per language. No Go, Rust, or Python SDKs are published.
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,61 @@ Longer walkthrough: [HOW_TO_USE_BLAZEDB.md](Docs/GettingStarted/HOW_TO_USE_BLAZE
 
 ---
 
+## Run it from a clone
+
+```bash
+swift run HelloBlazeDB          # smallest working example
+swift run ReadmeSamples         # every snippet in this README, verified
+
+swift build --product blazedb   # the CLI
+.build/debug/blazedb --help
+.build/debug/blazedb            # interactive picker and REPL, not a network server
+```
+
+The interactive REPL needs a real terminal. Run it from a shell, not from an IDE console.
+
+## Navigate the repo
+
+`./dev help` is the front door for every contributor command, so you do not have to read the tree to find things.
+
+```bash
+./dev help                # all contributor and benchmark commands
+./dev tiers               # test tiers and which script runs each
+./dev tests BPlusTree     # find tests by name
+./dev experiments         # list repository experiments
+```
+
+## Run the tests
+
+Locally, by tier. Tier 0 is the fast loop; Tier 1 is the PR gate.
+
+```bash
+./dev tier0               # fast local correctness
+./dev tier1               # PR correctness gate
+./dev tier2               # integration and recovery
+./dev tier3               # stress and destructive
+./dev test BPlusTreeNodeTests.createsSimpleTree   # one focused test
+```
+
+To reproduce CI exactly, these are the commands the `PR Gate` workflow runs in its macOS job, in order:
+
+```bash
+swift build --target BlazeDBCore
+./Scripts/check-sendable-observation.sh
+swift build --product blazedb
+BLAZEDB_TEST_SCOPE=tier0 swift test --filter BlazeDB_Tier0
+swift test --skip-build --filter BlazeDB_Tier1
+swift test --skip-build --filter BlazeDB_CLITests
+./Scripts/verify-readme-quickstart.sh
+./Scripts/verify-readme-samples.sh
+```
+
+The Linux job builds `BlazeDBCore` and the CLI tools, then runs the same Tier 0 filter. Apple platforms beyond macOS are cross-compiled only.
+
+Tier definitions, what belongs in each, and the full lane map: [TESTING_GUIDE.md](Docs/TESTING_GUIDE.md) · [XCODE_SCHEMES.md](Docs/Build/XCODE_SCHEMES.md)
+
+---
+
 ## Guarantees
 
 - Public database-opening APIs require a password; stored pages use AES-256-GCM ([key management](Docs/Status/KEY_MANAGEMENT_AND_COMPATIBILITY.md))
@@ -116,13 +171,7 @@ Authority for tiers: [Compatibility](Docs/COMPATIBILITY.md) · [android-status.m
 
 ## Tools and native embedding
 
-The `blazedb` CLI and REPL ship with the package for local inspection:
-
-```bash
-swift build --product blazedb
-.build/debug/blazedb --help
-.build/debug/blazedb          # interactive picker / REPL (not a network server)
-```
+The `blazedb` CLI and REPL ship with the package for local inspection. See [Run it from a clone](#run-it-from-a-clone) above for how to build and start it.
 
 `BlazeDBC` exposes a documented byte-oriented C ABI (`BlazeDBC/include/blazedb.h`), so any language that can call C is able to embed the same engine. That is interoperability capability, not an official SDK per language. No Go, Rust, or Python SDKs are published.
 

--- a/README.md
+++ b/README.md
@@ -198,7 +198,23 @@ Direction, not release guarantees: [ROADMAP.md](ROADMAP.md)
 | **Declared and compile-tested** | iOS, watchOS, tvOS, visionOS |
 | **experimental** | Android cross-compile + KMM sample runtime in the PR gate (not a published SDK) |
 
-Android is **experimental**: the PR gate cross-compiles the bridge and runs a KMM emulator smoke. It is not **shipped** as a consumer SDK (no `Package.swift` platform entry, no published registry artifacts) and not equivalent to Linux host Tier0.
+### Android and KMM (experimental)
+
+Android is reached through a Swift bridge plus a Kotlin Multiplatform module, not a published SDK.
+
+- **`BlazeDBAndroidBridge`** wraps `BlazeDBCore` and builds as `libBlazeDBAndroidBridge.so`. Two products expose it: `BlazeDBAndroidBridge` (dynamic) and `BlazeDBKMMBridgeStatic` (static). Sources in [Examples/BlazeDBAndroidBridge](Examples/BlazeDBAndroidBridge/).
+- **The KMM module** in [Examples/android](Examples/android/) links that bridge. `shared/src/androidMain` calls into Swift over JNI through a C shim (`System.loadLibrary("blazedb_android_bridge")`); `iosMain` uses cinterop instead.
+- Cross-compiled for `aarch64-unknown-linux-android28` and `x86_64-unknown-linux-android28`.
+
+Three jobs in the `PR Gate` workflow cover it (names shortened here; the workflow separates the prefix with a dash):
+
+| Job | What it proves |
+|-----|----------------|
+| Android Cross-Compile | builds the bridge, then asserts `libBlazeDBAndroidBridge.so` exists for both triples |
+| KMM Android x86_64 Emulator Runtime | boots an API 34 x86_64 emulator with KVM and runs `:app:connectedDebugAndroidTest`, a real on-device instrumentation test |
+| KMM Android arm64 Artifact Packaging | stages `arm64-v8a` native libs and packages the artifact |
+
+It stays **experimental** because there is no `Package.swift` platform entry and no published registry artifacts, so it is not a consumer SDK and not equivalent to Linux host Tier0.
 
 Authority for tiers: [Compatibility](Docs/COMPATIBILITY.md) · [android-status.md](Docs/android-status.md)
 


### PR DESCRIPTION
Documentation only. Five commits, each independently revertable.

**Repository mass is not product maturity.** The README had become a landing page, compatibility matrix, product manual, architecture index, tool catalog, and project audit at once, and a lot of that volume was doing defensive credibility work. This reorders it for onboarding and moves the reference material behind links.

361 to      281 lines, a 22 percent reduction. The trim was larger before commits 3 to 5 added the missing run, test, REPL, and Android detail back in a smaller form.

## 1. Trim and reposition

New order: what it is, a runnable example, is it the right choice, installation, run and test, guarantees, platforms, then links out.

- Added an **Is BlazeDB the right choice** table against SQLite and GRDB. It sits *after* the first code example on purpose: developers want to see whether the API is sane before reading a product-category argument.
- Promoted the negative case into **Do not use BlazeDB when you need**, near the top rather than buried two thirds down.
- **Removed the Repository scale section.** Every figure already exists in exact generated form in `Docs/Meta/REPOSITORY_METRICS.md` section 2, so the README was restating numbers that were canonical elsewhere. Project status links there now.
- Folded six tables (`Choose your path`, `Core API overview`, CLI status, architecture map, examples-by-status, and the four-part documentation map) into one Documentation table plus a compact tools section. Detail stays in `Docs/Tools`, `Examples/README`, `Docs/Architecture`, and the docs index.
- Renamed `Guarantees and boundaries` to `Guarantees` and dropped a restated "not a networked database server" sentence the new section already covers.

Kept deliberately: the shipped / beta / experimental / in-tree, not packaged / deferred status vocabulary, the full Android experimental caveat, single-process ownership, the network filesystem warning, and the note that the C ABI is interoperability capability rather than a per-language SDK.

`Docs/Meta/README.md` linked to `README.md#repository-scale`, which this removes; it now names `REPOSITORY_METRICS.md` as the canonical home. The `start-here-new-users` and `try-blazedb-from-this-repo` anchors are untouched, since other docs have 4 and 3 inbound links to them.

## 2. Restructure the SQLite comparison

The README now routes readers to `WHY_NOT_SQLITE.md`, so that page carries more weight. It said the same thing three times (`Short answer`, two "when is X a good fit" lists, and `Recommendation`, whose SQLite paragraph was a verbatim duplicate), buried its most credible sentence at line 124, and mixed maintainer directives into user-facing prose.

- Promoted **Where SQLite wins** to just after the short answer, with methodology links. SQLite wins raw insert throughput and cold-open latency; a reader following a link that promises to say so should not hunt for it.
- Replaced the two parallel bullet lists with a nine-axis side-by-side table.
- Deleted `Recommendation` as a duplicate.
- Consolidated every "do not claim X" directive into one labeled maintainer note at the end.
- Fixed a malformed one-row, empty-header table. Normalized 30 typographic quotes.

I grepped for twelve specific factual claims afterward rather than assuming they survived, and two had vanished: multi-process writers unsupported, and network filesystems not recommended. Both restored. `ARCHITECTURE_DETAILED.md` names this page as the authority for that wording.

## 3. Add run, navigate, and test sections

The trim removed navigation without replacing it. A contributor could install BlazeDB but not find how to run it, discover repo commands, or run the tests the way CI does.

- **Run it from a clone**: example runner, sample verifier, building and starting the CLI, plus the note that the interactive REPL needs a real terminal and will not start in an IDE console.
- **Navigate the repo**: `./dev help` as the single front door, with tiers, test search, and experiments.
- **Run the tests**: the four `./dev tier` commands and the focused single-test form, then the exact sequence the PR Gate macOS job runs, in order, so CI is reproducible locally instead of guessed at.

Every command was executed before being documented.

Also corrected `Docs/Tools/README.md`, whose tools map listed `swift run BlazeDoctor` and friends bare. That is not a working invocation: all three require arguments and exit 1 with a usage message. Table now shows the argument shape, with a note that their Xcode Run schemes need arguments set. The per-tool docs were already correct.

## 4. Make the REPL discoverable

The README mentioned an "interactive picker and REPL" for "local inspection" and stopped there. Nothing said the most useful thing: that this is how you open an existing `.blazedb` file and read or edit it without writing code. Someone with a database on disk had no signal that a tool for looking inside it ships in the box.

Adds **Open your own database in the REPL**: the three ways in, a command sample, and a pointer to the full reference.

The sample is taken from the live REPL rather than from the docs. Every command shown was run against a real database first: `inspect`, `schema`, `fetchAll` with its `--json` / `--ndjson` / `--raw` variants, `query` with its operator set and sort/limit/offset modifiers, `explain query`, `fetch` by uuid or row index, `insert`, `update`, `softDelete`, `delete`, `begin` / `commit` / `rollback`, `doctor`, and `status`.

**Corrects a claim from commit 3.** That said the REPL needs a real terminal. Only the picker does: it enters raw mode and fails in an IDE console with `tcgetattr failed`, while opening a path directly works with piped stdin. The README now distinguishes them and shows the scripted form, which makes the shell usable for one-off exports rather than only for sitting at a prompt.

Also stops the Tools section calling the CLI an inspection aid. It reads and writes real databases against the same engine the library uses.

## 5. Restore Android and KMM detail

The trim cut Android to one table row and a caveat sentence. That undersold it and made it unverifiable: a reader could not tell what "Android cross-compile plus KMM sample runtime" consists of, or that three CI jobs prove it every PR.

Adds a brief subsection naming the moving parts. Every claim was checked against source first:

- `BlazeDBAndroidBridge` wraps `BlazeDBCore`, builds as `libBlazeDBAndroidBridge.so`, and ships as two products, dynamic and `BlazeDBKMMBridgeStatic`.
- The KMM module in `Examples/android` links it. `androidMain` reaches Swift over JNI through a C shim (`System.loadLibrary("blazedb_android_bridge")`), `iosMain` uses cinterop, and `shared/build.gradle.kts` links `-lBlazeDBAndroidBridge` with a cinterop def file.
- Cross-compiled for `aarch64-unknown-linux-android28` and `x86_64-unknown-linux-android28`, both asserted present by CI.
- Three `PR Gate` jobs: cross-compile then verify the `.so` for both triples; enable KVM, boot an API 34 x86_64 emulator and run `:app:connectedDebugAndroidTest`, which is a real on-device instrumentation test rather than a build check; stage `arm64-v8a` and package.

The experimental label is unchanged but now has a stated reason instead of being a bare word: no `Package.swift` platform entry and no published registry artifacts. Confirmed that the platforms list contains only macOS, iOS, watchOS, tvOS, and visionOS, with android appearing solely in build conditionals.

CI job names are shortened in the table because the real ones contain em dashes, which this README does not use, and a note says so.

## Verification

| Check | Result |
|-------|--------|
| Size | 361 to      281 lines (22 percent) |
| README verifiers | `verify-readme-quickstart.sh` and `verify-readme-samples.sh` both pass |
| Relative links | all resolve in both files |
| Structure | 22 fences balanced, no duplicate headings, all tables column-consistent |
| `git diff --check` | clean |
| markdownlint | 76 to 56 violations, no new categories, MD001 on `main` fixed |

No markdownlint config exists in the repo, so those are unenforced defaults. The remainder is long-standing line-length and table-pipe-spacing style plus 2 intentional inline-HTML hits from the preserved anchors.

Branched from `main` and kept separate from #440 so that PR stays focused on the `run-core-tests.sh` exit-status fix.
