### PR TITLE
Scope query cache keys to database instances

### DIFF
--- a/BlazeDB/Query/QueryBuilder.swift
+++ b/BlazeDB/Query/QueryBuilder.swift
@@ -739,6 +739,11 @@ public final class QueryBuilder: @unchecked Sendable {
     internal func generateCacheKey() -> String {
         var key = "q"
 
+        // QueryCache.shared is process-global, so isolate results by collection instance.
+        if let collection {
+            key += "_c\(collection.instanceID.uuidString)"
+        }
+
         // Include filters with their full descriptors (field, operation, value hash)
         if !filterDescriptors.isEmpty {
             var hasher = Hasher()
@@ -1223,4 +1228,3 @@ extension QueryBuilder {
         return try result.records
     }
 }
-

--- a/BlazeDBTests/Tier0Core/CoreCorrectness/QueryCacheDatabaseIsolationTests.swift
+++ b/BlazeDBTests/Tier0Core/CoreCorrectness/QueryCacheDatabaseIsolationTests.swift
@@ -1,0 +1,125 @@
+import Foundation
+import XCTest
+@testable import BlazeDBCore
+
+final class QueryCacheDatabaseIsolationTests: XCTestCase {
+    private var databaseURLs: [URL] = []
+
+    override func setUp() {
+        super.setUp()
+        QueryCache.shared.clearAll()
+        QueryCache.shared.isEnabled = true
+
+        let testID = UUID().uuidString
+        let directory = FileManager.default.temporaryDirectory
+        databaseURLs = [
+            directory.appendingPathComponent("QueryCacheDatabaseIsolation-A-\(testID).blazedb"),
+            directory.appendingPathComponent("QueryCacheDatabaseIsolation-B-\(testID).blazedb")
+        ]
+    }
+
+    override func tearDown() {
+        QueryCache.shared.clearAll()
+        for databaseURL in databaseURLs {
+            for path in [
+                databaseURL,
+                databaseURL.deletingPathExtension().appendingPathExtension("meta"),
+                databaseURL.deletingPathExtension().appendingPathExtension("salt"),
+                databaseURL.deletingPathExtension().appendingPathExtension("wal")
+            ] {
+                try? FileManager.default.removeItem(at: path)
+            }
+        }
+        super.tearDown()
+    }
+
+    func testExecuteWithCacheIsScopedPerDatabaseInstance() throws {
+        let (databaseA, databaseB) = try openDatabases()
+        defer {
+            try? databaseA.close()
+            try? databaseB.close()
+        }
+
+        // Complete all writes before the first cached query so write invalidation cannot mask a collision.
+        try seed(databaseA, owner: "database-a", value: 101)
+        try seed(databaseB, owner: "database-b", value: 202)
+
+        let firstA = try databaseA.query()
+            .where("kind", equals: .string("shared"))
+            .execute(withCache: 60)
+        XCTAssertEqual(try firstA.records.compactMap { $0.storage["owner"]?.stringValue }, ["database-a"])
+
+        let repeatedA = try databaseA.query()
+            .where("kind", equals: .string("shared"))
+            .execute(withCache: 60)
+        XCTAssertEqual(try repeatedA.records.compactMap { $0.storage["owner"]?.stringValue }, ["database-a"])
+
+        let firstB = try databaseB.query()
+            .where("kind", equals: .string("shared"))
+            .execute(withCache: 60)
+        XCTAssertEqual(try firstB.records.compactMap { $0.storage["owner"]?.stringValue }, ["database-b"])
+
+        let repeatedB = try databaseB.query()
+            .where("kind", equals: .string("shared"))
+            .execute(withCache: 60)
+        XCTAssertEqual(try repeatedB.records.compactMap { $0.storage["owner"]?.stringValue }, ["database-b"])
+    }
+
+    func testGroupedAggregationCacheIsScopedPerDatabaseInstance() throws {
+        let (databaseA, databaseB) = try openDatabases()
+        defer {
+            try? databaseA.close()
+            try? databaseB.close()
+        }
+
+        // Complete all writes before the first cached aggregation for the same reason as above.
+        try seed(databaseA, owner: "database-a", value: 101)
+        try seed(databaseB, owner: "database-b", value: 202)
+
+        let firstA = try databaseA.query()
+            .groupBy("kind")
+            .sum("value", as: "total")
+            .executeGroupedAggregationWithCache(ttl: 60)
+        XCTAssertEqual(firstA.groups["shared"]?.sum("total") ?? 0, 101.0, accuracy: 0.001)
+
+        let repeatedA = try databaseA.query()
+            .groupBy("kind")
+            .sum("value", as: "total")
+            .executeGroupedAggregationWithCache(ttl: 60)
+        XCTAssertEqual(repeatedA.groups["shared"]?.sum("total") ?? 0, 101.0, accuracy: 0.001)
+
+        let firstB = try databaseB.query()
+            .groupBy("kind")
+            .sum("value", as: "total")
+            .executeGroupedAggregationWithCache(ttl: 60)
+        XCTAssertEqual(firstB.groups["shared"]?.sum("total") ?? 0, 202.0, accuracy: 0.001)
+
+        let repeatedB = try databaseB.query()
+            .groupBy("kind")
+            .sum("value", as: "total")
+            .executeGroupedAggregationWithCache(ttl: 60)
+        XCTAssertEqual(repeatedB.groups["shared"]?.sum("total") ?? 0, 202.0, accuracy: 0.001)
+    }
+
+    private func openDatabases() throws -> (BlazeDBClient, BlazeDBClient) {
+        let databaseA = try BlazeDBClient(
+            name: "query_cache_isolation_a",
+            fileURL: databaseURLs[0],
+            password: "QueryCacheIsolation-Test-2026!"
+        )
+        let databaseB = try BlazeDBClient(
+            name: "query_cache_isolation_b",
+            fileURL: databaseURLs[1],
+            password: "QueryCacheIsolation-Test-2026!"
+        )
+        return (databaseA, databaseB)
+    }
+
+    private func seed(_ database: BlazeDBClient, owner: String, value: Int) throws {
+        try database.insert(BlazeDataRecord([
+            "kind": .string("shared"),
+            "owner": .string(owner),
+            "value": .int(value)
+        ]))
+    }
+}

--- a/BlazeDBTests/Tier0Core/CoreCorrectness/QueryCacheDatabaseIsolationTests.swift
+++ b/BlazeDBTests/Tier0Core/CoreCorrectness/QueryCacheDatabaseIsolationTests.swift
@@ -3,123 +3,132 @@ import XCTest
 @testable import BlazeDBCore
 
 final class QueryCacheDatabaseIsolationTests: XCTestCase {
+    private let databaseName = "query_cache_isolation"
+    private let password = "QueryCacheIsolation-Test-2026!"
     private var databaseURLs: [URL] = []
 
     override func setUp() {
         super.setUp()
         QueryCache.shared.clearAll()
         QueryCache.shared.isEnabled = true
-
-        let testID = UUID().uuidString
+        let id = UUID().uuidString
         let directory = FileManager.default.temporaryDirectory
         databaseURLs = [
-            directory.appendingPathComponent("QueryCacheDatabaseIsolation-A-\(testID).blazedb"),
-            directory.appendingPathComponent("QueryCacheDatabaseIsolation-B-\(testID).blazedb")
+            directory.appendingPathComponent("QueryCacheDatabaseIsolation-A-\(id).blazedb"),
+            directory.appendingPathComponent("QueryCacheDatabaseIsolation-B-\(id).blazedb")
         ]
     }
 
     override func tearDown() {
         QueryCache.shared.clearAll()
-        for databaseURL in databaseURLs {
-            for path in [
-                databaseURL,
-                databaseURL.deletingPathExtension().appendingPathExtension("meta"),
-                databaseURL.deletingPathExtension().appendingPathExtension("salt"),
-                databaseURL.deletingPathExtension().appendingPathExtension("wal")
-            ] {
-                try? FileManager.default.removeItem(at: path)
-            }
+        for url in databaseURLs {
+            for artifact in databaseArtifacts(for: url) { try? FileManager.default.removeItem(at: artifact) }
         }
         super.tearDown()
     }
 
     func testExecuteWithCacheIsScopedPerDatabaseInstance() throws {
         let (databaseA, databaseB) = try openDatabases()
-        defer {
-            try? databaseA.close()
-            try? databaseB.close()
-        }
-
-        // Complete all writes before the first cached query so write invalidation cannot mask a collision.
+        defer { close(databaseA, databaseB) }
         try seed(databaseA, owner: "database-a", value: 101)
         try seed(databaseB, owner: "database-b", value: 202)
 
-        let firstA = try databaseA.query()
-            .where("kind", equals: .string("shared"))
-            .execute(withCache: 60)
-        XCTAssertEqual(try firstA.records.compactMap { $0.storage["owner"]?.stringValue }, ["database-a"])
+        XCTAssertEqual(try cachedOwners(databaseA), ["database-a"])
+        XCTAssertEqual(QueryCache.shared.stats().entries, 1, "First cached call must create one entry")
+        XCTAssertEqual(try cachedOwners(databaseA), ["database-a"])
+        XCTAssertEqual(QueryCache.shared.stats().entries, 1, "Identical calls must reuse one cache entry")
+        XCTAssertEqual(try cachedOwners(databaseB), ["database-b"])
+        XCTAssertEqual(QueryCache.shared.stats().entries, 2, "Distinct live databases need distinct entries")
+        XCTAssertEqual(try cachedOwners(databaseB), ["database-b"])
+        XCTAssertEqual(QueryCache.shared.stats().entries, 2, "Repeated calls in B must reuse its entry")
+    }
 
-        let repeatedA = try databaseA.query()
-            .where("kind", equals: .string("shared"))
-            .execute(withCache: 60)
-        XCTAssertEqual(try repeatedA.records.compactMap { $0.storage["owner"]?.stringValue }, ["database-a"])
+    func testDeprecatedExecuteWithCacheIsScopedPerDatabaseInstance() throws {
+        let (databaseA, databaseB) = try openDatabases()
+        defer { close(databaseA, databaseB) }
+        try seed(databaseA, owner: "database-a", value: 101)
+        try seed(databaseB, owner: "database-b", value: 202)
 
-        let firstB = try databaseB.query()
-            .where("kind", equals: .string("shared"))
-            .execute(withCache: 60)
-        XCTAssertEqual(try firstB.records.compactMap { $0.storage["owner"]?.stringValue }, ["database-b"])
-
-        let repeatedB = try databaseB.query()
-            .where("kind", equals: .string("shared"))
-            .execute(withCache: 60)
-        XCTAssertEqual(try repeatedB.records.compactMap { $0.storage["owner"]?.stringValue }, ["database-b"])
+        XCTAssertEqual(try cachedOwners(databaseA, deprecated: true), ["database-a"])
+        XCTAssertEqual(try cachedOwners(databaseB, deprecated: true), ["database-b"])
+        XCTAssertEqual(QueryCache.shared.stats().entries, 2, "Deprecated caching must isolate same-named live databases")
     }
 
     func testGroupedAggregationCacheIsScopedPerDatabaseInstance() throws {
         let (databaseA, databaseB) = try openDatabases()
-        defer {
-            try? databaseA.close()
-            try? databaseB.close()
-        }
-
-        // Complete all writes before the first cached aggregation for the same reason as above.
+        defer { close(databaseA, databaseB) }
         try seed(databaseA, owner: "database-a", value: 101)
         try seed(databaseB, owner: "database-b", value: 202)
 
-        let firstA = try databaseA.query()
-            .groupBy("kind")
-            .sum("value", as: "total")
-            .executeGroupedAggregationWithCache(ttl: 60)
-        XCTAssertEqual(firstA.groups["shared"]?.sum("total") ?? 0, 101.0, accuracy: 0.001)
+        XCTAssertEqual(try cachedTotal(databaseA), 101.0, accuracy: 0.001)
+        XCTAssertEqual(try cachedTotal(databaseA), 101.0, accuracy: 0.001)
+        XCTAssertEqual(try cachedTotal(databaseB), 202.0, accuracy: 0.001)
+        XCTAssertEqual(try cachedTotal(databaseB), 202.0, accuracy: 0.001)
+    }
 
-        let repeatedA = try databaseA.query()
-            .groupBy("kind")
-            .sum("value", as: "total")
-            .executeGroupedAggregationWithCache(ttl: 60)
-        XCTAssertEqual(repeatedA.groups["shared"]?.sum("total") ?? 0, 101.0, accuracy: 0.001)
+    func testCloseAndReopenDoesNotReuseEarlierCacheEntry() throws {
+        let (databaseA, donor) = try openDatabases()
+        defer { close(databaseA, donor) }
+        try seed(databaseA, owner: "before-close", value: 303)
+        try seed(donor, owner: "after-reopen", value: 404)
+        try seed(donor, owner: "after-reopen-extra", value: 505)
+        try donor.close()
 
-        let firstB = try databaseB.query()
-            .groupBy("kind")
-            .sum("value", as: "total")
-            .executeGroupedAggregationWithCache(ttl: 60)
-        XCTAssertEqual(firstB.groups["shared"]?.sum("total") ?? 0, 202.0, accuracy: 0.001)
+        XCTAssertEqual(try cachedOwners(databaseA), ["before-close"])
+        try databaseA.close()
+        // Replace closed files with pre-seeded contents; no post-cache database write can clear the old entry.
+        try replaceDatabase(at: databaseURLs[0], with: databaseURLs[1])
 
-        let repeatedB = try databaseB.query()
-            .groupBy("kind")
-            .sum("value", as: "total")
-            .executeGroupedAggregationWithCache(ttl: 60)
-        XCTAssertEqual(repeatedB.groups["shared"]?.sum("total") ?? 0, 202.0, accuracy: 0.001)
+        let reopened = try BlazeDBClient(name: databaseName, fileURL: databaseURLs[0], password: password)
+        defer { close(reopened) }
+        XCTAssertEqual(try cachedOwners(reopened), ["after-reopen", "after-reopen-extra"])
     }
 
     private func openDatabases() throws -> (BlazeDBClient, BlazeDBClient) {
-        let databaseA = try BlazeDBClient(
-            name: "query_cache_isolation_a",
-            fileURL: databaseURLs[0],
-            password: "QueryCacheIsolation-Test-2026!"
+        (
+            try BlazeDBClient(name: databaseName, fileURL: databaseURLs[0], password: password),
+            try BlazeDBClient(name: databaseName, fileURL: databaseURLs[1], password: password)
         )
-        let databaseB = try BlazeDBClient(
-            name: "query_cache_isolation_b",
-            fileURL: databaseURLs[1],
-            password: "QueryCacheIsolation-Test-2026!"
-        )
-        return (databaseA, databaseB)
     }
 
     private func seed(_ database: BlazeDBClient, owner: String, value: Int) throws {
         try database.insert(BlazeDataRecord([
-            "kind": .string("shared"),
-            "owner": .string(owner),
-            "value": .int(value)
+            "kind": .string("shared"), "owner": .string(owner), "value": .int(value)
         ]))
+    }
+
+    private func cachedOwners(_ database: BlazeDBClient, deprecated: Bool = false) throws -> [String] {
+        let records: [BlazeDataRecord]
+        if deprecated {
+            records = try database.query().where("kind", equals: .string("shared")).executeWithCache(ttl: 60)
+        } else {
+            records = try database.query().where("kind", equals: .string("shared")).execute(withCache: 60).records
+        }
+        return records.compactMap { $0.storage["owner"]?.stringValue }.sorted()
+    }
+
+    private func cachedTotal(_ database: BlazeDBClient) throws -> Double {
+        let result = try database.query().groupBy("kind").sum("value", as: "total")
+            .executeGroupedAggregationWithCache(ttl: 60)
+        return result.groups["shared"]?.sum("total") ?? 0
+    }
+
+    private func close(_ databases: BlazeDBClient...) {
+        for database in databases { try? database.close() }
+    }
+
+    private func databaseArtifacts(for url: URL) -> [URL] {
+        let base = url.deletingPathExtension()
+        return [url, base.appendingPathExtension("meta"), base.appendingPathExtension("salt"), base.appendingPathExtension("wal")]
+    }
+
+    private func replaceDatabase(at destination: URL, with source: URL) throws {
+        let fileManager = FileManager.default
+        let destinationArtifacts = databaseArtifacts(for: destination)
+        for artifact in destinationArtifacts { try? fileManager.removeItem(at: artifact) }
+        for (sourceArtifact, destinationArtifact) in zip(databaseArtifacts(for: source), destinationArtifacts)
+            where fileManager.fileExists(atPath: sourceArtifact.path) {
+            try fileManager.copyItem(at: sourceArtifact, to: destinationArtifact)
+        }
     }
 }


### PR DESCRIPTION
## Summary

- What changed? Query cache keys now include the collection instance identity, with Tier 0 coverage for direct, deprecated, grouped-aggregation, and close/reopen cache paths.
- Why was it needed? This prevents process-global cache entries from one database instance being served for another through the affected paths. Refs #306.

## Scope

- In scope: left-hand collection instance identity in shared query-cache keys and deterministic database-isolation regression coverage.
- Out of scope: right-hand join identity, aggregation-shape identity beyond the collection namespace, async-registry identity, and proving cache-hit consumption.

## Validation

Run on GitHub Actions against exact commit `6aee75bd6132930a21819339b3663136c19a55bc`:

```bash
./Scripts/preflight.sh
BLAZEDB_TEST_SCOPE=tier0 swift test --filter QueryCacheDatabaseIsolationTests
```

The preflight completed successfully with 240 Tier 0 cases. The focused command completed with 4 tests and 0 failures.

## Checklist

- [x] One branch = one concern
- [x] `git status` / `git diff` reviewed for containment
- [x] Docs updated in this PR if behavior or public usage changed — no public API or usage documentation changes are needed for this correctness fix
- [x] `Docs/SYSTEM_MAP.md` / `Docs/Testing/CI_AND_TEST_TIERS.md` updated **only if** this PR changes material surface, architecture, or CI/tier semantics (see PR expectations) — not applicable
- [x] Storage/WAL/encryption/recovery changes: followed [Docs/Contributing/STORAGE_CHANGE_CHECKLIST.md](../Docs/Contributing/STORAGE_CHANGE_CHECKLIST.md) — not applicable
- [x] CI checks pass

Generated by GPT-5.6 Sol (brief, review), GPT-5.6 Luna (implementation), Kimi K3 (verification)
