### PR TITLE
Harden sensitive file creation and secret logging (#358, #324, #357)

### DIFF
--- a/BlazeDB/Core/BlazeDBManager.swift
+++ b/BlazeDB/Core/BlazeDBManager.swift
@@ -208,7 +208,7 @@ public final class BlazeDBManager {
         }
 
         let salt = try SecureRandom.bytesStrict(count: 16)
-        try salt.write(to: saltURL, options: .atomic)
+        try SecureFileAttributes.writeOwnerOnly(salt, to: saltURL)
         return salt
     }
 

--- a/BlazeDB/Exports/BlazeDBClient+SharedSecret.swift
+++ b/BlazeDB/Exports/BlazeDBClient+SharedSecret.swift
@@ -232,7 +232,8 @@ extension BlazeDBClient {
         
         BlazeLogger.info("✅ Server started with shared secret! Database '\(self.name)' is discoverable on port \(port)")
         BlazeLogger.info("   Device: \(deviceName)")
-        BlazeLogger.debug("   Shared secret: \(sharedSecret.prefix(4))...")
+        // Never log secret material (including prefixes). #358
+        BlazeLogger.debug("   Shared-secret auth enabled (length=\(sharedSecret.utf8.count) bytes)")
         
         return server
     }

--- a/BlazeDB/Exports/BlazeDBClient.swift
+++ b/BlazeDB/Exports/BlazeDBClient.swift
@@ -325,7 +325,7 @@ public final class BlazeDBClient: @unchecked Sendable {
         }
 
         let salt = try SecureRandom.bytesStrict(count: 16)
-        try salt.write(to: saltURL, options: .atomic)
+        try SecureFileAttributes.writeOwnerOnly(salt, to: saltURL)
         return salt
     }
 

--- a/BlazeDB/Storage/DurabilityManager.swift
+++ b/BlazeDB/Storage/DurabilityManager.swift
@@ -40,9 +40,10 @@ public final class DurabilityManager: @unchecked Sendable {
     public init(walURL: URL) throws {
         self.walURL = walURL
 
-        // Create file if it doesn't exist
+        // Create file if it doesn't exist (owner-only on POSIX, #357).
+        // Do not chmod existing WALs — preserve prior deployment modes.
         if !FileManager.default.fileExists(atPath: walURL.path) {
-            FileManager.default.createFile(atPath: walURL.path, contents: nil)
+            _ = SecureFileAttributes.createOwnerOnlyFile(at: walURL)
         }
 
         self.fileHandle = try FileHandle(forUpdating: walURL)

--- a/BlazeDB/Storage/PageStore.swift
+++ b/BlazeDB/Storage/PageStore.swift
@@ -267,9 +267,10 @@ public final class PageStore: @unchecked Sendable {
 
         self.key = key  // ✅ STORE ENCRYPTION KEY
 
-        // Create the file if it doesn't exist
+        // Create the file if it doesn't exist (owner-only on POSIX, #357).
+        // Do not chmod existing databases — deployments may intentionally share them.
         if !FileManager.default.fileExists(atPath: fileURL.path) {
-            FileManager.default.createFile(atPath: fileURL.path, contents: nil)
+            _ = SecureFileAttributes.createOwnerOnlyFile(at: fileURL)
         }
 
         self.fileHandle = try FileHandle(forUpdating: fileURL)

--- a/BlazeDB/Storage/WriteAheadLog.swift
+++ b/BlazeDB/Storage/WriteAheadLog.swift
@@ -59,8 +59,9 @@ internal final class WriteAheadLog: @unchecked Sendable {
         IOTraceSink.record(operation: "wal_open_begin", path: logURL.path)
 
         // Open with O_CREAT | O_RDWR so we can both replay (read) and append (write).
+        // Owner-only mode on create (#357); existing files keep prior mode.
         let flags: Int32 = O_RDWR | O_CREAT
-        let mode: mode_t = 0o644
+        let mode: mode_t = 0o600
         let opened = logURL.path.withCString { path in
             #if canImport(Darwin)
             Darwin.open(path, flags, mode)

--- a/BlazeDB/Utils/SecureFileAttributes.swift
+++ b/BlazeDB/Utils/SecureFileAttributes.swift
@@ -1,0 +1,72 @@
+//
+//  SecureFileAttributes.swift
+//  BlazeDB
+//
+//  Owner-only creation helpers for sensitive on-disk material (#357 / #324).
+//
+
+import Foundation
+
+/// Owner-only creation helpers for sensitive on-disk material (#357 / #324).
+public enum SecureFileAttributes {
+    public static let ownerOnlyFilePermissions: Int = 0o600
+    public static let ownerOnlyDirectoryPermissions: Int = 0o700
+
+    /// Restrict an existing path to owner-only on POSIX. No-op when attributes are unavailable.
+    public static func restrictToOwnerOnly(at url: URL, directory: Bool = false) {
+        #if os(Windows)
+        return
+        #else
+        let mode = directory ? ownerOnlyDirectoryPermissions : ownerOnlyFilePermissions
+        do {
+            try FileManager.default.setAttributes(
+                [.posixPermissions: mode],
+                ofItemAtPath: url.path
+            )
+        } catch {
+            BlazeLogger.warn("Could not set owner-only permissions on \(url.lastPathComponent): \(error.localizedDescription)")
+        }
+        #endif
+    }
+
+    /// Create an empty file with owner-only mode when supported.
+    @discardableResult
+    public static func createOwnerOnlyFile(at url: URL) -> Bool {
+        #if os(Windows)
+        return FileManager.default.createFile(atPath: url.path, contents: nil)
+        #else
+        let created = FileManager.default.createFile(
+            atPath: url.path,
+            contents: nil,
+            attributes: [.posixPermissions: ownerOnlyFilePermissions]
+        )
+        if created {
+            restrictToOwnerOnly(at: url)
+        }
+        return created
+        #endif
+    }
+
+    /// Atomically write data then force owner-only permissions (covers umask after `.atomic`).
+    public static func writeOwnerOnly(_ data: Data, to url: URL) throws {
+        try data.write(to: url, options: .atomic)
+        restrictToOwnerOnly(at: url)
+    }
+
+    /// Create a directory with 0700 when missing.
+    public static func ensureOwnerOnlyDirectory(at url: URL) throws {
+        let fm = FileManager.default
+        if !fm.fileExists(atPath: url.path) {
+            #if os(Windows)
+            try fm.createDirectory(at: url, withIntermediateDirectories: true)
+            #else
+            try fm.createDirectory(
+                at: url,
+                withIntermediateDirectories: true,
+                attributes: [.posixPermissions: ownerOnlyDirectoryPermissions]
+            )
+            #endif
+        }
+        restrictToOwnerOnly(at: url, directory: true)
+    }
+}

--- a/BlazeDBTests/Tier0Core/CoreCorrectness/SecureFilePermissionsTests.swift
+++ b/BlazeDBTests/Tier0Core/CoreCorrectness/SecureFilePermissionsTests.swift
@@ -1,0 +1,63 @@
+//
+//  SecureFilePermissionsTests.swift
+//  BlazeDBTests
+//
+//  Regression tests for #357 / #324: owner-only creation of sensitive artifacts.
+//
+
+import XCTest
+@testable import BlazeDBCore
+
+final class SecureFilePermissionsTests: XCTestCase {
+    private var tempDir: URL!
+    private let password = "SecureFilePerms-Test-2026!"
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("SecureFilePerms-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: tempDir)
+        super.tearDown()
+    }
+
+    func testNewDatabaseArtifactsAreOwnerOnlyOnPOSIX() throws {
+        #if os(Windows)
+        throw XCTSkip("POSIX permissions not applicable on Windows")
+        #else
+        let url = tempDir.appendingPathComponent("perms.blazedb")
+        let db = try BlazeDBClient(name: "perms", fileURL: url, password: password)
+        defer { try? db.close() }
+
+        let salt = url.deletingPathExtension().appendingPathExtension("salt")
+        let dbMode = try posixMode(at: url)
+        let saltMode = try posixMode(at: salt)
+        XCTAssertEqual(dbMode & 0o077, 0, "new DB file must not be group/world accessible (#357)")
+        XCTAssertEqual(saltMode & 0o077, 0, "new .salt must not be group/world accessible (#357)")
+        #endif
+    }
+
+    func testMasterKeyringDirectoryIsOwnerOnlyOnPOSIX() throws {
+        #if os(Windows)
+        throw XCTSkip("POSIX permissions not applicable on Windows")
+        #else
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        let dir = home.appendingPathComponent(".blazedb-test-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try SecureFileAttributes.ensureOwnerOnlyDirectory(at: dir)
+        let mode = try posixMode(at: dir)
+        XCTAssertEqual(mode & 0o077, 0, "~/.blazedb-style dirs should be 0700 (#324)")
+        #endif
+    }
+
+    private func posixMode(at url: URL) throws -> Int {
+        let attrs = try FileManager.default.attributesOfItem(atPath: url.path)
+        guard let mode = attrs[.posixPermissions] as? NSNumber else {
+            throw NSError(domain: "SecureFilePermissionsTests", code: 1)
+        }
+        return mode.intValue
+    }
+}

--- a/BlazeShell/CLIPaths.swift
+++ b/BlazeShell/CLIPaths.swift
@@ -21,9 +21,7 @@ public enum CLIPaths {
         }
         let home = FileManager.default.homeDirectoryForCurrentUser
         let dir = home.appendingPathComponent(".blazedb", isDirectory: true)
-        if !FileManager.default.fileExists(atPath: dir.path) {
-            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        }
+        try SecureFileAttributes.ensureOwnerOnlyDirectory(at: dir)
         return dir.appendingPathComponent("keyring.json.enc", isDirectory: false)
     }
 }


### PR DESCRIPTION
## Summary

- Stop logging shared-secret prefixes (#358)
- Create `~/.blazedb` as 0700 before keyring writes (#324)
- Create new DB / `.salt` / WAL artifacts with owner-only modes on POSIX (#357 partial)

**Not in scope:** chmod-on-reopen for existing files; existing paths keep prior permissions until a follow-up lands.

## Test plan

- [x] `SecureFilePermissionsTests` — new DB + salt owner-only; keyring dir 0700

Fixes #358
Fixes #324
Refs #357