### PR TITLE
fix: isolate LazyFieldRecord cache by database

### DIFF
--- a/BlazeDB/Core/LazyFieldRecord.swift
+++ b/BlazeDB/Core/LazyFieldRecord.swift
@@ -151,7 +151,7 @@ extension DynamicCollection {
     /// - Returns: LazyFieldRecord if found
     public func fetchLazyFieldRecord(id: UUID, fieldSizeThreshold: Int = LazyFieldRecord.defaultFieldSizeThreshold) throws -> LazyFieldRecord? {
         // Check cache first
-        if let cached = RecordCache.shared.get(id: id) {
+        if let cached = recordCache.get(id: id) {
             return LazyFieldRecord(record: cached, fieldSizeThreshold: fieldSizeThreshold)
         }
         
@@ -174,7 +174,7 @@ extension DynamicCollection {
         // Cache the record (cache full decoded version for small records)
         if lazyRecord.lazyFieldOffsets.isEmpty {
             let fullRecord = try lazyRecord.toRecord()
-            RecordCache.shared.set(id: id, record: fullRecord)
+            recordCache.set(id: id, record: fullRecord)
         }
         
         return lazyRecord

--- a/BlazeDBTests/Tier0Core/CoreCorrectness/RecordCacheLifecycleTests.swift
+++ b/BlazeDBTests/Tier0Core/CoreCorrectness/RecordCacheLifecycleTests.swift
@@ -227,4 +227,53 @@ final class RecordCacheLifecycleTests: XCTestCase {
         RecordCache.release(forDatabase: registryPath, token: predecessor.token)
         RecordCache.release(forDatabase: registryPath, token: successor.token)
     }
+
+    /// #307: lazy-field fetches must use the owning database's cache, not the
+    /// process-global UUID-only cache shared by unrelated databases.
+    func testLazyFieldFetchDoesNotReuseSharedCacheAcrossDatabaseInstances() throws {
+        RecordCache.shared.clear()
+        defer { RecordCache.shared.clear() }
+
+        let recordID = UUID()
+        let firstDatabase = try makeClient(
+            "lazy-field-first",
+            at: tempDir.appendingPathComponent("lazy-field-first.blazedb")
+        )
+        defer { try? firstDatabase.close() }
+        try firstDatabase.insert(
+            BlazeDataRecord(["payload": .string("database-a")]),
+            id: recordID
+        )
+
+        let firstRecord = try XCTUnwrap(
+            try firstDatabase.collection.fetchLazyFieldRecord(id: recordID),
+            "the first database must return its lazy-field record"
+        )
+        XCTAssertEqual(firstRecord["payload"]?.stringValue, "database-a")
+        XCTAssertNil(
+            RecordCache.shared.get(id: recordID),
+            "lazy-field fetch must not populate the process-global cache"
+        )
+
+        let secondDatabase = try makeClient(
+            "lazy-field-second",
+            at: tempDir.appendingPathComponent("lazy-field-second.blazedb")
+        )
+        defer { try? secondDatabase.close() }
+        try secondDatabase.insert(
+            BlazeDataRecord(["payload": .string("database-b")]),
+            id: recordID
+        )
+        RecordCache.shared.set(
+            id: recordID,
+            record: BlazeDataRecord(["payload": .string("stale-global")])
+        )
+
+        let secondRecord = try XCTUnwrap(
+            try secondDatabase.collection.fetchLazyFieldRecord(id: recordID),
+            "the second database must return its own lazy-field record"
+        )
+        XCTAssertEqual(secondRecord["payload"]?.stringValue, "database-b")
+        RecordCache.shared.remove(id: recordID)
+    }
 }

--- a/BlazeDBTests/Tier0Core/CoreCorrectness/RecordCacheLifecycleTests.swift
+++ b/BlazeDBTests/Tier0Core/CoreCorrectness/RecordCacheLifecycleTests.swift
@@ -231,10 +231,9 @@ final class RecordCacheLifecycleTests: XCTestCase {
     /// #307: lazy-field fetches must use the owning database's cache, not the
     /// process-global UUID-only cache shared by unrelated databases.
     func testLazyFieldFetchDoesNotReuseSharedCacheAcrossDatabaseInstances() throws {
-        RecordCache.shared.clear()
-        defer { RecordCache.shared.clear() }
-
         let recordID = UUID()
+        defer { RecordCache.shared.remove(id: recordID) }
+
         let firstDatabase = try makeClient(
             "lazy-field-first",
             at: tempDir.appendingPathComponent("lazy-field-first.blazedb")
@@ -250,9 +249,40 @@ final class RecordCacheLifecycleTests: XCTestCase {
             "the first database must return its lazy-field record"
         )
         XCTAssertEqual(firstRecord["payload"]?.stringValue, "database-a")
+        XCTAssertNotNil(
+            firstDatabase.collection.recordCache.get(id: recordID),
+            "the first lazy-field fetch must populate the owning database cache"
+        )
         XCTAssertNil(
             RecordCache.shared.get(id: recordID),
             "lazy-field fetch must not populate the process-global cache"
+        )
+
+        // Change the backing page after the first fetch. A cache miss must see
+        // this replacement, while a cache hit must preserve the original.
+        let firstPageIndex = try XCTUnwrap(
+            firstDatabase.collection.indexMap[recordID]?.first,
+            "the first database must index its inserted record"
+        )
+        let changedBackingRecord = BlazeDataRecord([
+            "id": .uuid(recordID),
+            "payload": .string("database-a-on-disk")
+        ])
+        try firstDatabase.collection.store.writePage(
+            index: firstPageIndex,
+            plaintext: try BlazeBinaryEncoder.encode(changedBackingRecord)
+        )
+        var cachedPayload: String?
+        do {
+            cachedPayload = try firstDatabase.collection
+                .fetchLazyFieldRecord(id: recordID)?["payload"]?.stringValue
+        } catch {
+            cachedPayload = nil
+        }
+        XCTAssertEqual(
+            cachedPayload,
+            "database-a",
+            "the same database must reuse its cached lazy-field record"
         )
 
         let secondDatabase = try makeClient(
@@ -274,6 +304,5 @@ final class RecordCacheLifecycleTests: XCTestCase {
             "the second database must return its own lazy-field record"
         )
         XCTAssertEqual(secondRecord["payload"]?.stringValue, "database-b")
-        RecordCache.shared.remove(id: recordID)
     }
 }


### PR DESCRIPTION
## Summary

- Route lazy-field record cache lookups and inserts through the owning database's `recordCache` instead of the process-global UUID-only `RecordCache.shared`.
- Prevent two live databases containing the same record UUID from cross-serving decoded payloads while preserving the existing lazy-field fetch behavior.

## Scope

- In scope: the two cache accesses in `DynamicCollection.fetchLazyFieldRecord` and a Tier 0 regression covering owning-cache reuse after a backing-page change, two live databases, the same UUID, different payloads, and a poisoned global cache entry.
- Out of scope: the separate OwnerToken-helper footgun in #455 and the per-path registry / close / VACUUM lifecycle work already merged in #449.

Fixes #307

## Validation

List **exact** commands you ran (copy-paste from your terminal):

```bash
./dev test RecordCacheLifecycleTests/testLazyFieldFetchDoesNotReuseSharedCacheAcrossDatabaseInstances
./dev test RecordCacheLifecycleTests/testAcquireNeverInheritsAPreviousAcquisitionsDecodes
git diff --check
git diff --exit-code -- BlazeDB/Core/LazyFieldRecord.swift
python3 ~/.agent-bundle/scripts/author_stats.py -C /tmp/oss-contrib-uclWZk 8b3ab9867aec3a78a80bf4043b7a5d8b486745fc..HEAD
```

- Assertion-red proof: the strengthened regression's isolated owning-cache lookup bypass recompiled `LazyFieldRecord.swift` and failed its same-database assertion when the changed backing payload (`database-a-on-disk`) was returned; the isolated owning-cache insertion bypass recompiled and failed the owning-cache population assertion, the global-cache isolation assertion, and the same-database assertion.
- Focused green checks: the named regression completed 1 test with 0 failures (17.603s); the adjacent lifecycle test completed 1 test with 0 failures (0.004s); `git diff --check` completed cleanly.
- Mutation proof: each local-cache mutation was applied singly, source recompilation was observed, each run reached assertion failures, and `LazyFieldRecord.swift` was restored exactly after each mutation.
- Independent review: `SHIP 2ea7d8eddc4ea6012177f5a0000acd3c1d0c9c63` in the binding adversary report.
- Exact-SHA fork CI: [run 32767465749](https://github.com/Nitjsefnie-OSC/BlazeDB/actions/runs/32767465749) and its sole [job 97560090338](https://github.com/Nitjsefnie-OSC/BlazeDB/actions/runs/32767465749/job/97560090338) completed successfully with `total_count=1`. The ordinary log records `Tested commit: 2ea7d8eddc4ea6012177f5a0000acd3c1d0c9c63 (resolved from target_ref '2ea7d8eddc4ea6012177f5a0000acd3c1d0c9c63')` followed by the same standalone 40-character SHA.

## Checklist

- [x] One branch = one concern
- [x] `git status` / `git diff` reviewed for containment
- [x] Docs updated in this PR if behavior or public usage changed (not applicable: this restores the existing database-isolation contract without changing public API or usage)
- [x] `Docs/SYSTEM_MAP.md` / `Docs/Testing/CI_AND_TEST_TIERS.md` updated **only if** this PR changes material surface, architecture, or CI/tier semantics (not applicable)
- [x] Storage/WAL/encryption/recovery changes: followed [Docs/Contributing/STORAGE_CHANGE_CHECKLIST.md](../Docs/Contributing/STORAGE_CHANGE_CHECKLIST.md) (not applicable; none changed)
- [x] CI checks pass — exact-SHA fork run 32767465749 / job 97560090338 succeeded for candidate `2ea7d8eddc4ea6012177f5a0000acd3c1d0c9c63`

Generated by GPT-5.6 Luna (implementation, testing), GPT-5.6 Sol (review)
