### PR TITLE
Fail closed on unauthenticated NDJSON txn_log sidecars (#365)

### DIFF
--- a/BlazeDB/Core/BlazeDBManager.swift
+++ b/BlazeDB/Core/BlazeDBManager.swift
@@ -58,18 +58,32 @@ public final class BlazeDBManager {
             ?? fileURL.deletingLastPathComponent().appendingPathComponent("txn_log.json")
     }
 
-    /// Legacy NDJSON recovery hook used by manager-style tooling.
-    /// If a `txn_log-*.json` or `txn_log.json` exists next to the database file, this will
-    /// treat it as a plaintext page-level journal and replay it into the encrypted `PageStore`.
-    /// Normal `BlazeDBClient` usage does not generate these logs; they are strictly for
-    /// legacy migration / advanced recovery scenarios and should be treated as sensitive.
-    private static func recoverTransactionLogIfPresent(into store: PageStore, fileURL: URL) throws {
+    /// Legacy NDJSON `txn_log*.json` sidecars are **unauthenticated plaintext** page ops.
+    ///
+    /// Security (#365): auto-replaying them into a keyed `PageStore` seals attacker-chosen plaintext
+    /// under the victim key. This is fail-closed removal, not authenticated recovery.
+    ///
+    /// **What still recovers:** production `BlazeDBClient` / `PageStore` crash recovery uses the binary
+    /// WAL (`.wal`) path inside `PageStore.init`, not NDJSON sidecars. `BlazeDBClient.open` already
+    /// deletes legacy NDJSON sidecars instead of replaying them. Manager mount now matches that boundary.
+    ///
+    /// Operators with a legitimate NDJSON journal must restore through an authenticated backup or a future
+    /// signed/authenticated journal format — not silent replay on mount.
+    private static func rejectUnauthenticatedTransactionLogIfPresent(fileURL: URL) throws {
         let fm = FileManager.default
-        let candidates = transactionLogURLs(for: fileURL)
-        let chosen = candidates.first(where: { fm.fileExists(atPath: $0.path) }) ?? preferredTransactionLogURL(for: fileURL)
-        let log = TransactionLog(logFileURL: chosen)
-        try log.recover(into: store, from: chosen)
-        BlazeLogger.info("Recovered journal: \(chosen.lastPathComponent)")
+        for candidate in transactionLogURLs(for: fileURL) where fm.fileExists(atPath: candidate.path) {
+            BlazeLogger.warn(
+                "Removing unauthenticated legacy NDJSON journal \(candidate.lastPathComponent) without replay (#365)"
+            )
+            do {
+                try fm.removeItem(at: candidate)
+            } catch {
+                throw NSError(domain: "BlazeDBManager", code: 3651, userInfo: [
+                    NSLocalizedDescriptionKey:
+                        "Refusing to mount while unauthenticated txn_log sidecar \(candidate.lastPathComponent) cannot be removed: \(error.localizedDescription)"
+                ])
+            }
+        }
     }
 
     /// Mount a DB from the given file path.
@@ -94,7 +108,7 @@ public final class BlazeDBManager {
         let key = try Self.keyFromPassword(password, salt: kdfSalt)
         let metaURL = fileURL.deletingPathExtension().appendingPathExtension("meta")
         let store = try PageStore(fileURL: fileURL, key: key)
-        try Self.recoverTransactionLogIfPresent(into: store, fileURL: fileURL)
+        try Self.rejectUnauthenticatedTransactionLogIfPresent(fileURL: fileURL)
         
         // CRITICAL: Pass password to DynamicCollection so migration can access password-protected layouts
         let collection = try DynamicCollection(
@@ -257,7 +271,7 @@ public final class BlazeDBManager {
         let kdfSalt = try Self.loadOrCreateKDFSalt(for: fileURL)
         let key = try Self.keyFromPassword(password ?? "", salt: kdfSalt)
         let store = try PageStore(fileURL: fileURL, key: key)
-        try Self.recoverTransactionLogIfPresent(into: store, fileURL: fileURL)
+        try Self.rejectUnauthenticatedTransactionLogIfPresent(fileURL: fileURL)
         
         // CRITICAL: Pass password to DynamicCollection so migration can access password-protected layouts
         let collection = try DynamicCollection(
@@ -289,24 +303,29 @@ public final class BlazeDBManager {
     }
     
     /// Recover all transactions for all mounted databases from any legacy NDJSON journals.
-    /// This walks `txn_log-*.json` / `txn_log.json` sidecars (if present) and replays
-    /// their plaintext page operations into the mounted stores. Default `BlazeDBClient`
-    /// CRUD does not emit these files; this is an advanced migration / operator tool.
+    ///
+    /// **Disabled (#365):** adjacent `txn_log*.json` files are unauthenticated plaintext.
+    /// Replaying them into a keyed `PageStore` would seal attacker-controlled pages under the
+    /// database key. Callers that find these sidecars should delete them and restore from an
+    /// authenticated backup / binary WAL path instead.
     public func recoverAllTransactions() throws {
         stateLock.lock()
         defer { stateLock.unlock() }
-        for (name, collection) in mountedDatabases {
-            guard let fileURL = dbFileURLs[name] else {
-                BlazeLogger.warn("Missing file URL for \(name); skipping recovery")
-                continue
-            }
-            let candidates = Self.transactionLogURLs(for: fileURL)
+        var found: [String] = []
+        for (name, _) in mountedDatabases {
+            guard let fileURL = dbFileURLs[name] else { continue }
             let fm = FileManager.default
-            let chosen = candidates.first(where: { fm.fileExists(atPath: $0.path) }) ?? Self.preferredTransactionLogURL(for: fileURL)
-            let log = TransactionLog(logFileURL: chosen)
-            try log.recover(into: collection.store, from: chosen)
-            BlazeLogger.info("Recovered journal for \(name): \(chosen.lastPathComponent)")
+            for candidate in Self.transactionLogURLs(for: fileURL) where fm.fileExists(atPath: candidate.path) {
+                found.append("\(name):\(candidate.lastPathComponent)")
+            }
         }
+        guard found.isEmpty else {
+            throw NSError(domain: "BlazeDBManager", code: 3650, userInfo: [
+                NSLocalizedDescriptionKey:
+                    "Legacy NDJSON txn_log replay is disabled because journals are unauthenticated plaintext (#365). Sidecars present: \(found.joined(separator: ", ")). Remove them and restore from an authenticated backup."
+            ])
+        }
+        BlazeLogger.info("recoverAllTransactions: no legacy NDJSON journals present")
     }
     
     /// Flush all mounted PageStores to disk.

--- a/BlazeDBTests/Tier0Core/CoreCorrectness/TxnLogRecoveryBoundaryTests.swift
+++ b/BlazeDBTests/Tier0Core/CoreCorrectness/TxnLogRecoveryBoundaryTests.swift
@@ -1,0 +1,168 @@
+//
+//  TxnLogRecoveryBoundaryTests.swift
+//  BlazeDBTests
+//
+//  Regression tests for #365: unauthenticated NDJSON txn_log must not replay into
+//  keyed PageStores on BlazeDBManager mount. Binary WAL recovery remains the
+//  authenticated crash-recovery path for BlazeDBClient / PageStore.
+//
+
+import XCTest
+@testable import BlazeDBCore
+#if canImport(CryptoKit)
+import CryptoKit
+#else
+import Crypto
+#endif
+
+final class TxnLogRecoveryBoundaryTests: XCTestCase {
+    private var tempDir: URL!
+    private let password = "TxnLogBoundary-Test-2026!"
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        KeyManager.setTestPBKDF2IterationsOverride(1_000)
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TxnLogBoundary-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        KeyManager.setTestPBKDF2IterationsOverride(nil)
+        try? FileManager.default.removeItem(at: tempDir)
+        try super.tearDownWithError()
+    }
+
+    /// Plant a committed NDJSON write beside the DB file (legacy sidecar location).
+    private func writeLegacyTxnLogSidecar(
+        beside dbURL: URL,
+        pageID: Int,
+        plaintext: Data,
+        useNamespaced: Bool = false
+    ) throws -> URL {
+        let txID = UUID().uuidString
+        let begin = try JSONEncoder().encode(TransactionLog.Operation.begin(txID: txID))
+        let write = try JSONEncoder().encode(TransactionLog.Operation.write(pageID: pageID, data: plaintext))
+        let commit = try JSONEncoder().encode(TransactionLog.Operation.commit(txID: txID))
+        var ndjson = Data()
+        ndjson.append(begin); ndjson.append(0x0A)
+        ndjson.append(write); ndjson.append(0x0A)
+        ndjson.append(commit); ndjson.append(0x0A)
+
+        let logURL: URL
+        if useNamespaced {
+            let base = dbURL.deletingPathExtension().lastPathComponent
+            let digest = SHA256.hash(data: Data(dbURL.path.utf8))
+            let digestHex = Data(digest).map { String(format: "%02x", $0) }.joined()
+            logURL = dbURL.deletingLastPathComponent()
+                .appendingPathComponent("txn_log-\(base)-\(digestHex).json")
+        } else {
+            logURL = dbURL.deletingLastPathComponent().appendingPathComponent("txn_log.json")
+        }
+        try ndjson.write(to: logURL)
+        return logURL
+    }
+
+    func testManagerMountRemovesUnauthenticatedTxnLogWithoutReplay() throws {
+        let dbURL = tempDir.appendingPathComponent("mount-txnlog.blazedb")
+
+        let store1 = try PageStore(fileURL: dbURL, key: try key(for: dbURL))
+        let original = Data(repeating: 0xAB, count: 64)
+        try store1.writePage(index: 7, plaintext: original)
+        store1.close()
+
+        let injected = Data(repeating: 0xEE, count: 64)
+        let journal = try writeLegacyTxnLogSidecar(beside: dbURL, pageID: 7, plaintext: injected)
+
+        let manager = BlazeDBManager()
+        _ = try manager.mountDatabase(named: "victim", fileURL: dbURL, password: password)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: journal.path), "sidecar must be removed, not replayed")
+        manager.unmountDatabase(named: "victim")
+
+        let store2 = try PageStore(fileURL: dbURL, key: try key(for: dbURL))
+        let readBack = try store2.readPage(index: 7)
+        XCTAssertEqual(readBack, original, "injected plaintext must not be sealed into the encrypted DB")
+        store2.close()
+    }
+
+    func testManagerMountRemovesNamespacedTxnLogSidecarWithoutReplay() throws {
+        let dbURL = tempDir.appendingPathComponent("namespaced-txnlog.blazedb")
+
+        let store1 = try PageStore(fileURL: dbURL, key: try key(for: dbURL))
+        try store1.writePage(index: 3, plaintext: Data(repeating: 0x11, count: 32))
+        store1.close()
+
+        let journal = try writeLegacyTxnLogSidecar(
+            beside: dbURL,
+            pageID: 3,
+            plaintext: Data(repeating: 0x22, count: 32),
+            useNamespaced: true
+        )
+
+        let manager = BlazeDBManager()
+        _ = try manager.mountDatabase(named: "db", fileURL: dbURL, password: password)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: journal.path))
+        manager.unmountDatabase(named: "db")
+    }
+
+    func testManagerMountWithoutTxnLogSidecarPreservesExistingPages() throws {
+        let dbURL = tempDir.appendingPathComponent("clean-mount.blazedb")
+
+        let store1 = try PageStore(fileURL: dbURL, key: try key(for: dbURL))
+        let payload = Data(repeating: 0xCD, count: 48)
+        try store1.writePage(index: 2, plaintext: payload)
+        store1.close()
+
+        let manager = BlazeDBManager()
+        _ = try manager.mountDatabase(named: "db", fileURL: dbURL, password: password)
+        manager.unmountDatabase(named: "db")
+
+        let store2 = try PageStore(fileURL: dbURL, key: try key(for: dbURL))
+        XCTAssertEqual(try store2.readPage(index: 2), payload)
+        store2.close()
+    }
+
+    func testBlazeDBClientOpenStillWorksWithoutTxnLogSidecar() throws {
+        let dbURL = tempDir.appendingPathComponent("client-open.blazedb")
+        let db = try BlazeDBClient(name: "client-open", fileURL: dbURL, password: password)
+        let id = try db.insert(BlazeDataRecord(["note": .string("durable")]))
+        try db.persist()
+        try db.close()
+
+        let db2 = try BlazeDBClient(name: "client-open", fileURL: dbURL, password: password)
+        defer { try? db2.close() }
+        let record = try db2.fetch(id: id)
+        XCTAssertEqual(record?.storage["note"]?.stringValue, "durable")
+    }
+
+    func testRecoverAllTransactionsFailsClosedWhenTxnLogPresent() throws {
+        let dbURL = tempDir.appendingPathComponent("recover-all.blazedb")
+        let manager = BlazeDBManager()
+        _ = try manager.mountDatabase(named: "db", fileURL: dbURL, password: password)
+
+        _ = try writeLegacyTxnLogSidecar(
+            beside: dbURL,
+            pageID: 1,
+            plaintext: Data(repeating: 0x99, count: 16)
+        )
+
+        XCTAssertThrowsError(try manager.recoverAllTransactions()) { error in
+            let ns = error as NSError
+            XCTAssertEqual(ns.domain, "BlazeDBManager")
+            XCTAssertEqual(ns.code, 3650)
+        }
+        manager.unmountAllDatabases()
+    }
+
+    private func key(for dbURL: URL) throws -> SymmetricKey {
+        let saltURL = dbURL.deletingPathExtension().appendingPathExtension("salt")
+        let salt: Data
+        if FileManager.default.fileExists(atPath: saltURL.path) {
+            salt = try Data(contentsOf: saltURL)
+        } else {
+            salt = try SecureRandom.bytesStrict(count: 16)
+            try salt.write(to: saltURL, options: .atomic)
+        }
+        return try KeyManager.getKey(from: password, salt: salt)
+    }
+}

--- a/Docs/Security/SECURITY.md
+++ b/Docs/Security/SECURITY.md
@@ -67,14 +67,21 @@ Records are encoded to BlazeBinary, assembled into 4KB pages, encrypted with AES
 - Mitigation: Row-level security, policy evaluation
 
 4. **Storage Corruption**: Accidental or malicious data corruption
-- Mitigation: CRC32 checksums, corruption detection, automatic recovery
+- Mitigation: GCM authentication tags, binary WAL where enabled, recovery tooling
+
+### Crash recovery and journals
+
+Production `BlazeDBClient` / `PageStore` crash recovery uses the **binary write-ahead log** (`.wal`).
+
+Legacy adjacent **NDJSON `txn_log*.json` sidecars are unauthenticated plaintext**. `BlazeDBManager` **does not replay them** on mount (#365): sidecars are removed and mount proceeds using the encrypted store only. Operators with a legitimate legacy NDJSON journal must restore from an authenticated backup; there is no silent auto-replay into keyed stores.
 
 ### Attack Surfaces
 
-- **Local Storage**: Encrypted pages prevent plaintext access
+- **Local Storage**: Encrypted pages prevent plaintext access without the key
 - **Network Sync**: TLS + E2E encryption prevent interception
-- **Query Interface**: RLS policies filter unauthorized data
-- **Key Storage**: Secure Enclave prevents key extraction
+- **Query Interface**: RLS policies filter unauthorized data when enabled
+- **Key Storage**: Secure Enclave / keyring files (owner-only where supported)
+- **Legacy NDJSON `txn_log`**: Unauthenticated plaintext journals are **not** auto-applied into keyed stores (#365)
 
 ---
 


### PR DESCRIPTION
## Summary

- Remove unauthenticated NDJSON `txn_log` sidecars on `BlazeDBManager` mount/reload instead of replaying them into keyed stores
- `recoverAllTransactions()` fails closed (error 3650) when such sidecars exist
- Binary WAL (`.wal`) remains the production crash-recovery path; NDJSON replay is intentionally disabled because it is unauthenticated plaintext

**Tradeoff:** operators with legacy NDJSON journals must restore from authenticated backup or wait for a signed journal format. This PR disables silent replay rather than authenticating it.

## Test plan

- [x] `TxnLogRecoveryBoundaryTests` — injected journal not replayed, sidecar removed, original pages preserved
- [x] Clean mount and `BlazeDBClient` open still work
- [x] `recoverAllTransactions()` throws 3650 when sidecar present

Fixes #365