### PR TITLE
docs: link Graph Query API from README indexes

### DIFF
--- a/Docs/API/GRAPH_QUERY_API.md
+++ b/Docs/API/GRAPH_QUERY_API.md
@@ -85,7 +85,11 @@ let monthlyRevenue = try db.graph()
 
 ## Moving Windows
 
-Moving windows are useful for smoothing data and calculating trends:
+Moving windows are useful for smoothing data and calculating trends.
+
+`movingAverage` / `movingSum` run over points ordered by **ascending X** (category order or chronological date bins). That neighbour set is fixed before any presentation sort: `.sorted(ascending: false)` only reverses the finished points; it does not change which values each window aggregates ([#377](https://github.com/Mikedan37/BlazeDB/issues/377), [#445](https://github.com/Mikedan37/BlazeDB/pull/445)).
+
+Leading-edge windows are partial (fewer than `windowSize` samples) until enough X-ordered points exist.
 
 ### Moving Average
 
@@ -133,15 +137,17 @@ let points = try db.graph()
 
 ## Sorting
 
-Graph queries are automatically sorted by X-axis in ascending order. You can customize this:
+Returned points are presented in ascending X order by default. You can reverse presentation with `.sorted(ascending: false)`:
 
 ```swift
 let points = try db.graph()
 .x("category")
 .y(.count)
-.sorted(ascending: false) // Descending order
+.sorted(ascending: false) // Descending presentation
 .toPoints()
 ```
+
+When a moving window is also requested, BlazeDB still computes the window on the ascending-X series first, then applies this presentation order.
 
 ## Type-Safe Access
 

--- a/Docs/API/README.md
+++ b/Docs/API/README.md
@@ -8,5 +8,6 @@ Start with the default shipped core story first:
 Canonical API references:
 
 - [API_REFERENCE.md](API_REFERENCE.md) - primary API reference (includes advanced and conditional surfaces)
+- [GRAPH_QUERY_API.md](GRAPH_QUERY_API.md) - advanced charting helper (`db.graph()…toPoints()`); not required for core CRUD
 - [COMPLETE_PROJECT_DOCUMENTATION.md](COMPLETE_PROJECT_DOCUMENTATION.md) - broad catalog; not all sections represent default OSS runtime behavior
 

--- a/Docs/README.md
+++ b/Docs/README.md
@@ -70,6 +70,7 @@ Still public and usable; not the first day of reading:
 | Schema validation APIs | Advanced and supported | [API Reference](API/API_REFERENCE.md) · `SchemaValidation` in source | Dedicated guide under consolidation |
 | Indexing and search tuning | Advanced and supported | [Developer Guide](DEVELOPER_GUIDE.md) · [Performance](Performance/README.md) | Maintained entry points |
 | Manual mapping (`BlazeDocument`) | Advanced and supported | [Developer Guide](DEVELOPER_GUIDE.md) · [API Reference](API/API_REFERENCE.md) | Maintained entry points |
+| Graph / chart datapoints | Advanced and supported | [Graph Query API](API/GRAPH_QUERY_API.md) · `db.graph()` | Chart-ready XY points; optional for CRUD apps |
 
 SQLite/Core Data migrator write-ups and older Status migration notes may still exist. Treat them as historical or incomplete unless a maintained doc above links to them. Do not treat folder presence as a promise of a finished migration product experience.
 

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ Start with the [documentation index](Docs/README.md), which carries support stat
 | Area | Entry point |
 |------|-------------|
 | Get started | [Getting Started](Docs/GettingStarted/README.md) · [HOW_TO_USE_BLAZEDB.md](Docs/GettingStarted/HOW_TO_USE_BLAZEDB.md) · [Linux](Docs/GettingStarted/LINUX_GETTING_STARTED.md) |
-| API and queries | [API Reference](Docs/API/API_REFERENCE.md) · [Developer Guide](Docs/DEVELOPER_GUIDE.md) |
+| API and queries | [API Reference](Docs/API/API_REFERENCE.md) · [Developer Guide](Docs/DEVELOPER_GUIDE.md) · [Graph Query](Docs/API/GRAPH_QUERY_API.md) (advanced charting) |
 | Engine internals | [Architecture](Docs/Architecture/README.md) · [Codebase map](Docs/Architecture/CODEBASE_MAP.md) |
 | Encryption and keys | [Key management](Docs/Status/KEY_MANAGEMENT_AND_COMPATIBILITY.md) · [Security architecture](Docs/Security/README.md) |
 | Durability and recovery | [Durability Mode Support](Docs/Status/DURABILITY_MODE_SUPPORT.md) |


### PR DESCRIPTION
## Summary
- Link existing `Docs/API/GRAPH_QUERY_API.md` from root README, `Docs/README.md` (Advanced), and `Docs/API/README.md` so the chart datapoints API is discoverable without promoting it as core CRUD.
- Clarify moving-window semantics: aggregate ascending-X neighbours first; presentation sort only reorders finished points ([#377](https://github.com/Mikedan37/BlazeDB/issues/377) / [#445](https://github.com/Mikedan37/BlazeDB/pull/445)).

## Notes for reviewers
- **Separate from [#445](https://github.com/Mikedan37/BlazeDB/pull/445)** — keep reviewing that PR on its own; this is docs-only discoverability.
- Window-order wording describes the correct contract; land #445 for the code fix if it is not already merged.

## Test plan
- [ ] Spot-check links from README → Graph Query guide
- [ ] Confirm Advanced table in Docs/README frames it as optional charting helper