### PR TITLE
docs: clarify key derivation vocabulary (PBKDF2, not Argon2id)

### DIFF
--- a/Docs/README.md
+++ b/Docs/README.md
@@ -47,7 +47,7 @@ Use these first for current behavior:
 | [Security architecture](Security/README.md) | Encryption, keys, and threat-model docs |
 | [Security policy](../SECURITY.md) | Vulnerability reporting and disclosure |
 | [Durability Mode Support](Status/DURABILITY_MODE_SUPPORT.md) | WAL, durability modes, and recovery behavior (includes default-path guarantees) |
-| [Key Management](Status/KEY_MANAGEMENT_AND_COMPATIBILITY.md) | Password and key behavior |
+| [Key Management](Status/KEY_MANAGEMENT_AND_COMPATIBILITY.md) | Password vs salt vs PBKDF2 vs AES; Argon2 naming caveat |
 | [Performance](Performance/README.md) | Tuning and performance concepts |
 | [Benchmarks](Benchmarks/README.md) | Executable workloads, methodology, and results |
 | [Tools](Tools/README.md) | CLI and companion tools |

--- a/Docs/Status/KEY_MANAGEMENT_AND_COMPATIBILITY.md
+++ b/Docs/Status/KEY_MANAGEMENT_AND_COMPATIBILITY.md
@@ -1,16 +1,114 @@
 # Key Management and Compatibility Modes
 
-This note defines supported key-management behavior for OSS users and explicitly flags unsafe compatibility paths.
+This note defines supported key-management behavior for OSS users, separates the different “key” concepts that often get mashed together, and flags unsafe compatibility paths.
+
+## One-sentence product claim (2.8.1)
+
+BlazeDB derives its **normal database encryption key** from a **password** and a **per-database salt** using **PBKDF2-HMAC-SHA256** (600,000 iterations in release), then uses that **256-bit symmetric key** with **AES-256-GCM** for page encryption.
+
+**PBKDF2 is not the encryption algorithm. AES-GCM is.** PBKDF2 is how a human password becomes a suitable AES key.
+
+---
+
+## Vocabulary: do not mash these together
+
+Cryptography reuses the word “key” for several jobs. In BlazeDB they are distinct:
+
+| Concept | What it is | Secret? |
+|---------|------------|---------|
+| **Password** | Human input | Yes (user secret) — **not** an encryption key |
+| **Salt** | Random per-database bytes (`.salt` sidecar) | **No** — readable on disk is normal |
+| **KDF output / derived key** | 32 bytes from password + salt via PBKDF2 | Yes |
+| **AES key** | That same material as CryptoKit `SymmetricKey` | Yes — used for page seal/open |
+| **`Argon2KDF` output** | Another 32-byte derivation path | Yes — **proprietary, not Argon2id**; not the default open KDF |
+| **Secure Enclave key** | Apple hardware/keychain-backed material | Platform-specific — usually **protects or unlocks** secrets; not “the AES page key” by itself |
+
+### Normal open path
+
+```text
+password
+   +
+per-DB salt
+   ↓
+PBKDF2-HMAC-SHA256  (600,000 iterations in release)
+   ↓
+32 bytes
+   ↓
+SymmetricKey
+   ↓
+AES-256-GCM
+   ↓
+encrypted database pages
+```
+
+Code path: `BlazeDBClient.resolveEncryptionKey` → `KeyManager.getKey(from:salt:)` → `deriveKeyPBKDF2` → page crypto in `PageStore`.
+
+Warm reopen in the same process may reuse a verified session key and skip the 600k stretch (see [DATABASE_SESSION_KEY_LIFECYCLE.md](../Security/DATABASE_SESSION_KEY_LIFECYCLE.md)).
+
+### Why PBKDF2 exists
+
+A password like `hunter2-but-for-databases` is unsuitable as an AES key directly. Humans choose low-entropy strings. AES wants a uniformly distributed 256-bit key.
+
+PBKDF2 repeatedly runs HMAC-SHA256 so guessing passwords is computationally expensive:
+
+```text
+PBKDF2(password, salt, 600_000) → 256 bits → AES key material
+```
+
+`SymmetricKey(data:)` is the Swift/CryptoKit wrapper around those bytes — not a second cryptographic key.
+
+### What the salt changes
+
+Same password on two databases **must** yield different keys:
+
+```text
+password123 + salt_A → key_A
+password123 + salt_B → key_B
+```
+
+Without a salt, the same password would always produce the same key across databases. Stealing one derived key must not unlock every DB that shared a password. The `.salt` file being readable is expected: salt is not a secret.
+
+### Where `Argon2KDF` differs
+
+Both **PBKDF2** and **real Argon2id** are password-based KDFs. Real Argon2id also forces substantial **memory** cost to raise the price of GPU/ASIC cracking.
+
+BlazeDB’s type named `Argon2KDF` is **not** RFC Argon2id. The file itself says it is Argon2-inspired / proprietary. Conceptually it is a **custom memory-buffer + HMAC/SHA256 construction**, not the Argon2 algorithm. Algorithms are defined constructions, not genres.
+
+| Path | Uses this KDF? |
+|------|----------------|
+| Default DB open (`KeyManager.getKey`) | **No** — PBKDF2 @ 600k |
+| `KeyManager.getKeyArgon2` | Defined; not the production open default |
+| CLI master keyring / layout signature auto-detect | May invoke `Argon2KDF` for **compatibility** |
+
+**Do not market or document BlazeDB as “Argon2id.”** Renaming/freezing the proprietary construction without silently changing bytes is tracked as [#316](https://github.com/Mikedan37/BlazeDB/issues/316). Swapping in real Argon2id under the same name would change keys and make existing material unreadable.
+
+### Secure Enclave is a separate axis
+
+- **PBKDF2 / custom KDF** answer: *How do I turn password material into key bytes?*
+- **AES-GCM** answers: *How do I encrypt pages with that key?*
+- **Secure Enclave / Keychain** answers: *Where can sensitive material or operations be protected on Apple hardware?*
+
+They are not competing “encryption types.” Enclave support is optional and platform-gated (`KeySource.secureEnclave`), not the default password-open story on every OS.
+
+---
 
 ## Supported Key Management Modes
 
 BlazeDB supports:
 
-- password-derived keys via PBKDF2-SHA256 with per-database `.salt`,
-- compatibility key-derivation attempts for legacy material where applicable,
+- password-derived keys via **PBKDF2-HMAC-SHA256** with per-database `.salt` (**production default**),
+- compatibility key-derivation attempts for legacy material where applicable (including alternate KDF tries),
 - optional Secure Enclave integration where platform support exists.
 
 Operational default is password-derived keys unless the application configures a different key source.
+
+Iteration policy (approx.):
+
+| Environment | PBKDF2 iterations |
+|-------------|-------------------|
+| Release / normal | **600,000** |
+| XCTest (default) | 100,000 |
+| Override | `BLAZEDB_PBKDF2_ITERATIONS` |
 
 ## Compatibility Fallbacks (Use With Care)
 
@@ -18,7 +116,7 @@ The following are compatibility paths for legacy data and migrations:
 
 - `allowUnsignedLayoutFallback` in secure layout loading,
 - legacy metadata/layout normalization decode paths,
-- alternate KDF verification attempts when signature verification fails.
+- alternate KDF verification attempts when signature verification fails (may try proprietary `Argon2KDF` then PBKDF2 variants).
 
 These paths are intended for controlled migration and recovery scenarios, not steady-state production operation.
 
@@ -35,3 +133,10 @@ This flag must never be enabled for production data.
 3. Validate and re-save metadata in current secure format after migration.
 4. Track KDF/crypto policy changes in `CHANGELOG.md`.
 5. Before changing open latency or key caching, read [DATABASE_SESSION_KEY_LIFECYCLE.md](../Security/DATABASE_SESSION_KEY_LIFECYCLE.md).
+6. When answering “what encryption does BlazeDB use?”, state **AES-256-GCM for pages** and **PBKDF2 for password→key** separately; do not claim Argon2id until a real Argon2 library is adopted and migrated under [#316](https://github.com/Mikedan37/BlazeDB/issues/316).
+
+## Related
+
+- Open tour: [Architecture/TOURS/01_OPEN_AND_RECOVERY.md](../Architecture/TOURS/01_OPEN_AND_RECOVERY.md)
+- Session warm vs cold: [DATABASE_SESSION_KEY_LIFECYCLE.md](../Security/DATABASE_SESSION_KEY_LIFECYCLE.md)
+- Implementation: `BlazeDB/Crypto/KeyManager.swift`, `BlazeDB/Crypto/Argon2KDF.swift`, `BlazeDB/Storage/PageStore.swift`

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Tier definitions, what belongs in each, and the full lane map: [TESTING_GUIDE.md
 
 ## Guarantees
 
-- Public database-opening APIs require a password; stored pages use AES-256-GCM ([key management](Docs/Status/KEY_MANAGEMENT_AND_COMPATIBILITY.md))
+- Public database-opening APIs require a password; keys are derived with PBKDF2-HMAC-SHA256 and pages use AES-256-GCM ([key management](Docs/Status/KEY_MANAGEMENT_AND_COMPATIBILITY.md) — not Argon2id)
 - Default storage path uses WAL-backed recovery ([documented durability behavior and overflow caveats](Docs/Status/DURABILITY_MODE_SUPPORT.md))
 - Typed document APIs and raw key-value access ([API reference](Docs/API/API_REFERENCE.md))
 - Transactional write APIs ([transactions](Docs/DEVELOPER_GUIDE.md#transactions)) and in-process live queries ([architecture](Docs/Architecture/LIVE_QUERY_ARCHITECTURE.md))


### PR DESCRIPTION
**Quick rules:** [CONTRIBUTING.md — PR expectations](../CONTRIBUTING.md#pr-expectations) (one branch, `preflight`, list commands, docs with behavior, squash merge).

## Summary

- Expand `Docs/Status/KEY_MANAGEMENT_AND_COMPATIBILITY.md` into the canonical plain-English model of password vs salt vs PBKDF2-derived AES key vs proprietary `Argon2KDF` vs Secure Enclave, with the 2.8.1 production open path called out explicitly.
- Tighten README Guarantees and the Docs index blurb so we do not imply Argon2id; production open remains PBKDF2-HMAC-SHA256 (600k) + AES-256-GCM.
- Needed because “key” and leftover Argon2 naming in the tree were getting mashed together in public-facing claims.

## Scope

- In scope:
  - `Docs/Status/KEY_MANAGEMENT_AND_COMPATIBILITY.md`
  - `README.md` Guarantees bullet
  - `Docs/README.md` index line for Key Management
- Out of scope:
  - Renaming or changing `Argon2KDF` bytes (tracked in #316)
  - Code/crypto behavior changes
  - Rewriting older architecture docs that still say Argon2id

## Validation

List **exact** commands you ran (copy-paste from your terminal):

```bash
# Docs-only; spot-checked claims against implementation:
# - BlazeDB/Crypto/KeyManager.swift (PBKDF2 @ 600k)
# - BlazeDB/Crypto/Argon2KDF.swift (NOT Argon2id header)
# - BlazeDBClient.resolveEncryptionKey → getKey(from:salt:)
rg -n 'Argon2|PBKDF2|600_000|resolveEncryptionKey' BlazeDB/Crypto BlazeDB/Exports/BlazeDBClient.swift Docs/Status/KEY_MANAGEMENT_AND_COMPATIBILITY.md README.md
```

## Checklist

- [x] One branch = one concern
- [x] `git status` / `git diff` reviewed for containment
- [x] Docs updated in this PR if behavior or public usage changed
- [ ] `Docs/SYSTEM_MAP.md` / `Docs/Testing/CI_AND_TEST_TIERS.md` updated **only if** this PR changes material surface, architecture, or CI/tier semantics (see PR expectations)
- [ ] Storage/WAL/encryption/recovery changes: followed [Docs/Contributing/STORAGE_CHANGE_CHECKLIST.md](../Docs/Contributing/STORAGE_CHANGE_CHECKLIST.md)
- [ ] CI checks pass

Closes nothing (docs honesty). Related: #316.