### PR TITLE
Close RLS enforcement gaps (#334–#337)

### DIFF
--- a/BlazeDB/Core/ChangeObservation.swift
+++ b/BlazeDB/Core/ChangeObservation.swift
@@ -189,7 +189,10 @@ private final class FilteredChangeBridge: @unchecked Sendable {
                       predicate(record) {
                 relevantChanges.append(change)
             } else if case .delete = change.type {
-                relevantChanges.append(change)
+                // Fail closed (#337): filtered observers do not receive delete events.
+                // The deleted payload is gone, so predicate/RLS cannot be evaluated;
+                // forwarding would leak identifiers for rows the observer may not see.
+                continue
             }
         }
 

--- a/BlazeDB/Exports/BlazeDBClient+Monitoring.swift
+++ b/BlazeDB/Exports/BlazeDBClient+Monitoring.swift
@@ -450,8 +450,14 @@ extension BlazeDBClient {
         return total
     }
     
-    /// Get record count (fast, no actual reads!)
+    /// Get record count.
+    ///
+    /// When RLS is enabled with policies, returns the RLS-visible count (same as ``count()``)
+    /// so callers cannot learn the true cardinality via this side channel (#336).
     public func getRecordCount() -> Int {
+        if shouldEnforceRLS {
+            return (try? count()) ?? 0
+        }
         return collection.queue.sync { collection.indexMap.count }
     }
     

--- a/BlazeDB/Exports/BlazeDBClient.swift
+++ b/BlazeDB/Exports/BlazeDBClient.swift
@@ -372,7 +372,7 @@ public final class BlazeDBClient: @unchecked Sendable {
     internal let encryptionKey: SymmetricKey
 
     @inline(__always)
-    private var shouldEnforceRLS: Bool {
+    internal var shouldEnforceRLS: Bool {
         rls.isEnabled() && rls.hasPolicies()
     }
 
@@ -1032,6 +1032,8 @@ public final class BlazeDBClient: @unchecked Sendable {
                     updated.storage[key] = value
                 }
                 updated.storage["updatedAt"] = .date(Date())
+                // WITH CHECK: resulting row must also pass UPDATE policy (#335)
+                try enforceRLS(.update, record: updated)
                 try collection.update(id: id, with: updated)
                 updateCount += 1
             }
@@ -1366,6 +1368,9 @@ public final class BlazeDBClient: @unchecked Sendable {
         // Execute enhanced triggers
         try executeEnhancedTriggers(for: .beforeUpdate, record: existingRecord, modifiedRecord: &modifiedRecord, collection: collection, collectionName: name)
         let recordToUpdate = modifiedRecord ?? data
+        
+        // WITH CHECK: resulting row must also pass UPDATE policy (#335)
+        try enforceRLS(.update, record: recordToUpdate)
         
         // Validate foreign keys
         try validateForeignKeys(for: recordToUpdate, operation: "update")

--- a/BlazeDB/Query/GraphQuery.swift
+++ b/BlazeDB/Query/GraphQuery.swift
@@ -115,9 +115,12 @@ public final class GraphQuery<T> {
         self.userContext = userContext
         self.queryBuilder = QueryBuilder(collection: collection)
         
-        // Inject RLS filter if user context provided and RLS is enabled
+        // Prefer explicit userContext; otherwise honor the client's active RLS context (#334).
         if let userContext = userContext, let client = client {
-            injectRLSFilter(userContext: userContext, client: client)
+            injectRLSFilter(securityContext: userContext.toSecurityContext(), client: client, adminBypass: userContext.isAdmin)
+        } else if let client = client, let securityContext = client.rls.getContext() {
+            let adminBypass = securityContext.hasRole("admin") || securityContext.hasRole("superuser")
+            injectRLSFilter(securityContext: securityContext, client: client, adminBypass: adminBypass)
         }
     }
     
@@ -125,9 +128,9 @@ public final class GraphQuery<T> {
     
     /// Inject RLS filter into query builder (non-invasive, additive only)
     /// Optimized for performance: pre-computes checks, reduces per-record overhead
-    private func injectRLSFilter(userContext: BlazeUserContext, client: BlazeDBClient) {
+    private func injectRLSFilter(securityContext: SecurityContext, client: BlazeDBClient, adminBypass: Bool) {
         // OPTIMIZATION 1: Admin bypass (check once, not per record)
-        guard !userContext.isAdmin else {
+        guard !adminBypass else {
             BlazeLogger.debug("🔐 GraphQuery: Admin user, bypassing RLS")
             return
         }
@@ -139,7 +142,6 @@ public final class GraphQuery<T> {
         }
         
         // OPTIMIZATION 3: Pre-compute SecurityContext (once, not per record)
-        let securityContext = userContext.toSecurityContext()
         let policyEngine = client.rls.policyEngine
         
         // OPTIMIZATION 4: Pre-filter policies and cache enabled state (reduces lock contention)
@@ -155,16 +157,8 @@ public final class GraphQuery<T> {
             return
         }
         
-        // OPTIMIZATION 5: Pre-compute team membership set (O(1) lookup instead of O(n))
-        // Note: teamIDSet and userID available through userContext in the filter closure
-        _ = Set(userContext.teamIDs)  // Pre-computed for potential future optimization
-        
-        // OPTIMIZATION 6: Create optimized filter closure
-        // - Pre-computes checks that don't depend on record
-        // - Uses Set for O(1) team membership checks
-        // - Reduces dictionary lookups where possible
+        // OPTIMIZATION 5: Create optimized filter closure
         let rlsFilter: (BlazeDataRecord) -> Bool = { record in
-            // Fast path: Check policies with pre-filtered list
             return policyEngine.isAllowed(
                 operation: PolicyOperation.select,
                 context: securityContext,
@@ -176,7 +170,7 @@ public final class GraphQuery<T> {
         // This ensures: effectiveFilter = RLSFilter && userProvidedFilter
         queryBuilder.where(rlsFilter)
         
-        BlazeLogger.debug("🔐 GraphQuery: Optimized RLS filter injected for user \(userContext.userID) (role: \(userContext.role), \(applicablePolicies.count) policies)")
+        BlazeLogger.debug("🔐 GraphQuery: Optimized RLS filter injected for user \(securityContext.userID) (\(applicablePolicies.count) policies)")
     }
     
     // MARK: - X-Axis Configuration

--- a/BlazeDB/Query/GraphQuery.swift
+++ b/BlazeDB/Query/GraphQuery.swift
@@ -803,7 +803,7 @@ extension BlazeDBClient {
     /// }
     /// ```
     public func graph(@GraphQueryBuilder _ content: (GraphQuery<BlazeDataRecord>) -> GraphQuery<BlazeDataRecord>) -> GraphQuery<BlazeDataRecord> {
-        let base = GraphQuery<BlazeDataRecord>(collection: collection)
+        let base = GraphQuery<BlazeDataRecord>(collection: collection, client: self)
         return content(base)
     }
 }

--- a/BlazeDBTests/Tier0Core/CoreCorrectness/RLSEnforcementGapTests.swift
+++ b/BlazeDBTests/Tier0Core/CoreCorrectness/RLSEnforcementGapTests.swift
@@ -1,0 +1,138 @@
+//
+//  RLSEnforcementGapTests.swift
+//  BlazeDBTests
+//
+//  Regression tests for #334–#337: GraphQuery context, WITH CHECK on updates,
+//  stats/count side channels, and filtered observer delete forwarding.
+//
+
+import XCTest
+@testable import BlazeDBCore
+
+final class RLSEnforcementGapTests: XCTestCase {
+    private var tempDir: URL!
+    private let password = "RLSEnforcementGap-Test-2026!"
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("RLSGap-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: tempDir)
+        super.tearDown()
+    }
+
+    func testPublicGraphHonorsClientRLSContext() throws {
+        let url = tempDir.appendingPathComponent("graph-rls.blazedb")
+        let db = try BlazeDBClient(name: "graph-rls", fileURL: url, password: password)
+        defer { try? db.close() }
+
+        let teamA = UUID()
+        let teamB = UUID()
+        let userA = UUID()
+
+        db.enableRLS()
+        db.setRLSContext(userID: userA, teamIDs: [teamA], roles: ["engineer"])
+        db.rls.addPolicy(SecurityPolicy(
+            name: "team_select",
+            operation: .select,
+            type: .restrictive
+        ) { context, record in
+            guard let team = record.storage["team_id"]?.uuidValue else { return false }
+            return context.teamIDs.contains(team)
+        })
+
+        db.setRLSContext(userID: userA, teamIDs: [teamA, teamB], roles: ["admin"])
+        _ = try db.insert(BlazeDataRecord(["team_id": .uuid(teamA), "n": .int(1)]))
+        _ = try db.insert(BlazeDataRecord(["team_id": .uuid(teamA), "n": .int(2)]))
+        _ = try db.insert(BlazeDataRecord(["team_id": .uuid(teamB), "n": .int(3)]))
+
+        db.setRLSContext(userID: userA, teamIDs: [teamA], roles: ["engineer"])
+        let points = try db.graph().x("team_id").y(.count).toPoints()
+        XCTAssertEqual(points.count, 1, "public graph() must apply client RLS context (#334)")
+        XCTAssertEqual(points.first?.y as? Int, 2)
+    }
+
+    func testUpdateRejectsPostMutationRLSViolation() throws {
+        let url = tempDir.appendingPathComponent("with-check.blazedb")
+        let db = try BlazeDBClient(name: "with-check", fileURL: url, password: password)
+        defer { try? db.close() }
+
+        let owner = UUID()
+        let other = UUID()
+        db.enableRLS()
+        db.setRLSContext(userID: owner, roles: ["admin"])
+        db.rls.addPolicy(SecurityPolicy(
+            name: "owner_update",
+            operation: .update,
+            type: .restrictive
+        ) { context, record in
+            record.storage["userId"]?.uuidValue == context.userID
+        })
+        db.rls.addPolicy(SecurityPolicy(
+            name: "owner_insert",
+            operation: .insert,
+            type: .restrictive
+        ) { context, record in
+            record.storage["userId"]?.uuidValue == context.userID || context.hasRole("admin")
+        })
+        db.rls.addPolicy(SecurityPolicy(
+            name: "owner_select",
+            operation: .select,
+            type: .restrictive
+        ) { context, record in
+            record.storage["userId"]?.uuidValue == context.userID || context.hasRole("admin")
+        })
+
+        let id = try db.insert(BlazeDataRecord(["userId": .uuid(owner), "note": .string("mine")]))
+        db.setRLSContext(userID: owner, roles: ["member"])
+
+        var stolen = try XCTUnwrap(try db.fetch(id: id))
+        stolen.storage["userId"] = .uuid(other)
+        XCTAssertThrowsError(try db.update(id: id, with: stolen), "WITH CHECK must reject ownership transfer (#335)")
+        let still = try XCTUnwrap(try db.fetch(id: id))
+        XCTAssertEqual(still.storage["userId"]?.uuidValue, owner)
+    }
+
+    func testGetRecordCountRespectsRLS() throws {
+        let url = tempDir.appendingPathComponent("count-rls.blazedb")
+        let db = try BlazeDBClient(name: "count-rls", fileURL: url, password: password)
+        defer { try? db.close() }
+
+        let user = UUID()
+        let other = UUID()
+        db.enableRLS()
+        db.setRLSContext(userID: user, roles: ["admin"])
+        db.configureRLSAdminAndOwnerPolicies(userIDField: "userId")
+        _ = try db.insert(BlazeDataRecord(["userId": .uuid(user)]))
+        _ = try db.insert(BlazeDataRecord(["userId": .uuid(other)]))
+
+        db.setRLSContext(userID: user, roles: ["member"])
+        XCTAssertEqual(db.getRecordCount(), 1, "getRecordCount must not leak total rows under RLS (#336)")
+        XCTAssertEqual(try db.stats().recordCount, 1)
+    }
+
+    func testFilteredObservationDoesNotForwardDeletes() throws {
+        let url = tempDir.appendingPathComponent("observe-rls.blazedb")
+        let db = try BlazeDBClient(name: "observe-rls", fileURL: url, password: password)
+        defer { try? db.close() }
+
+        let id = try db.insert(BlazeDataRecord(["tag": .string("keep")]))
+        let exp = expectation(description: "no delete forwarded")
+        exp.isInverted = true
+        let token = db.observe(where: { ($0.storage["tag"]?.stringValue ?? "") == "keep" }) { changes in
+            for change in changes {
+                if case .delete = change.type {
+                    exp.fulfill()
+                }
+            }
+        }
+        defer { token.invalidate() }
+
+        try db.delete(id: id)
+        wait(for: [exp], timeout: 0.3)
+    }
+}

--- a/BlazeDBTests/Tier0Core/CoreCorrectness/RLSEnforcementGapTests.swift
+++ b/BlazeDBTests/Tier0Core/CoreCorrectness/RLSEnforcementGapTests.swift
@@ -25,6 +25,38 @@ final class RLSEnforcementGapTests: XCTestCase {
         super.tearDown()
     }
 
+    func testGraphBuilderHonorsClientRLSContext() throws {
+        let url = tempDir.appendingPathComponent("graph-builder-rls.blazedb")
+        let db = try BlazeDBClient(name: "graph-builder-rls", fileURL: url, password: password)
+        defer { try? db.close() }
+
+        let teamA = UUID()
+        let teamB = UUID()
+        let userA = UUID()
+
+        db.enableRLS()
+        db.rls.addPolicy(SecurityPolicy(
+            name: "team_select",
+            operation: .select,
+            type: .restrictive
+        ) { context, record in
+            guard let team = record.storage["team_id"]?.uuidValue else { return false }
+            return context.teamIDs.contains(team)
+        })
+
+        db.setRLSContext(userID: userA, teamIDs: [teamA, teamB], roles: ["admin"])
+        _ = try db.insert(BlazeDataRecord(["team_id": .uuid(teamA), "n": .int(1)]))
+        _ = try db.insert(BlazeDataRecord(["team_id": .uuid(teamA), "n": .int(2)]))
+        _ = try db.insert(BlazeDataRecord(["team_id": .uuid(teamB), "n": .int(3)]))
+
+        db.setRLSContext(userID: userA, teamIDs: [teamA], roles: ["engineer"])
+        let points = try db.graph {
+            $0.x("team_id").y(.count)
+        }.toPoints()
+        XCTAssertEqual(points.count, 1, "graph { } builder must apply client RLS context (#334)")
+        XCTAssertEqual(points.first?.y as? Int, 2)
+    }
+
     func testPublicGraphHonorsClientRLSContext() throws {
         let url = tempDir.appendingPathComponent("graph-rls.blazedb")
         let db = try BlazeDBClient(name: "graph-rls", fileURL: url, password: password)
@@ -93,6 +125,48 @@ final class RLSEnforcementGapTests: XCTestCase {
         var stolen = try XCTUnwrap(try db.fetch(id: id))
         stolen.storage["userId"] = .uuid(other)
         XCTAssertThrowsError(try db.update(id: id, with: stolen), "WITH CHECK must reject ownership transfer (#335)")
+        let still = try XCTUnwrap(try db.fetch(id: id))
+        XCTAssertEqual(still.storage["userId"]?.uuidValue, owner)
+    }
+
+    func testUpdateManyRejectsPostMutationRLSViolation() throws {
+        let url = tempDir.appendingPathComponent("with-check-many.blazedb")
+        let db = try BlazeDBClient(name: "with-check-many", fileURL: url, password: password)
+        defer { try? db.close() }
+
+        let owner = UUID()
+        let other = UUID()
+        db.enableRLS()
+        db.setRLSContext(userID: owner, roles: ["admin"])
+        db.rls.addPolicy(SecurityPolicy(
+            name: "owner_update",
+            operation: .update,
+            type: .restrictive
+        ) { context, record in
+            record.storage["userId"]?.uuidValue == context.userID
+        })
+        db.rls.addPolicy(SecurityPolicy(
+            name: "owner_insert",
+            operation: .insert,
+            type: .restrictive
+        ) { context, record in
+            record.storage["userId"]?.uuidValue == context.userID || context.hasRole("admin")
+        })
+        db.rls.addPolicy(SecurityPolicy(
+            name: "owner_select",
+            operation: .select,
+            type: .restrictive
+        ) { context, record in
+            record.storage["userId"]?.uuidValue == context.userID || context.hasRole("admin")
+        })
+
+        let id = try db.insert(BlazeDataRecord(["userId": .uuid(owner), "note": .string("mine")]))
+        db.setRLSContext(userID: owner, roles: ["member"])
+
+        XCTAssertThrowsError(
+            try db.updateMany(where: { _ in true }, set: ["userId": .uuid(other)]),
+            "updateMany WITH CHECK must reject ownership transfer (#335)"
+        )
         let still = try XCTUnwrap(try db.fetch(id: id))
         XCTAssertEqual(still.storage["userId"]?.uuidValue, owner)
     }


### PR DESCRIPTION
## Summary

- `graph()` uses client RLS context (#334)
- `update` / `updateMany` enforce WITH CHECK (#335)
- `getRecordCount()` respects RLS filters (#336)
- Filtered change observers do not forward deletes outside the filter (#337)

## Test plan

- [x] `RLSEnforcementGapTests` (4 regressions)

Fixes #334
Fixes #335
Fixes #336
Fixes #337