### PR TITLE
fix: correct SQL RANK() for ties in window functions

### DIFF
--- a/BlazeDB/Query/WindowFunctions.swift
+++ b/BlazeDB/Query/WindowFunctions.swift
@@ -212,15 +212,16 @@ extension QueryBuilder {
             return 1
         }
         
-        // Count how many records have same order values before this one
-        var rank = 1
+        // SQL RANK(): ties share the minimum 1-based index of the peer group.
+        // Find the first row with the same order key as the current record.
+        var firstSame = recordIndex
         for i in 0..<recordIndex {
-            if !recordsEqual(sortedPartition[i], sortedPartition[recordIndex], by: orderBy) {
-                rank = i + 1
+            if recordsEqual(sortedPartition[i], sortedPartition[recordIndex], by: orderBy) {
+                firstSame = i
+                break
             }
         }
-        
-        return rank
+        return firstSame + 1
     }
     
     private func computeDenseRank(for record: BlazeDataRecord, in allRecords: [BlazeDataRecord], partitionBy: [String]?, orderBy: [String]) -> Int {

--- a/BlazeDBTests/Tier0Core/CoreCorrectness/RankWindowTieTests.swift
+++ b/BlazeDBTests/Tier0Core/CoreCorrectness/RankWindowTieTests.swift
@@ -1,6 +1,6 @@
 //
 //  RankWindowTieTests.swift
-//  BlazeDBTests — #376: SQL RANK() must skip after ties
+//  BlazeDBTests - #376: SQL RANK() must skip after ties
 //
 //  Regression: values [10, 20, 20, 30] must rank as [1, 2, 2, 4].
 //  Window functions are Apple-only (`#if !BLAZEDB_LINUX_CORE`).

--- a/BlazeDBTests/Tier0Core/CoreCorrectness/RankWindowTieTests.swift
+++ b/BlazeDBTests/Tier0Core/CoreCorrectness/RankWindowTieTests.swift
@@ -1,0 +1,98 @@
+//
+//  RankWindowTieTests.swift
+//  BlazeDBTests — #376: SQL RANK() must skip after ties
+//
+//  Regression: values [10, 20, 20, 30] must rank as [1, 2, 2, 4].
+//  Window functions are Apple-only (`#if !BLAZEDB_LINUX_CORE`).
+//
+
+import XCTest
+#if canImport(BlazeDBCore)
+@testable import BlazeDBCore
+#else
+@testable import BlazeDB
+#endif
+
+#if !BLAZEDB_LINUX_CORE
+final class RankWindowTieTests: XCTestCase {
+    private var dbURL: URL!
+    private var db: BlazeDBClient!
+
+    override func setUp() {
+        super.setUp()
+        dbURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("RankWindowTie-\(UUID().uuidString).blazedb")
+        db = try! BlazeDBClient(
+            name: "RankWindowTie",
+            fileURL: dbURL,
+            password: "RankWindowTie-Pass_123!"
+        )
+    }
+
+    override func tearDown() {
+        try? db.close()
+        let base = dbURL.deletingPathExtension()
+        for ext in ["blazedb", "meta", "wal", "salt", "indexes"] {
+            try? FileManager.default.removeItem(at: base.appendingPathExtension(ext))
+        }
+        try? FileManager.default.removeItem(at: dbURL)
+        db = nil
+        dbURL = nil
+        super.tearDown()
+    }
+
+    /// #376 minimal case from review: ties share rank; next rank skips.
+    func testRankSkipsAfterTies() throws {
+        let scores = [10, 20, 20, 30]
+        for score in scores {
+            _ = try db.insert(BlazeDataRecord([
+                "id": .uuid(UUID()),
+                "score": .int(score)
+            ]))
+        }
+
+        let results = try db.query()
+            .orderBy("score", descending: false)
+            .rank(partitionBy: nil, orderBy: ["score"], as: "rank")
+            .executeWithWindow()
+
+        XCTAssertEqual(results.count, scores.count)
+
+        let expectedRanks = [1, 2, 2, 4]
+        for (index, result) in results.enumerated() {
+            let rank = result.getWindowValue("rank")?.intValue
+            XCTAssertEqual(
+                rank,
+                expectedRanks[index],
+                "score=\(scores[index]) expected rank \(expectedRanks[index]), got \(String(describing: rank))"
+            )
+        }
+    }
+
+    /// Longer peer groups still produce standard SQL RANK gaps ([1,2,2,4,4,4,7]).
+    func testRankSkipsAfterLongerTieGroups() throws {
+        let scores = [10, 20, 20, 30, 30, 30, 40]
+        for score in scores {
+            _ = try db.insert(BlazeDataRecord([
+                "id": .uuid(UUID()),
+                "score": .int(score)
+            ]))
+        }
+
+        let results = try db.query()
+            .orderBy("score", descending: false)
+            .rank(partitionBy: nil, orderBy: ["score"], as: "rank")
+            .executeWithWindow()
+
+        let expectedRanks = [1, 2, 2, 4, 4, 4, 7]
+        XCTAssertEqual(results.count, expectedRanks.count)
+        for (index, result) in results.enumerated() {
+            XCTAssertEqual(
+                result.getWindowValue("rank")?.intValue,
+                expectedRanks[index],
+                "index \(index) score=\(scores[index])"
+            )
+        }
+    }
+}
+#endif // !BLAZEDB_LINUX_CORE


### PR DESCRIPTION
## Summary

fix: correct SQL RANK() for ties in window functions

## Changes

- computeRank used rank = i+1 on inequality, which under-ranks after ties.
- RANK is now the 1-based index of the first peer with the same order key.

Fixes #376
