### PR TITLE
Fix unified delete leaving main-file pages readable

### DIFF
--- a/BlazeDB/Storage/PageStore.swift
+++ b/BlazeDB/Storage/PageStore.swift
@@ -804,6 +804,14 @@ public final class PageStore: @unchecked Sendable {
         try atomicWrite(offset: offset, data: buffer)
     }
 
+    /// Zeros a page slot in the main file during unified commit (mirrors WAL recovery delete replay).
+    internal func _zeroMainFilePage(index: Int) throws {
+        pageCache.remove(index)
+        let offset = off_t(index * pageSize)
+        let zeroed = Data(repeating: 0, count: pageSize)
+        try atomicWrite(offset: offset, data: zeroed)
+    }
+
     /// Durability boundary: WAL (or unified commit) must be durable before the main-file
     /// page write. Crash between those steps recovers from WAL; the reverse order loses data.
     /// Must be called under barrier on `queue`.

--- a/BlazeDB/Transactions/BlazeTransaction.swift
+++ b/BlazeDB/Transactions/BlazeTransaction.swift
@@ -148,6 +148,7 @@ public final class BlazeTransaction {
 
         // Phase 1: Encrypt all pages and append to WAL
         var encryptedBuffers: [(index: Int, buffer: Data)] = []
+        var deletedPageIDs: [Int] = []
         for (pageID, plaintext) in stagedPages {
             guard pageID >= 0 && pageID <= Int(UInt32.max) else {
                 throw NSError(
@@ -160,6 +161,7 @@ public final class BlazeTransaction {
             if plaintext.isEmpty {
                 // Delete operation — skip encryption, just record in WAL
                 try dm.appendDelete(transactionID: txID, pageIndex: pageIndex)
+                deletedPageIDs.append(pageID)
                 continue
             }
             let buffer = try store._encryptPageBuffer(plaintext: plaintext)
@@ -171,6 +173,9 @@ public final class BlazeTransaction {
         try dm.appendCommit(transactionID: txID)
 
         // Phase 3: Apply pages to the main file (WAL is now durable)
+        for pageID in deletedPageIDs {
+            try store._zeroMainFilePage(index: pageID)
+        }
         for (pageID, buffer) in encryptedBuffers {
             try store._writeEncryptedBuffer(index: pageID, buffer: buffer)
         }

--- a/BlazeDBTests/Tier0Core/Durability/BlazeTransactionUnifiedWALTests.swift
+++ b/BlazeDBTests/Tier0Core/Durability/BlazeTransactionUnifiedWALTests.swift
@@ -368,6 +368,30 @@ final class BlazeTransactionUnifiedWALTests: XCTestCase {
         store2.close()
     }
 
+    /// Regression for #364: clean commit + checkpoint + reopen must zero deleted pages on the main file.
+    /// Recovery already zeroes deletes; commit must mirror that before checkpoint clears the WAL.
+    func testUnifiedDeleteCommitCheckpointAndReopenRemovesMainFilePage() throws {
+        let dbURL = tempDir.appendingPathComponent("test-delete-commit.db")
+        let walURL = dbURL.deletingPathExtension().appendingPathExtension("wal")
+
+        let store1 = try PageStore(fileURL: dbURL, key: testKey, walMode: .unified)
+        try store1.writePage(index: 4, plaintext: Data(repeating: 0xAB, count: 100))
+
+        let tx = BlazeTransaction(store: store1)
+        try tx.delete(pageID: 4)
+        try tx.commit()
+
+        try store1.checkpoint()
+        let entriesAfterCheckpoint = try DurabilityManager.scanEntries(from: walURL)
+        XCTAssertEqual(entriesAfterCheckpoint.count, 0, "WAL should be empty after checkpoint")
+        store1.close()
+
+        let store2 = try PageStore(fileURL: dbURL, key: testKey, walMode: .unified)
+        let readBack = try store2.readPage(index: 4)
+        XCTAssertNil(readBack, "Deleted page must not remain readable from main file after commit+checkpoint+reopen")
+        store2.close()
+    }
+
     /// Checkpoint then reopen: data survives, WAL is clean.
     func testCheckpointThenReopenPreservesData() throws {
         let dbURL = tempDir.appendingPathComponent("test.db")


### PR DESCRIPTION
Closes #364.

## Summary
- add a regression test for delete, commit, checkpoint, and reopen
- zero deleted pages during unified commit so the main file matches recovery behavior
- keep the fix narrow to the unified delete publish path

## Test plan
- [x] `BLAZEDB_TEST_SCOPE=tier0 swift test --filter 'BlazeTransactionUnifiedWALTests.testUnifiedDeleteCommitCheckpointAndReopenRemovesMainFilePage'`
- [x] `BLAZEDB_TEST_SCOPE=tier0 swift test --filter 'BlazeTransactionUnifiedWALTests|PageStoreUnifiedWALTests'`
- [x] remove the fix and confirm the new regression test fails again

## Related
- fixes the behavior described in #364