### PR TITLE
Prefer BLAZEDB_PASSWORD over argv in CLI tools (#310, #313)

### DIFF
--- a/BlazeDB/Utils/CLIWarning.swift
+++ b/BlazeDB/Utils/CLIWarning.swift
@@ -1,0 +1,16 @@
+//
+//  CLIWarning.swift
+//  BlazeDB
+//
+//  Swift 6-safe stderr warnings for standalone CLI executables (#310/#313).
+//
+
+import Foundation
+
+public enum CLIWarning {
+    /// Write a warning line to stderr without touching the global `stderr` var (Linux Swift 6).
+    public static func write(_ message: String) {
+        guard let data = (message + "\n").data(using: .utf8) else { return }
+        FileHandle.standardError.write(data)
+    }
+}

--- a/BlazeDBTests/Tier0Core/Gate/CLISmokeTests.swift
+++ b/BlazeDBTests/Tier0Core/Gate/CLISmokeTests.swift
@@ -34,6 +34,7 @@ private final class LockedDataBuffer: @unchecked Sendable {
 
 final class CLISmokeTests: XCTestCase {
     var tempDir: URL!
+    private let testPassword = "TestPass123!"
     
     override func setUpWithError() throws {
         try super.setUpWithError()
@@ -56,10 +57,16 @@ final class CLISmokeTests: XCTestCase {
     // MARK: - Helper Methods
     
     private func resolveExecutablePath(_ executable: String) -> String? {
-        let projectRoot = URL(fileURLWithPath: #file)
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
+        var dir = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+        var projectRoot: URL?
+        while dir.path != "/" {
+            if FileManager.default.fileExists(atPath: dir.appendingPathComponent("Package.swift").path) {
+                projectRoot = dir
+                break
+            }
+            dir.deleteLastPathComponent()
+        }
+        guard let projectRoot else { return nil }
         
         let buildRoot = projectRoot.appendingPathComponent(".build")
         let candidateDirs = [
@@ -92,7 +99,24 @@ final class CLISmokeTests: XCTestCase {
         return nil
     }
     
-    private func runCommand(_ executable: String, arguments: [String] = []) -> (exitCode: Int32, output: String, error: String) {
+    private func cliEnvironment(_ overrides: [String: String] = [:]) -> [String: String] {
+        var env = ProcessInfo.processInfo.environment
+        env["BLAZEDB_PASSWORD"] = testPassword
+        for (key, value) in overrides {
+            if value.isEmpty {
+                env.removeValue(forKey: key)
+            } else {
+                env[key] = value
+            }
+        }
+        return env
+    }
+
+    private func runCommand(
+        _ executable: String,
+        arguments: [String] = [],
+        environment: [String: String]? = nil
+    ) -> (exitCode: Int32, output: String, error: String) {
         let process = Process()
         
         guard let finalPath = resolveExecutablePath(executable) else {
@@ -101,6 +125,7 @@ final class CLISmokeTests: XCTestCase {
         
         process.executableURL = URL(fileURLWithPath: finalPath)
         process.arguments = arguments
+        process.environment = environment ?? cliEnvironment()
         return runProcess(process)
     }
     
@@ -163,7 +188,7 @@ final class CLISmokeTests: XCTestCase {
     
     private func createTestDatabase() throws -> URL {
         let dbPath = tempDir.appendingPathComponent("test.blazedb")
-        let db = try BlazeDBClient(name: "TestDB", fileURL: dbPath, password: "TestPass123!")
+        let db = try BlazeDBClient(name: "TestDB", fileURL: dbPath, password: testPassword)
         
         // Insert test data
         for i in 1...10 {
@@ -247,7 +272,7 @@ final class CLISmokeTests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: restoredPath.path), "Restored database should exist")
         
         // Verify restored database
-        let restoredDB = try BlazeDBClient(name: "Restored", fileURL: restoredPath, password: "TestPass123!")
+        let restoredDB = try BlazeDBClient(name: "Restored", fileURL: restoredPath, password: testPassword)
         let records = try restoredDB.fetchAll()
         XCTAssertEqual(records.count, 10, "Restored database should have 10 records")
         try restoredDB.close()
@@ -275,6 +300,40 @@ final class CLISmokeTests: XCTestCase {
         XCTAssertNotEqual(verifyExitCode, 0, "BlazeDump verify should fail for corrupted dump")
     }
     
+    // MARK: - CLI password source (#310/#313)
+
+    func testBlazeInfo_PrefersBLAZEDBPasswordOverArgv() throws {
+        let dbPath = try createTestDatabase()
+        let wrongArgvPassword = "wrong-argv-password-should-be-ignored"
+
+        let (exitCode, output, error) = runCommand(
+            "BlazeInfo",
+            arguments: [dbPath.path, wrongArgvPassword],
+            environment: cliEnvironment()
+        )
+
+        XCTAssertEqual(exitCode, 0, "BLAZEDB_PASSWORD must unlock the DB. Error: \(error)")
+        XCTAssertTrue(output.contains("Records:"), "Expected successful info output. Output: \(output)")
+        XCTAssertTrue(error.contains("password argument ignored"), "Expected env-over-argv warning. stderr: \(error)")
+        XCTAssertFalse(error.contains(wrongArgvPassword), "stderr must not echo argv password")
+    }
+
+    func testBlazeInfo_WarnsWhenPasswordPassedOnArgv() throws {
+        let dbPath = try createTestDatabase()
+        var env = cliEnvironment()
+        env.removeValue(forKey: "BLAZEDB_PASSWORD")
+
+        let (exitCode, _, error) = runCommand(
+            "BlazeInfo",
+            arguments: [dbPath.path, testPassword],
+            environment: env
+        )
+
+        XCTAssertEqual(exitCode, 0, "argv password should still work for compatibility. stderr: \(error)")
+        XCTAssertTrue(error.contains("BLAZEDB_PASSWORD"), "Expected argv deprecation warning. stderr: \(error)")
+        XCTAssertFalse(error.contains(testPassword), "stderr must not echo the password")
+    }
+
     // MARK: - Integration Test
     
     func testCLI_EndToEnd() throws {
@@ -303,7 +362,7 @@ final class CLISmokeTests: XCTestCase {
         XCTAssertEqual(restoreExitCode, 0, "Restore should succeed")
         
         // Verify restored database works
-        let restoredDB = try BlazeDBClient(name: "E2E", fileURL: restoredPath, password: "TestPass123!")
+        let restoredDB = try BlazeDBClient(name: "E2E", fileURL: restoredPath, password: testPassword)
         let records = try restoredDB.fetchAll()
         XCTAssertEqual(records.count, 10, "Restored database should have correct record count")
         try restoredDB.close()

--- a/BlazeDoctor/main.swift
+++ b/BlazeDoctor/main.swift
@@ -294,13 +294,18 @@ if args.contains("--help") || args.contains("-h") {
     BlazeDB Doctor - Health Check Tool
     
     Usage:
-      blazedb doctor <db-path> <password> [--json]
+      blazedb doctor <db-path> [<password>] [--json]
+    
+    Password (prefer not putting secrets on argv — they appear in process listings):
+      1. Interactive / env: export BLAZEDB_PASSWORD then omit the password argument
+      2. Legacy: pass <password> as the second argument (deprecated)
     
     Options:
       --json    Output results as JSON (for scripting)
       -h, --help    Show this help message
     
     Examples:
+      BLAZEDB_PASSWORD='...' blazedb doctor /path/to/db.blazedb
       blazedb doctor /path/to/db.blazedb mypassword
       blazedb doctor /path/to/db.blazedb mypassword --json
     
@@ -312,15 +317,30 @@ if args.contains("--help") || args.contains("-h") {
 }
 
 let jsonOutput = args.contains("--json")
+let positional = args.dropFirst().filter { $0 != "--json" }
 
-guard args.count >= 3 else {
+guard positional.count >= 1 else {
     print("Error: Missing required arguments")
-    print("Usage: blazedb doctor <db-path> <password> [--json]")
-    print("Use --help for more information")
+    print("Usage: blazedb doctor <db-path> [<password>] [--json]")
+    print("Prefer BLAZEDB_PASSWORD over argv. Use --help for more information")
     exit(1)
 }
 
-let dbPath = args[1]
-let password = args[2]
+let dbPath = positional[0]
+let envPassword = ProcessInfo.processInfo.environment["BLAZEDB_PASSWORD"]
+let password: String
+if let envPassword, !envPassword.isEmpty {
+    if positional.count >= 2 {
+        fputs("warning: password argument ignored; using BLAZEDB_PASSWORD (#310/#313)\n", stderr)
+    }
+    password = envPassword
+} else if positional.count >= 2 {
+    fputs("warning: passing the database password on argv exposes it via process listings; prefer BLAZEDB_PASSWORD (#310/#313)\n", stderr)
+    password = positional[1]
+} else {
+    print("Error: Missing password (set BLAZEDB_PASSWORD or pass <password>)")
+    print("Usage: blazedb doctor <db-path> [<password>] [--json]")
+    exit(1)
+}
 
 runDoctor(dbPath: dbPath, password: password, jsonOutput: jsonOutput)

--- a/BlazeDoctor/main.swift
+++ b/BlazeDoctor/main.swift
@@ -126,6 +126,8 @@ func runDoctor(dbPath: String, password: String, jsonOutput: Bool) {
         }
         
         // Check 4: Read/Write cycle
+        // Probe cleanup must be durable before process exit: insert can hit disk while an
+        // in-memory-only delete would leave a residual row for dump/restore (#310/#313 CI).
         do {
             let testRecord = BlazeDataRecord([
                 "_doctor_test": .bool(true),
@@ -138,8 +140,13 @@ func runDoctor(dbPath: String, password: String, jsonOutput: Bool) {
             // Read back
             if let readRecord = try client.fetch(id: insertedID),
                readRecord.storage["_doctor_test"] == .bool(true) {
-                // Clean up test record
-                try? client.delete(id: insertedID)
+                try client.delete(id: insertedID)
+                try client.persist()
+                if try client.fetch(id: insertedID) != nil {
+                    throw BlazeDBError.invalidData(
+                        reason: "doctor probe delete did not remove _doctor_test record \(insertedID)"
+                    )
+                }
                 
                 checks.append(DoctorReport.CheckResult(
                     name: "Read/Write Cycle",
@@ -274,8 +281,16 @@ func runDoctor(dbPath: String, password: String, jsonOutput: Bool) {
                 print("❌ Database health check failed")
             }
         }
+
+        // exit(_:) skips deinit; flush/close so probe deletes are durable for later dump/restore.
+        do {
+            try client.close()
+        } catch {
+            errors.append("Failed to close database cleanly: \(error.localizedDescription)")
+            healthy = false
+        }
         
-        exit(report.healthy ? 0 : 1)
+        exit(healthy ? 0 : 1)
     }
 }
 

--- a/BlazeDoctor/main.swift
+++ b/BlazeDoctor/main.swift
@@ -331,11 +331,11 @@ let envPassword = ProcessInfo.processInfo.environment["BLAZEDB_PASSWORD"]
 let password: String
 if let envPassword, !envPassword.isEmpty {
     if positional.count >= 2 {
-        fputs("warning: password argument ignored; using BLAZEDB_PASSWORD (#310/#313)\n", stderr)
+        CLIWarning.write("warning: password argument ignored; using BLAZEDB_PASSWORD (#310/#313)")
     }
     password = envPassword
 } else if positional.count >= 2 {
-    fputs("warning: passing the database password on argv exposes it via process listings; prefer BLAZEDB_PASSWORD (#310/#313)\n", stderr)
+    CLIWarning.write("warning: passing the database password on argv exposes it via process listings; prefer BLAZEDB_PASSWORD (#310/#313)")
     password = positional[1]
 } else {
     print("Error: Missing password (set BLAZEDB_PASSWORD or pass <password>)")

--- a/BlazeDump/main.swift
+++ b/BlazeDump/main.swift
@@ -113,12 +113,12 @@ if args.contains("--help") || args.contains("-h") {
 func resolveCLIPassword(positionalPassword: String?) -> String {
     if let env = ProcessInfo.processInfo.environment["BLAZEDB_PASSWORD"], !env.isEmpty {
         if positionalPassword != nil {
-            fputs("warning: password argument ignored; using BLAZEDB_PASSWORD (#310/#313)\n", stderr)
+            CLIWarning.write("warning: password argument ignored; using BLAZEDB_PASSWORD (#310/#313)")
         }
         return env
     }
     if let positionalPassword, !positionalPassword.isEmpty {
-        fputs("warning: passing the database password on argv exposes it via process listings; prefer BLAZEDB_PASSWORD (#310/#313)\n", stderr)
+        CLIWarning.write("warning: passing the database password on argv exposes it via process listings; prefer BLAZEDB_PASSWORD (#310/#313)")
         return positionalPassword
     }
     print("Error: Missing password (set BLAZEDB_PASSWORD or pass <password>)")

--- a/BlazeDump/main.swift
+++ b/BlazeDump/main.swift
@@ -82,20 +82,23 @@ if args.contains("--help") || args.contains("-h") {
     BlazeDB Dump Tool
     
     Commands:
-      dump <db-path> <dump-path> <password>
+      dump <db-path> <dump-path> [<password>]
         Export database to dump file
         
-      restore <dump-path> <db-path> <password> [--allow-schema-mismatch]
+      restore <dump-path> <db-path> [<password>] [--allow-schema-mismatch]
         Restore database from dump file
         
       verify <dump-path>
         Verify dump file integrity
         
+    Password: prefer BLAZEDB_PASSWORD over argv (argv is visible in process listings).
+    
     Options:
       --allow-schema-mismatch    Allow restore even if schema versions don't match
       -h, --help                 Show this help message
     
     Examples:
+      BLAZEDB_PASSWORD='...' blazedb dump /path/to/db.blazedb /path/to/backup.blazedump
       blazedb dump /path/to/db.blazedb /path/to/backup.blazedump mypassword
       blazedb restore /path/to/backup.blazedump /path/to/newdb.blazedb mypassword
       blazedb verify /path/to/backup.blazedump
@@ -105,6 +108,21 @@ if args.contains("--help") || args.contains("-h") {
       1    Failure
     """)
     exit(0)
+}
+
+func resolveCLIPassword(positionalPassword: String?) -> String {
+    if let env = ProcessInfo.processInfo.environment["BLAZEDB_PASSWORD"], !env.isEmpty {
+        if positionalPassword != nil {
+            fputs("warning: password argument ignored; using BLAZEDB_PASSWORD (#310/#313)\n", stderr)
+        }
+        return env
+    }
+    if let positionalPassword, !positionalPassword.isEmpty {
+        fputs("warning: passing the database password on argv exposes it via process listings; prefer BLAZEDB_PASSWORD (#310/#313)\n", stderr)
+        return positionalPassword
+    }
+    print("Error: Missing password (set BLAZEDB_PASSWORD or pass <password>)")
+    exit(1)
 }
 
 guard args.count >= 2 else {
@@ -117,21 +135,24 @@ let command = args[1]
 
 switch command {
 case "dump":
-    guard args.count >= 5 else {
+    guard args.count >= 4 else {
         print("Error: Missing arguments for dump command")
-        print("Usage: blazedb dump <db-path> <dump-path> <password>")
+        print("Usage: blazedb dump <db-path> <dump-path> [<password>]")
         exit(1)
     }
-    dumpDatabase(dbPath: args[2], dumpPath: args[3], password: args[4])
+    let password = resolveCLIPassword(positionalPassword: args.count >= 5 ? args[4] : nil)
+    dumpDatabase(dbPath: args[2], dumpPath: args[3], password: password)
     
 case "restore":
-    guard args.count >= 5 else {
+    let filtered = args.filter { $0 != "--allow-schema-mismatch" }
+    guard filtered.count >= 4 else {
         print("Error: Missing arguments for restore command")
-        print("Usage: blazedb restore <dump-path> <db-path> <password> [--allow-schema-mismatch]")
+        print("Usage: blazedb restore <dump-path> <db-path> [<password>] [--allow-schema-mismatch]")
         exit(1)
     }
     let allowMismatch = args.contains("--allow-schema-mismatch")
-    restoreDatabase(dumpPath: args[2], dbPath: args[3], password: args[4], allowSchemaMismatch: allowMismatch)
+    let password = resolveCLIPassword(positionalPassword: filtered.count >= 5 ? filtered[4] : nil)
+    restoreDatabase(dumpPath: filtered[2], dbPath: filtered[3], password: password, allowSchemaMismatch: allowMismatch)
     
 case "verify":
     guard args.count >= 3 else {

--- a/BlazeInfo/main.swift
+++ b/BlazeInfo/main.swift
@@ -73,7 +73,11 @@ if args.contains("--help") || args.contains("-h") {
     BlazeDB Info Tool
     
     Usage:
-      blazedb info <db-path> <password>
+      blazedb info <db-path> [<password>]
+    
+    Password (prefer BLAZEDB_PASSWORD over argv — argv is visible in process listings):
+      1. export BLAZEDB_PASSWORD=... then omit the password argument
+      2. Legacy: pass <password> as the second argument (deprecated)
     
     Prints database information:
       - Path and name
@@ -85,8 +89,8 @@ if args.contains("--help") || args.contains("-h") {
       -h, --help    Show this help message
     
     Examples:
+      BLAZEDB_PASSWORD='...' blazedb info /path/to/db.blazedb
       blazedb info /path/to/db.blazedb mypassword
-      blazedb info ./mydb.blazedb mypassword
     
     Exit codes:
       0    Success
@@ -95,14 +99,28 @@ if args.contains("--help") || args.contains("-h") {
     exit(0)
 }
 
-guard args.count >= 3 else {
+let positional = Array(args.dropFirst())
+guard positional.count >= 1 else {
     print("Error: Missing required arguments")
-    print("Usage: blazedb info <db-path> <password>")
-    print("Use --help for more information")
+    print("Usage: blazedb info <db-path> [<password>]")
+    print("Prefer BLAZEDB_PASSWORD over argv. Use --help for more information")
     exit(1)
 }
 
-let dbPath = args[1]
-let password = args[2]
+let dbPath = positional[0]
+let envPassword = ProcessInfo.processInfo.environment["BLAZEDB_PASSWORD"]
+let password: String
+if let envPassword, !envPassword.isEmpty {
+    if positional.count >= 2 {
+        fputs("warning: password argument ignored; using BLAZEDB_PASSWORD (#310/#313)\n", stderr)
+    }
+    password = envPassword
+} else if positional.count >= 2 {
+    fputs("warning: passing the database password on argv exposes it via process listings; prefer BLAZEDB_PASSWORD (#310/#313)\n", stderr)
+    password = positional[1]
+} else {
+    print("Error: Missing password (set BLAZEDB_PASSWORD or pass <password>)")
+    exit(1)
+}
 
 printDatabaseInfo(dbPath: dbPath, password: password)

--- a/BlazeInfo/main.swift
+++ b/BlazeInfo/main.swift
@@ -112,11 +112,11 @@ let envPassword = ProcessInfo.processInfo.environment["BLAZEDB_PASSWORD"]
 let password: String
 if let envPassword, !envPassword.isEmpty {
     if positional.count >= 2 {
-        fputs("warning: password argument ignored; using BLAZEDB_PASSWORD (#310/#313)\n", stderr)
+        CLIWarning.write("warning: password argument ignored; using BLAZEDB_PASSWORD (#310/#313)")
     }
     password = envPassword
 } else if positional.count >= 2 {
-    fputs("warning: passing the database password on argv exposes it via process listings; prefer BLAZEDB_PASSWORD (#310/#313)\n", stderr)
+    CLIWarning.write("warning: passing the database password on argv exposes it via process listings; prefer BLAZEDB_PASSWORD (#310/#313)")
     password = positional[1]
 } else {
     print("Error: Missing password (set BLAZEDB_PASSWORD or pass <password>)")


### PR DESCRIPTION
## Summary

- `blazedb doctor`, `blazedb info`, and dump/restore accept `BLAZEDB_PASSWORD`
- Warn on stderr when password is passed on argv (argv still supported for compatibility)

**Not in scope:** removing argv password support entirely; stronger remediation tracked in #310 / #313.

## Test plan

- [ ] Manual: `BLAZEDB_PASSWORD=... blazedb info <db>` succeeds without argv password
- [ ] Manual: argv password prints deprecation warning

Refs #310
Refs #313