### PR TITLE
Apply shared insert validation to explicit-id and bulk inserts

### DIFF
--- a/BlazeDB/Core/UniqueConstraints.swift
+++ b/BlazeDB/Core/UniqueConstraints.swift
@@ -121,6 +121,60 @@ public class UniqueConstraintManager {
             }
         }
     }
+
+    /// Validate uniqueness against not-yet-written siblings in the same batch.
+    /// Durable uniqueness is still checked separately via `validateUnique`.
+    public func validateUniqueAgainstPending(
+        record: BlazeDataRecord,
+        pending: [BlazeDataRecord]
+    ) throws {
+        let fieldsSnapshot: Set<String>
+        let compoundSnapshot: Set<String>
+        lock.lock()
+        fieldsSnapshot = uniqueFields
+        compoundSnapshot = uniqueCompoundFields
+        lock.unlock()
+
+        let recordId = record.storage["id"]?.uuidValue
+
+        for field in fieldsSnapshot {
+            guard let value = record.storage[field] else { continue }
+            let conflict = pending.contains { pendingRecord in
+                guard pendingRecord.storage[field] == value else { return false }
+                guard let pendingId = pendingRecord.storage["id"]?.uuidValue else { return true }
+                return pendingId != recordId
+            }
+            if conflict {
+                throw BlazeDBError.uniqueConstraintViolation(
+                    field: field,
+                    value: value,
+                    message: "Duplicate value '\(value)' for unique field '\(field)' within batch"
+                )
+            }
+        }
+
+        for compoundKey in compoundSnapshot {
+            let fields = compoundKey.components(separatedBy: "+")
+            guard fields.allSatisfy({ record.storage[$0] != nil }) else { continue }
+            let values = fields.compactMap { record.storage[$0] }
+            guard values.count == fields.count else { continue }
+
+            let conflict = pending.contains { pendingRecord in
+                guard fields.allSatisfy({ pendingRecord.storage[$0] == record.storage[$0] }) else {
+                    return false
+                }
+                guard let pendingId = pendingRecord.storage["id"]?.uuidValue else { return true }
+                return pendingId != recordId
+            }
+            if conflict {
+                throw BlazeDBError.uniqueConstraintViolation(
+                    field: compoundKey,
+                    value: nil,
+                    message: "Duplicate values for unique compound fields '\(compoundKey)' within batch"
+                )
+            }
+        }
+    }
 }
 
 // MARK: - BlazeDBClient Unique Constraints Extension
@@ -159,6 +213,14 @@ extension BlazeDBClient {
     /// Validate unique constraints before insert/update
     internal func validateUniqueConstraints(in record: BlazeDataRecord, excludeId: UUID? = nil) throws {
         try uniqueConstraintManager.validateUnique(collection: collection, record: record, excludeId: excludeId)
+    }
+
+    /// Validate unique constraints against other prepared records in the same batch.
+    internal func validateUniqueConstraintsAgainstPending(
+        in record: BlazeDataRecord,
+        pending: [BlazeDataRecord]
+    ) throws {
+        try uniqueConstraintManager.validateUniqueAgainstPending(record: record, pending: pending)
     }
 }
 

--- a/BlazeDB/Exports/BlazeDBClient.swift
+++ b/BlazeDB/Exports/BlazeDBClient.swift
@@ -813,6 +813,63 @@ public final class BlazeDBClient: @unchecked Sendable {
 
     // MARK: - CRUD
 
+    /// Shared validation and before-insert transforms for all public insert entry points.
+    private func prepareRecordForInsert(
+        _ data: BlazeDataRecord,
+        explicitID: UUID? = nil
+    ) throws -> (record: BlazeDataRecord, id: UUID) {
+        var record = data
+        let id: UUID
+        if let explicitID {
+            id = explicitID
+            record.storage["id"] = .uuid(id)
+        } else if case let .uuid(existingID)? = record.storage["id"] {
+            id = existingID
+        } else if case let .string(idStr)? = record.storage["id"], let parsed = UUID(uuidString: idStr) {
+            id = parsed
+            record.storage["id"] = .uuid(parsed)
+        } else {
+            id = UUID()
+            record.storage["id"] = .uuid(id)
+        }
+
+        if record.storage["createdAt"] == nil {
+            record.storage["createdAt"] = .date(Date())
+        }
+
+        try validateAgainstSchema(record)
+
+        var modifiedRecord: BlazeDataRecord? = record
+        try triggerManager.executeTriggers(for: .beforeInsert, record: record, modifiedRecord: &modifiedRecord)
+        try executeEnhancedTriggers(
+            for: .beforeInsert,
+            record: record,
+            modifiedRecord: &modifiedRecord,
+            collection: collection,
+            collectionName: name
+        )
+        let recordToInsert = modifiedRecord ?? record
+
+        try enforceRLS(.insert, record: recordToInsert)
+        try validateForeignKeys(for: recordToInsert, operation: "insert")
+        try validateCheckConstraints(in: recordToInsert)
+        try validateUniqueConstraints(in: recordToInsert)
+
+        return (recordToInsert, id)
+    }
+
+    private func runAfterInsertTriggers(for record: BlazeDataRecord) throws {
+        var modifiedRecord: BlazeDataRecord? = record
+        try triggerManager.executeTriggers(for: .afterInsert, record: record, modifiedRecord: &modifiedRecord)
+        try executeEnhancedTriggers(
+            for: .afterInsert,
+            record: record,
+            modifiedRecord: &modifiedRecord,
+            collection: collection,
+            collectionName: name
+        )
+    }
+
     /// Inserts a new record into the database.
     ///
     /// If the record doesn't have an `id` field, a new UUID will be generated automatically.
@@ -834,53 +891,15 @@ public final class BlazeDBClient: @unchecked Sendable {
         let startTime = Date()
         
         do {
-            var record = data
-            let id: UUID
-            if case let .uuid(existingID)? = record.storage["id"] {
-                id = existingID
-            } else if case let .string(idStr)? = record.storage["id"], let parsed = UUID(uuidString: idStr) {
-                id = parsed
-                record.storage["id"] = .uuid(parsed) // normalize to uuid
-            } else {
-                id = UUID()
-                record.storage["id"] = .uuid(id)
-            }
+            let prepared = try prepareRecordForInsert(data)
 
-            if record.storage["createdAt"] == nil {
-                record.storage["createdAt"] = .date(Date())
-            }
+            try performSafeWrite { _ = try collection.insert(prepared.record) }
+            legacyTransactionLogNoOp("insert", payload: prepared.record.storage)
             
-            // Validate against schema (if defined)
-            try validateAgainstSchema(record)
-            
-            // Execute BEFORE INSERT triggers
-            var modifiedRecord: BlazeDataRecord? = record
-            try triggerManager.executeTriggers(for: .beforeInsert, record: record, modifiedRecord: &modifiedRecord)
-            // Execute enhanced triggers
-            try executeEnhancedTriggers(for: .beforeInsert, record: record, modifiedRecord: &modifiedRecord, collection: collection, collectionName: name)
-            let recordToInsert = modifiedRecord ?? record
-
-            try enforceRLS(.insert, record: recordToInsert)
-            
-            // Validate foreign keys
-            try validateForeignKeys(for: recordToInsert, operation: "insert")
-            
-            // Validate check constraints
-            try validateCheckConstraints(in: recordToInsert)
-            
-            // Validate unique constraints
-            try validateUniqueConstraints(in: recordToInsert)
-
-            try performSafeWrite { _ = try collection.insert(recordToInsert) }
-            legacyTransactionLogNoOp("insert", payload: recordToInsert.storage)
-            
-            // Execute AFTER INSERT triggers
-            try triggerManager.executeTriggers(for: .afterInsert, record: recordToInsert, modifiedRecord: &modifiedRecord)
-            // Execute enhanced triggers
-            try executeEnhancedTriggers(for: .afterInsert, record: recordToInsert, modifiedRecord: &modifiedRecord, collection: collection, collectionName: name)
+            try runAfterInsertTriggers(for: prepared.record)
             
             // Notify change observers (for sync)
-            notifyInsert(id: id)
+            notifyInsert(id: prepared.id)
             
             #if !BLAZEDB_LINUX_CORE
             // Track telemetry (if enabled)
@@ -888,7 +907,7 @@ public final class BlazeDBClient: @unchecked Sendable {
             telemetry.record(operation: "insert", duration: insertDuration, success: true, recordCount: 1)
             #endif
             
-            return id
+            return prepared.id
         } catch {
             #if !BLAZEDB_LINUX_CORE
             // Track telemetry for failure
@@ -901,17 +920,11 @@ public final class BlazeDBClient: @unchecked Sendable {
 
     /// Insert a record with a specific UUID (for transaction tests and deterministic inserts)
     public func insert(_ data: BlazeDataRecord, id: UUID) throws {
-        var record = data
-        record.storage["id"] = .uuid(id)
-        if record.storage["createdAt"] == nil {
-            record.storage["createdAt"] = .date(Date())
-        }
-        try enforceRLS(.insert, record: record)
-        try performSafeWrite { _ = try collection.insert(record) }
-        legacyTransactionLogNoOp("insert", payload: record.storage)
-        
-        // Notify change observers (for sync)
-        notifyInsert(id: id)
+        let prepared = try prepareRecordForInsert(data, explicitID: id)
+        try performSafeWrite { _ = try collection.insert(prepared.record) }
+        legacyTransactionLogNoOp("insert", payload: prepared.record.storage)
+        try runAfterInsertTriggers(for: prepared.record)
+        notifyInsert(id: prepared.id)
     }
     
     /// Insert multiple records in a single batch (much faster than individual inserts)
@@ -925,32 +938,35 @@ public final class BlazeDBClient: @unchecked Sendable {
         let startTime = Date()
         
         do {
-            if shouldEnforceRLS {
-                for record in records {
-                    try enforceRLS(.insert, record: record)
-                }
+            var preparedRecords: [BlazeDataRecord] = []
+            preparedRecords.reserveCapacity(records.count)
+            for record in records {
+                preparedRecords.append(try prepareRecordForInsert(record).record)
             }
+
             var ids: [UUID] = []
             try performSafeWrite {
                 #if !BLAZEDB_LINUX_CORE
                 // Use optimized batch insert (3-5x faster!)
-                ids = try collection.insertBatch(records)
+                ids = try collection.insertBatch(preparedRecords)
                 #else
                 // Linux: Fallback to individual inserts
-                for record in records {
+                for record in preparedRecords {
                     let id = try collection.insert(record)
                     ids.append(id)
                 }
                 #endif
                 
                 // Log to transaction log
-                for (index, _) in ids.enumerated() {
-                    if index < records.count {
-                        legacyTransactionLogNoOp("insert", payload: records[index].storage)
-                    }
+                for (index, record) in preparedRecords.enumerated() where index < ids.count {
+                    legacyTransactionLogNoOp("insert", payload: record.storage)
                 }
             }
             BlazeLogger.info("Inserted \(ids.count) records in optimized batch")
+
+            for (index, record) in preparedRecords.enumerated() where index < ids.count {
+                try runAfterInsertTriggers(for: record)
+            }
             
             // Notify change observers (for sync) - batch notification
             let changes = ids.map { DatabaseChange(type: .insert($0), collectionName: name) }

--- a/BlazeDB/Exports/BlazeDBClient.swift
+++ b/BlazeDB/Exports/BlazeDBClient.swift
@@ -941,7 +941,11 @@ public final class BlazeDBClient: @unchecked Sendable {
             var preparedRecords: [BlazeDataRecord] = []
             preparedRecords.reserveCapacity(records.count)
             for record in records {
-                preparedRecords.append(try prepareRecordForInsert(record).record)
+                let prepared = try prepareRecordForInsert(record).record
+                // Durable uniqueness is checked in prepare; also reject duplicates among
+                // not-yet-written siblings so insertMany matches sequential insert().
+                try validateUniqueConstraintsAgainstPending(in: prepared, pending: preparedRecords)
+                preparedRecords.append(prepared)
             }
 
             var ids: [UUID] = []

--- a/BlazeDBTests/Tier0Core/CoreCorrectness/InsertPathInvariantTests.swift
+++ b/BlazeDBTests/Tier0Core/CoreCorrectness/InsertPathInvariantTests.swift
@@ -61,6 +61,11 @@ final class InsertPathInvariantTests: XCTestCase {
             ]),
             "insertMany() should reject duplicate unique values inside the same batch"
         )
+        XCTAssertEqual(
+            try db.count(),
+            0,
+            "A failed same-batch unique check must not leave any rows from that batch"
+        )
     }
 
     func testInsertManyHonorsCheckConstraintsLikeInsert() throws {

--- a/BlazeDBTests/Tier0Core/CoreCorrectness/InsertPathInvariantTests.swift
+++ b/BlazeDBTests/Tier0Core/CoreCorrectness/InsertPathInvariantTests.swift
@@ -1,0 +1,72 @@
+import Foundation
+import XCTest
+@testable import BlazeDBCore
+
+/// Regression tests for #379: all public insert paths must honor the same constraints and triggers.
+final class InsertPathInvariantTests: XCTestCase {
+    private let password = "InsertPathInvariant-2026!"
+    private var tempDir: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("insert-path-invariant-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: tempDir)
+        super.tearDown()
+    }
+
+    func testInsertWithExplicitIDHonorsUniqueConstraintLikeInsert() throws {
+        let url = tempDir.appendingPathComponent("explicit-id-unique.blazedb")
+        let db = try BlazeDBClient(name: "ExplicitIDUnique", fileURL: url, password: password)
+        defer { try? db.close() }
+
+        try db.createUniqueIndex(on: "email")
+        _ = try db.insert(BlazeDataRecord(["email": .string("dup@example.com")]))
+
+        XCTAssertThrowsError(
+            try db.insert(BlazeDataRecord(["email": .string("dup@example.com")]), id: UUID()),
+            "insert(_:id:) should enforce the same unique constraint as insert()"
+        )
+    }
+
+    func testInsertManyHonorsCheckConstraintsLikeInsert() throws {
+        let url = tempDir.appendingPathComponent("insert-many-check.blazedb")
+        let db = try BlazeDBClient(name: "InsertManyCheck", fileURL: url, password: password)
+        defer { try? db.close() }
+
+        db.addCheckConstraint(CheckConstraint(name: "adult", field: "age") { record in
+            (record.storage["age"]?.intValue ?? 0) >= 18
+        })
+
+        XCTAssertThrowsError(
+            try db.insert(BlazeDataRecord(["age": .int(15)])),
+            "insert() should reject a check-constraint violation"
+        )
+        XCTAssertThrowsError(
+            try db.insertMany([BlazeDataRecord(["age": .int(15)])]),
+            "insertMany() should reject the same check-constraint violation"
+        )
+    }
+
+    func testInsertManyRunsInsertTriggersLikeInsert() throws {
+        let url = tempDir.appendingPathComponent("insert-many-trigger.blazedb")
+        let db = try BlazeDBClient(name: "InsertManyTrigger", fileURL: url, password: password)
+        defer { try? db.close() }
+
+        db.onInsert { _, modified, _ in
+            modified?.storage["triggered"] = .string("yes")
+        }
+
+        let ids = try db.insertMany([BlazeDataRecord(["name": .string("bulk")])])
+        let fetched = try db.fetch(id: ids[0])
+        XCTAssertEqual(
+            fetched?.storage["triggered"]?.stringValue,
+            "yes",
+            "insertMany() should apply the same trigger side effects as insert()"
+        )
+    }
+}

--- a/BlazeDBTests/Tier0Core/CoreCorrectness/InsertPathInvariantTests.swift
+++ b/BlazeDBTests/Tier0Core/CoreCorrectness/InsertPathInvariantTests.swift
@@ -33,6 +33,36 @@ final class InsertPathInvariantTests: XCTestCase {
         )
     }
 
+    func testInsertManyHonorsUniqueConstraintAgainstExistingRows() throws {
+        let url = tempDir.appendingPathComponent("insert-many-unique-existing.blazedb")
+        let db = try BlazeDBClient(name: "InsertManyUniqueExisting", fileURL: url, password: password)
+        defer { try? db.close() }
+
+        try db.createUniqueIndex(on: "email")
+        _ = try db.insert(BlazeDataRecord(["email": .string("dup@example.com")]))
+
+        XCTAssertThrowsError(
+            try db.insertMany([BlazeDataRecord(["email": .string("dup@example.com")])]),
+            "insertMany() should reject a unique constraint violation against existing rows"
+        )
+    }
+
+    func testInsertManyHonorsUniqueConstraintWithinSameBatch() throws {
+        let url = tempDir.appendingPathComponent("insert-many-unique-batch.blazedb")
+        let db = try BlazeDBClient(name: "InsertManyUniqueBatch", fileURL: url, password: password)
+        defer { try? db.close() }
+
+        try db.createUniqueIndex(on: "email")
+
+        XCTAssertThrowsError(
+            try db.insertMany([
+                BlazeDataRecord(["email": .string("dup@example.com")]),
+                BlazeDataRecord(["email": .string("dup@example.com")]),
+            ]),
+            "insertMany() should reject duplicate unique values inside the same batch"
+        )
+    }
+
     func testInsertManyHonorsCheckConstraintsLikeInsert() throws {
         let url = tempDir.appendingPathComponent("insert-many-check.blazedb")
         let db = try BlazeDBClient(name: "InsertManyCheck", fileURL: url, password: password)


### PR DESCRIPTION
Closes #379.

## Summary
- add regression tests for explicit-id unique checks, batch check constraints, and batch insert triggers
- route `insert(_:id:)` and `insertMany()` through the same insert validation and trigger path as `insert()`
- keep the change narrow instead of refactoring all insert internals

## Test plan
- [x] `BLAZEDB_TEST_SCOPE=tier0 swift test --filter 'InsertPathInvariantTests'`
- [x] remove the fix and confirm all three new tests fail again

## Related
- fixes the behavior described in #379