### PR TITLE
fix: clear record caches across database lifecycles

### DIFF
--- a/BlazeDB/Core/DynamicCollection.swift
+++ b/BlazeDB/Core/DynamicCollection.swift
@@ -2062,9 +2062,16 @@ public final class DynamicCollection {
                 }
 
                 store.close()
+                RecordCache.removeForDatabase(store.fileURL.path)
                 password = nil
                 closed = true
             }
+        }
+
+        // Synchronous vacuum closes the store while it already owns this queue.
+        // Mark the collection closed so deinit cannot evict a replacement cache.
+        internal func markClosedAfterDirectStoreClose() {
+            closed = true
         }
         
         internal func saveLayout() throws {

--- a/BlazeDB/Core/DynamicCollection.swift
+++ b/BlazeDB/Core/DynamicCollection.swift
@@ -108,6 +108,7 @@ public final class DynamicCollection {
     
     /// Per-database record cache (isolates rollback effects between databases)
     public let recordCache: RecordCache
+    private let cacheOwnerToken: RecordCache.OwnerToken  // registry ownership for recordCache
     
     /// B-tree indexes for range queries (greaterThan, lessThan, between)
     public let btreeIndexManager: BTreeIndexManager
@@ -248,7 +249,9 @@ public final class DynamicCollection {
         self.versionManager = VersionManager()  // Initialize MVCC
         
         // Per-database record cache (isolated from other databases)
-        self.recordCache = RecordCache.forDatabase(store.fileURL.path)
+        let acquiredCache = RecordCache.acquire(forDatabase: store.fileURL.path)
+        self.recordCache = acquiredCache.cache
+        self.cacheOwnerToken = acquiredCache.token
         
         // B-tree index manager for range queries
         self.btreeIndexManager = BTreeIndexManager()
@@ -623,7 +626,9 @@ public final class DynamicCollection {
             self.versionManager = VersionManager()  // Initialize MVCC
             
             // Per-database record cache (isolated from other databases)
-            self.recordCache = RecordCache.forDatabase(store.fileURL.path)
+            let acquiredCache = RecordCache.acquire(forDatabase: store.fileURL.path)
+            self.recordCache = acquiredCache.cache
+            self.cacheOwnerToken = acquiredCache.token
             
             // B-tree index manager for range queries
             self.btreeIndexManager = BTreeIndexManager()
@@ -2055,22 +2060,27 @@ public final class DynamicCollection {
             try queue.sync(flags: .barrier) {
                 guard !closed else { return }
 
+                var flushError: Error?
                 if unsavedChanges > 0, layoutSignatureVerified {
-                    try store.synchronize()
-                    try saveLayout()
-                    unsavedChanges = 0
+                    do {
+                        try store.synchronize()
+                        try saveLayout()
+                        unsavedChanges = 0
+                    } catch { flushError = error }  // release first, surface after
                 }
 
                 store.close()
-                RecordCache.removeForDatabase(store.fileURL.path)
+                RecordCache.release(forDatabase: store.fileURL.path, token: cacheOwnerToken)
                 password = nil
                 closed = true
+                if let flushError { throw flushError }
             }
         }
 
-        // Synchronous vacuum closes the store while it already owns this queue.
-        // Mark the collection closed so deinit cannot evict a replacement cache.
-        internal func markClosedAfterDirectStoreClose() {
+        // Synchronous vacuum closes the store while it already owns this queue. Release the
+        // entry we own and mark closed, so no later deinit can evict a replacement's entry.
+        internal func releaseAfterDirectStoreClose() {
+            RecordCache.release(forDatabase: store.fileURL.path, token: cacheOwnerToken)
             closed = true
         }
         

--- a/BlazeDB/Core/RecordCache.swift
+++ b/BlazeDB/Core/RecordCache.swift
@@ -29,10 +29,40 @@ public final class RecordCache: @unchecked Sendable {
     /// - Note: Prefer per-database caches via BlazeDBClient.recordCache
     public static let shared = RecordCache(name: "shared")
     
+    /// Opaque proof that one acquisition owns a path's registry entry.
+    internal struct OwnerToken: Equatable, Sendable {
+        fileprivate let value: UInt64
+    }
+    private struct Entry {
+        let cache: RecordCache
+        var owner = OwnerToken(value: 0)  // 0 is never minted: an unobserved entry is unowned
+    }
     /// Per-database cache registry (keyed by database path)
-    nonisolated(unsafe) private static var perDatabaseCaches: [String: RecordCache] = [:]
+    nonisolated(unsafe) private static var perDatabaseCaches: [String: Entry] = [:]
+    nonisolated(unsafe) private static var nextOwnerValue: UInt64 = 0  // guarded by registryLock
     private static let registryLock = NSLock()
     
+    /// Acquire `databasePath`'s cache and become its owner; ownership moves to the newest acquirer.
+    internal static func acquire(forDatabase databasePath: String) -> (cache: RecordCache, token: OwnerToken) {
+        registryLock.lock()
+        defer { registryLock.unlock() }
+        nextOwnerValue &+= 1
+        let token = OwnerToken(value: nextOwnerValue)
+        let cache = perDatabaseCaches[databasePath]?.cache ?? RecordCache(name: databasePath)
+        cache.clear()  // defence in depth: no session may inherit a previous owner's decodes
+        perDatabaseCaches[databasePath] = Entry(cache: cache, owner: token)
+        return (cache, token)
+    }
+
+    /// Release `databasePath`'s cache only while `token` owns it; a stale owner is a no-op.
+    internal static func release(forDatabase databasePath: String, token: OwnerToken) {
+        registryLock.lock()
+        defer { registryLock.unlock() }
+        guard let entry = perDatabaseCaches[databasePath], entry.owner == token else { return }
+        perDatabaseCaches.removeValue(forKey: databasePath)
+        entry.cache.clear()
+    }
+
     /// Get or create a per-database cache
     /// - Parameter databasePath: The database file path
     /// - Returns: A RecordCache instance specific to this database
@@ -41,11 +71,11 @@ public final class RecordCache: @unchecked Sendable {
         defer { registryLock.unlock() }
         
         if let existing = perDatabaseCaches[databasePath] {
-            return existing
+            return existing.cache
         }
         
         let cache = RecordCache(name: databasePath)
-        perDatabaseCaches[databasePath] = cache
+        perDatabaseCaches[databasePath] = Entry(cache: cache)
         return cache
     }
     
@@ -54,7 +84,7 @@ public final class RecordCache: @unchecked Sendable {
         registryLock.lock()
         defer { registryLock.unlock() }
         
-        if let cache = perDatabaseCaches.removeValue(forKey: databasePath) {
+        if let cache = perDatabaseCaches.removeValue(forKey: databasePath)?.cache {
             cache.clear()
         }
     }

--- a/BlazeDB/Storage/VacuumCompaction.swift
+++ b/BlazeDB/Storage/VacuumCompaction.swift
@@ -260,8 +260,7 @@ extension BlazeDBClient {
 
             // Release the live file handles before swapping files in place.
             collection.store.close()
-            RecordCache.removeForDatabase(collection.store.fileURL.path)
-            collection.markClosedAfterDirectStoreClose()
+            collection.releaseAfterDirectStoreClose()
             
             // ATOMIC: Rename old → backup (if crash here, old file still exists)
             try FileManager.default.moveItem(at: originalDataURL, to: dataBackupURL)

--- a/BlazeDB/Storage/VacuumCompaction.swift
+++ b/BlazeDB/Storage/VacuumCompaction.swift
@@ -260,6 +260,8 @@ extension BlazeDBClient {
 
             // Release the live file handles before swapping files in place.
             collection.store.close()
+            RecordCache.removeForDatabase(collection.store.fileURL.path)
+            collection.markClosedAfterDirectStoreClose()
             
             // ATOMIC: Rename old → backup (if crash here, old file still exists)
             try FileManager.default.moveItem(at: originalDataURL, to: dataBackupURL)
@@ -376,4 +378,3 @@ extension BlazeDBClient {
         }
     }
 }
-

--- a/BlazeDBTests/Tier0Core/CoreCorrectness/RecordCacheLifecycleTests.swift
+++ b/BlazeDBTests/Tier0Core/CoreCorrectness/RecordCacheLifecycleTests.swift
@@ -1,0 +1,67 @@
+//
+//  RecordCacheLifecycleTests.swift
+//  BlazeDBTests — #307: evict per-database record caches at teardown
+//
+
+import XCTest
+import Foundation
+@testable import BlazeDBCore
+
+final class RecordCacheLifecycleTests: XCTestCase {
+    private var tempDir: URL!
+
+    override func setUp() {
+        super.setUp()
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("RecordCacheLifecycle-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: tempDir)
+        super.tearDown()
+    }
+
+    /// #307: a fresh database recreated at the same path must not inherit a
+    /// decoded record cached by the previous session.
+    func testCloseAndRecreateSamePathDoesNotReturnStaleCachedPayload() throws {
+        let databaseURL = tempDir.appendingPathComponent("record-cache.blazedb")
+        let password = "RecordCacheLifecycle-Pass_123!"
+        let recordID = UUID()
+
+        let firstSession = try BlazeDBClient(
+            name: "record-cache-first",
+            fileURL: databaseURL,
+            password: password
+        )
+        try firstSession.insert(
+            BlazeDataRecord(["payload": .string("first-session")]),
+            id: recordID
+        )
+        let firstPayload = try firstSession.fetch(id: recordID)?.storage["payload"]?.stringValue
+        XCTAssertEqual(firstPayload, "first-session")
+        try firstSession.close()
+
+        let databaseBaseURL = databaseURL.deletingPathExtension()
+        for extensionName in ["blazedb", "meta", "wal", "salt", "indexes"] {
+            try? FileManager.default.removeItem(
+                at: databaseBaseURL.appendingPathExtension(extensionName)
+            )
+        }
+        XCTAssertFalse(FileManager.default.fileExists(atPath: databaseURL.path))
+
+        let secondSession = try BlazeDBClient(
+            name: "record-cache-second",
+            fileURL: databaseURL,
+            password: password
+        )
+        try secondSession.insert(
+            BlazeDataRecord(["payload": .string("second-session")]),
+            id: recordID
+        )
+        let secondPayload = try secondSession.fetch(id: recordID)?.storage["payload"]?.stringValue
+        XCTAssertEqual(secondPayload, "second-session")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: databaseURL.path))
+        try secondSession.close()
+    }
+}

--- a/BlazeDBTests/Tier0Core/CoreCorrectness/RecordCacheLifecycleTests.swift
+++ b/BlazeDBTests/Tier0Core/CoreCorrectness/RecordCacheLifecycleTests.swift
@@ -18,6 +18,8 @@ final class RecordCacheLifecycleTests: XCTestCase {
     }
 
     override func tearDown() {
+        unsetenv("BLAZEDB_SIMULATE_VACUUM_RENAME_FAILURE")
+        unsetenv("BLAZEDB_FORCE_LAYOUT_SAVE_FAILURE")
         try? FileManager.default.removeItem(at: tempDir)
         super.tearDown()
     }
@@ -63,5 +65,149 @@ final class RecordCacheLifecycleTests: XCTestCase {
         XCTAssertEqual(secondPayload, "second-session")
         XCTAssertTrue(FileManager.default.fileExists(atPath: databaseURL.path))
         try secondSession.close()
+    }
+
+    // MARK: - #307 registry-ownership coverage
+
+    private static let databasePassword = "RecordCacheLifecycle-Pass_123!"
+
+    private func makeClient(_ name: String, at url: URL) throws -> BlazeDBClient {
+        try BlazeDBClient(name: name, fileURL: url, password: Self.databasePassword)
+    }
+
+    /// `forDatabase` mints a fresh empty cache for an unowned path, so a released path
+    /// can never surface a decode made by a previous session.
+    private func assertNoRegisteredDecode(_ id: UUID, at path: String, _ message: String,
+                                          file: StaticString = #filePath, line: UInt = #line) {
+        XCTAssertNil(RecordCache.forDatabase(path).get(id: id), message, file: file, line: line)
+    }
+
+    /// Seeds `count` fillers plus one fetched record (populating the cache), then persists
+    /// so `unsavedChanges` is zero before VACUUM.
+    private func seedAndPopulateCache(_ client: BlazeDBClient, cachedID: UUID, count: Int) throws -> Int {
+        for value in 0..<count {
+            _ = try client.insert(BlazeDataRecord(["value": .int(value)]))
+        }
+        try client.insert(BlazeDataRecord(["payload": .string("pre-vacuum")]), id: cachedID)
+        XCTAssertNotNil(try client.fetch(id: cachedID), "seeding must populate the record cache")
+        try client.persist()
+        return count + 1
+    }
+
+    /// #307: teardown through `deinit` must release the registry entry exactly like an
+    /// explicit close, so a database recreated at the same path serves only its own data.
+    func testDeinitWithoutExplicitCloseDoesNotLeaveDecodedRecordsRegistered() throws {
+        let databaseURL = tempDir.appendingPathComponent("record-cache-deinit.blazedb")
+        let recordID = UUID()
+        var firstSession: BlazeDBClient? = try makeClient("record-cache-deinit-first", at: databaseURL)
+        let registryPath = try XCTUnwrap(firstSession?.collection.fileURL.path)
+        try firstSession?.insert(BlazeDataRecord(["payload": .string("first-session")]), id: recordID)
+        XCTAssertEqual(try firstSession?.fetch(id: recordID)?.storage["payload"]?.stringValue, "first-session")
+        firstSession = nil  // deterministic drop: this teardown runs through deinit only
+        assertNoRegisteredDecode(recordID, at: registryPath, "deinit must release the registry entry")
+
+        let databaseBaseURL = databaseURL.deletingPathExtension()
+        for extensionName in ["blazedb", "meta", "wal", "salt", "indexes"] {
+            try? FileManager.default.removeItem(at: databaseBaseURL.appendingPathExtension(extensionName))
+        }
+        let secondSession = try makeClient("record-cache-deinit-second", at: databaseURL)
+        try secondSession.insert(BlazeDataRecord(["payload": .string("second-session")]), id: recordID)
+        XCTAssertEqual(try secondSession.fetch(id: recordID)?.storage["payload"]?.stringValue, "second-session")
+        try secondSession.close()
+    }
+
+    /// #307: a successful VACUUM installs a replacement collection, which must own the
+    /// path's registry entry; the pre-vacuum cache is emptied on its way out.
+    func testVacuumSuccessInstallsFreshOwnedCache() throws {
+        let databaseURL = tempDir.appendingPathComponent("record-cache-vacuum-success.blazedb")
+        let seededID = UUID()
+        let client = try makeClient("record-cache-vacuum-success", at: databaseURL)
+        let seededCount = try seedAndPopulateCache(client, cachedID: seededID, count: 20)
+        let registryPath = client.collection.fileURL.path
+        let preVacuumCache = client.collection.recordCache
+        XCTAssertNotNil(preVacuumCache.get(id: seededID), "fixture must cache a decoded record")
+
+        try client.vacuum()
+        XCTAssertTrue(RecordCache.forDatabase(registryPath) === client.collection.recordCache,
+                      "the live post-vacuum collection must own the registry entry for its path")
+        XCTAssertFalse(client.collection.recordCache === preVacuumCache,
+                       "the pre-vacuum cache must not stay registered for the replacement")
+        XCTAssertNil(preVacuumCache.get(id: seededID),
+                     "a released cache must be emptied, not merely unregistered")
+        XCTAssertEqual(try client.fetchAll().count, seededCount)
+        try client.close()
+    }
+
+    /// #307: a VACUUM that fails before its replacement is constructed rolls back to a
+    /// fresh same-path collection, which must own the registry entry.
+    func testVacuumRenameFailureRollbackKeepsLiveCacheRegistered() throws {
+        let databaseURL = tempDir.appendingPathComponent("record-cache-vacuum-rename.blazedb")
+        let client = try makeClient("record-cache-vacuum-rename", at: databaseURL)
+        let seededCount = try seedAndPopulateCache(client, cachedID: UUID(), count: 20)
+        let registryPath = client.collection.fileURL.path
+        let preVacuumCache = client.collection.recordCache
+        setenv("BLAZEDB_SIMULATE_VACUUM_RENAME_FAILURE", "1", 1)
+        XCTAssertThrowsError(try client.vacuum(), "the simulated rename failure must surface")
+        unsetenv("BLAZEDB_SIMULATE_VACUUM_RENAME_FAILURE")
+        XCTAssertTrue(RecordCache.forDatabase(registryPath) === client.collection.recordCache,
+                      "the rollback replacement must own the registry entry for its path")
+        XCTAssertFalse(client.collection.recordCache === preVacuumCache,
+                       "the pre-vacuum cache must not stay registered for the rollback replacement")
+        XCTAssertEqual(try client.fetchAll().count, seededCount)
+        try client.close()
+    }
+
+    /// #307: a VACUUM that fails *after* its success replacement was constructed discards that
+    /// replacement while a rollback replacement is live on the same path; releasing the obsolete
+    /// one must not evict the live one's cache — both can hold the very same cache object.
+    func testVacuumRollbackAfterSuccessReplacementKeepsLiveCacheRegistered() throws {
+        let databaseURL = tempDir.appendingPathComponent("record-cache-vacuum-post.blazedb")
+        let client = try makeClient("record-cache-vacuum-post", at: databaseURL)
+        let seededCount = try seedAndPopulateCache(client, cachedID: UUID(), count: 20)
+        let registryPath = client.collection.fileURL.path
+        // A NON-EMPTY directory at the marker path fails the write only after the replacement exists.
+        let markerURL = client.collection.fileURL
+            .deletingPathExtension().appendingPathExtension("vacuum_success")
+        try FileManager.default.createDirectory(at: markerURL, withIntermediateDirectories: true)
+        try Data([0x01]).write(to: markerURL.appendingPathComponent("occupied"))
+        XCTAssertThrowsError(try client.vacuum(), "a post-replacement VACUUM failure must surface")
+        XCTAssertTrue(RecordCache.forDatabase(registryPath) === client.collection.recordCache,
+                      "an obsolete vacuum replacement must not evict the live rollback replacement's cache")
+        XCTAssertEqual(try client.fetchAll().count, seededCount)
+        XCTAssertFalse(client.isClosed)
+        try client.close()
+    }
+
+    /// #307: a close whose flush fails must still surface that failure AND still release
+    /// the registry entry — release is not conditional on flush success.
+    func testCloseFlushFailureStillReleasesRegisteredCache() throws {
+        let databaseURL = tempDir.appendingPathComponent("record-cache-close-flush.blazedb")
+        let recordID = UUID()
+        let client = try makeClient("record-cache-close-flush", at: databaseURL)
+        try client.insert(BlazeDataRecord(["payload": .string("first-session")]), id: recordID)
+        XCTAssertNotNil(try client.fetch(id: recordID), "fixture must cache a decoded record")
+        _ = try client.insert(BlazeDataRecord(["payload": .string("unflushed")]))
+        let registryPath = client.collection.fileURL.path
+        setenv("BLAZEDB_FORCE_LAYOUT_SAVE_FAILURE", "1", 1)
+        XCTAssertThrowsError(try client.collection.close(), "close must still surface the flush failure")
+        assertNoRegisteredDecode(recordID, at: registryPath, "a failed flush must still release the entry")
+        unsetenv("BLAZEDB_FORCE_LAYOUT_SAVE_FAILURE")
+    }
+
+    /// #307: the client keeps suppressing a flush failure and keeps marking itself closed,
+    /// but it must not do both while stranding a registry entry for the same path.
+    func testCloseFlushFailureLeavesClientClosedWithCleanRegistry() throws {
+        let databaseURL = tempDir.appendingPathComponent("record-cache-client-flush.blazedb")
+        let recordID = UUID()
+        let client = try makeClient("record-cache-client-flush", at: databaseURL)
+        try client.insert(BlazeDataRecord(["payload": .string("first-session")]), id: recordID)
+        XCTAssertNotNil(try client.fetch(id: recordID), "fixture must cache a decoded record")
+        _ = try client.insert(BlazeDataRecord(["payload": .string("unflushed")]))
+        let registryPath = client.collection.fileURL.path
+        setenv("BLAZEDB_FORCE_LAYOUT_SAVE_FAILURE", "1", 1)
+        XCTAssertNoThrow(try client.close(), "client close must keep suppressing flush failures")
+        unsetenv("BLAZEDB_FORCE_LAYOUT_SAVE_FAILURE")
+        XCTAssertTrue(client.isClosed, "client close must still mark the database closed")
+        assertNoRegisteredDecode(recordID, at: registryPath, "a closed client must not strand an entry")
     }
 }

--- a/BlazeDBTests/Tier0Core/CoreCorrectness/RecordCacheLifecycleTests.swift
+++ b/BlazeDBTests/Tier0Core/CoreCorrectness/RecordCacheLifecycleTests.swift
@@ -210,4 +210,21 @@ final class RecordCacheLifecycleTests: XCTestCase {
         XCTAssertTrue(client.isClosed, "client close must still mark the database closed")
         assertNoRegisteredDecode(recordID, at: registryPath, "a closed client must not strand an entry")
     }
+
+    /// #307: for any path P, an acquisition of P must never observe a decode written by an
+    /// earlier acquisition of P — whether or not that predecessor ever released. Transferring
+    /// ownership is not enough on its own: the successor is handed the very same cache object.
+    func testAcquireNeverInheritsAPreviousAcquisitionsDecodes() {
+        let registryPath = tempDir.appendingPathComponent("registry-property.blazedb").path
+        let recordID = UUID()
+        let predecessor = RecordCache.acquire(forDatabase: registryPath)
+        predecessor.cache.set(id: recordID, record: BlazeDataRecord(["payload": .string("previous-session")]))
+        // The predecessor deliberately never releases: a still-open handle, or an initializer
+        // that threw after acquiring, leaves its entry in place and the property must still hold.
+        let successor = RecordCache.acquire(forDatabase: registryPath)
+        XCTAssertNil(successor.cache.get(id: recordID),
+                     "a new acquisition must never inherit a previous owner's decodes")
+        RecordCache.release(forDatabase: registryPath, token: predecessor.token)
+        RecordCache.release(forDatabase: registryPath, token: successor.token)
+    }
 }


### PR DESCRIPTION
## Summary

- What changed?
  - Replace path-only record-cache teardown with owner-scoped acquisition and release, including close, deinitialization, flush-failure, reopen, and vacuum replacement paths.
  - Add Tier 0 lifecycle coverage for stale-owner release and for a new acquisition never inheriting decoded records from its predecessor. The final round changed tests only.
- Why was it needed?
  - A cache entry could outlive its database session, while an obsolete same-path owner could also remove a newer owner's entry. That allowed stale decoded records across reopen and replacement transitions.

## Scope

- In scope:
  - Per-database `RecordCache` ownership and teardown behavior.
  - Transition coverage for close, deinit, flush failure, vacuum success and rollback, and acquisition before a predecessor releases.
  - Existing public `forDatabase` and `removeForDatabase` helpers remain available to avoid an API break; teardown now uses the owner-aware internal path.
  - On-disk format and compatibility are unchanged. No WAL mode or durability default changes; the storage-adjacent change is limited to cache ownership release during close and vacuum replacement.
- Out of scope:
  - The process-global `RecordCache.shared` use in `LazyFieldRecord` remains a separate cross-database UUID risk already documented in #307. This branch partially addresses #307 and does not claim that item is fixed.
  - Tier 1 was not rerun after the preservation rebase; the exact-head storage gate exercises Tier 0.
  - #448 [Bug] PR Gate build cache breaks after fork workspace path changes

## Validation

Run on a GitHub Actions Linux runner (`ubuntu-22.04`, Swift 6.2.1) against exact commit `ea217cd010a8e069af72813a5cf86efc364075f2` in storage-checklist run `32175263735` (job `95835621673`):

```bash
./Scripts/preflight.sh
# 244 Tier 0 test invocations; durability lane passed; Tier 0 and preflight completed

./dev tier0
# 244 Tier 0 test invocations; durability lane passed; Tier 0 completed
```

Both commands completed successfully with the regression `RecordCacheLifecycleTests/testAcquireNeverInheritsAPreviousAcquisitionsDecodes` included. The targeted failure modes are stale decoded state after same-path recreation and obsolete-owner registry removal during vacuum replacement.

## Checklist

- [x] One branch = one concern
- [x] `git status` / `git diff` reviewed for containment
- [x] Docs updated in this PR if behavior or public usage changed
- [x] `Docs/SYSTEM_MAP.md` / `Docs/Testing/CI_AND_TEST_TIERS.md` updated **only if** this PR changes material surface, architecture, or CI/tier semantics (see PR expectations)
- [x] Storage/WAL/encryption/recovery changes: followed [Docs/Contributing/STORAGE_CHANGE_CHECKLIST.md](../Docs/Contributing/STORAGE_CHANGE_CHECKLIST.md)
- [x] CI checks pass

Generated by GPT-5.6 Luna (implementation, testing), Claude Opus 5 (implementation, testing, review), GPT-5.6 Sol (brief, review), Kimi K3 (implementation, verification)
