### PR TITLE
Align KDF naming and docs with production PBKDF2 (#273, #317)

### DIFF
--- a/BlazeDB/Core/BlazeDBManager.swift
+++ b/BlazeDB/Core/BlazeDBManager.swift
@@ -58,18 +58,32 @@ public final class BlazeDBManager {
             ?? fileURL.deletingLastPathComponent().appendingPathComponent("txn_log.json")
     }
 
-    /// Legacy NDJSON recovery hook used by manager-style tooling.
-    /// If a `txn_log-*.json` or `txn_log.json` exists next to the database file, this will
-    /// treat it as a plaintext page-level journal and replay it into the encrypted `PageStore`.
-    /// Normal `BlazeDBClient` usage does not generate these logs; they are strictly for
-    /// legacy migration / advanced recovery scenarios and should be treated as sensitive.
-    private static func recoverTransactionLogIfPresent(into store: PageStore, fileURL: URL) throws {
+    /// Legacy NDJSON `txn_log*.json` sidecars are **unauthenticated plaintext** page ops.
+    ///
+    /// Security (#365): auto-replaying them into a keyed `PageStore` seals attacker-chosen plaintext
+    /// under the victim key. This is fail-closed removal, not authenticated recovery.
+    ///
+    /// **What still recovers:** production `BlazeDBClient` / `PageStore` crash recovery uses the binary
+    /// WAL (`.wal`) path inside `PageStore.init`, not NDJSON sidecars. `BlazeDBClient.open` already
+    /// deletes legacy NDJSON sidecars instead of replaying them. Manager mount now matches that boundary.
+    ///
+    /// Operators with a legitimate NDJSON journal must restore through an authenticated backup or a future
+    /// signed/authenticated journal format — not silent replay on mount.
+    private static func rejectUnauthenticatedTransactionLogIfPresent(fileURL: URL) throws {
         let fm = FileManager.default
-        let candidates = transactionLogURLs(for: fileURL)
-        let chosen = candidates.first(where: { fm.fileExists(atPath: $0.path) }) ?? preferredTransactionLogURL(for: fileURL)
-        let log = TransactionLog(logFileURL: chosen)
-        try log.recover(into: store, from: chosen)
-        BlazeLogger.info("Recovered journal: \(chosen.lastPathComponent)")
+        for candidate in transactionLogURLs(for: fileURL) where fm.fileExists(atPath: candidate.path) {
+            BlazeLogger.warn(
+                "Removing unauthenticated legacy NDJSON journal \(candidate.lastPathComponent) without replay (#365)"
+            )
+            do {
+                try fm.removeItem(at: candidate)
+            } catch {
+                throw NSError(domain: "BlazeDBManager", code: 3651, userInfo: [
+                    NSLocalizedDescriptionKey:
+                        "Refusing to mount while unauthenticated txn_log sidecar \(candidate.lastPathComponent) cannot be removed: \(error.localizedDescription)"
+                ])
+            }
+        }
     }
 
     /// Mount a DB from the given file path.
@@ -94,7 +108,7 @@ public final class BlazeDBManager {
         let key = try Self.keyFromPassword(password, salt: kdfSalt)
         let metaURL = fileURL.deletingPathExtension().appendingPathExtension("meta")
         let store = try PageStore(fileURL: fileURL, key: key)
-        try Self.recoverTransactionLogIfPresent(into: store, fileURL: fileURL)
+        try Self.rejectUnauthenticatedTransactionLogIfPresent(fileURL: fileURL)
         
         // CRITICAL: Pass password to DynamicCollection so migration can access password-protected layouts
         let collection = try DynamicCollection(
@@ -257,7 +271,7 @@ public final class BlazeDBManager {
         let kdfSalt = try Self.loadOrCreateKDFSalt(for: fileURL)
         let key = try Self.keyFromPassword(password ?? "", salt: kdfSalt)
         let store = try PageStore(fileURL: fileURL, key: key)
-        try Self.recoverTransactionLogIfPresent(into: store, fileURL: fileURL)
+        try Self.rejectUnauthenticatedTransactionLogIfPresent(fileURL: fileURL)
         
         // CRITICAL: Pass password to DynamicCollection so migration can access password-protected layouts
         let collection = try DynamicCollection(
@@ -289,24 +303,29 @@ public final class BlazeDBManager {
     }
     
     /// Recover all transactions for all mounted databases from any legacy NDJSON journals.
-    /// This walks `txn_log-*.json` / `txn_log.json` sidecars (if present) and replays
-    /// their plaintext page operations into the mounted stores. Default `BlazeDBClient`
-    /// CRUD does not emit these files; this is an advanced migration / operator tool.
+    ///
+    /// **Disabled (#365):** adjacent `txn_log*.json` files are unauthenticated plaintext.
+    /// Replaying them into a keyed `PageStore` would seal attacker-controlled pages under the
+    /// database key. Callers that find these sidecars should delete them and restore from an
+    /// authenticated backup / binary WAL path instead.
     public func recoverAllTransactions() throws {
         stateLock.lock()
         defer { stateLock.unlock() }
-        for (name, collection) in mountedDatabases {
-            guard let fileURL = dbFileURLs[name] else {
-                BlazeLogger.warn("Missing file URL for \(name); skipping recovery")
-                continue
-            }
-            let candidates = Self.transactionLogURLs(for: fileURL)
+        var found: [String] = []
+        for (name, _) in mountedDatabases {
+            guard let fileURL = dbFileURLs[name] else { continue }
             let fm = FileManager.default
-            let chosen = candidates.first(where: { fm.fileExists(atPath: $0.path) }) ?? Self.preferredTransactionLogURL(for: fileURL)
-            let log = TransactionLog(logFileURL: chosen)
-            try log.recover(into: collection.store, from: chosen)
-            BlazeLogger.info("Recovered journal for \(name): \(chosen.lastPathComponent)")
+            for candidate in Self.transactionLogURLs(for: fileURL) where fm.fileExists(atPath: candidate.path) {
+                found.append("\(name):\(candidate.lastPathComponent)")
+            }
         }
+        guard found.isEmpty else {
+            throw NSError(domain: "BlazeDBManager", code: 3650, userInfo: [
+                NSLocalizedDescriptionKey:
+                    "Legacy NDJSON txn_log replay is disabled because journals are unauthenticated plaintext (#365). Sidecars present: \(found.joined(separator: ", ")). Remove them and restore from an authenticated backup."
+            ])
+        }
+        BlazeLogger.info("recoverAllTransactions: no legacy NDJSON journals present")
     }
     
     /// Flush all mounted PageStores to disk.

--- a/BlazeDB/Crypto/Argon2KDF.swift
+++ b/BlazeDB/Crypto/Argon2KDF.swift
@@ -58,10 +58,10 @@ public enum Argon2KDF {
         )
     }
     
-    /// Derive key using Argon2id
-    /// 
-    /// Note: Swift doesn't have native Argon2, so we use a memory-hard PBKDF2 variant
-    /// that approximates Argon2's memory-hard properties using large memory buffers.
+    /// Derive key using the proprietary memory-hard helper (not RFC Argon2id).
+    ///
+    /// Swift has no native Argon2 here; this uses large memory buffers plus HMAC/SHA-256.
+    /// Do not document or label this path as Argon2id.
     ///
     /// - Parameters:
     ///   - password: User password
@@ -187,12 +187,12 @@ public enum Argon2KDF {
     }
 }
 
-/// Extension to KeyManager for Argon2 support
+/// Extension to KeyManager for the proprietary memory-hard helper.
 extension KeyManager {
-    /// Get key using Argon2id (hardened KDF)
-    /// 
-    /// This is the recommended method for new databases.
-    /// For backward compatibility, existing databases can still use PBKDF2.
+    /// Derive a key with `Argon2KDF` (proprietary; **not** RFC Argon2id).
+    ///
+    /// Not used by the production `BlazeDBClient` / `PageStore` open path, which uses
+    /// `getKey(from:salt:)` → PBKDF2-HMAC-SHA256.
     public static func getKeyArgon2(
         from password: String,
         salt: Data,
@@ -205,7 +205,6 @@ extension KeyManager {
             throw KeyManagerError.passwordTooWeak(failure)
         }
         
-        // Use Argon2id for key derivation
         return try Argon2KDF.deriveKey(
             from: password,
             salt: salt,

--- a/BlazeDB/Crypto/KeyManager.swift
+++ b/BlazeDB/Crypto/KeyManager.swift
@@ -21,6 +21,12 @@ enum KeyManagerError: Error {
 }
 
 public final class KeyManager {
+    /// Release/production default for password → AES-key derivation.
+    /// Documented publicly; do not change without a migration story.
+    public static let productionPBKDF2Iterations = 600_000
+    /// Faster default under XCTest when no override/env is set.
+    public static let xctestPBKDF2Iterations = 100_000
+
     internal static let legacyPasswordSalt = Data("AshPileSalt".utf8)
     nonisolated(unsafe) private static var passwordKeyCache = [String: SymmetricKey]()
     private static let passwordKeyCacheLock = NSLock()
@@ -40,9 +46,9 @@ public final class KeyManager {
             return parsed
         }
         if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil {
-            return 100_000
+            return xctestPBKDF2Iterations
         }
-        return 600_000
+        return productionPBKDF2Iterations
     }
 
     /// Test-only hook for bounding PBKDF2 cost in non-crypto-focused suites.
@@ -87,7 +93,7 @@ public final class KeyManager {
         pbkdf2DerivationCount += 1
         pbkdf2DerivationCountLock.unlock()
 
-        // Use CryptoKit's native PBKDF2 (SHA256)
+        // PBKDF2-HMAC-SHA256 (hand-rolled over CryptoKit HMAC; not a platform PBKDF2 API).
         let passwordData = Data(password.utf8)
         let derivedKey = try deriveKeyPBKDF2(
             password: passwordData,
@@ -101,10 +107,8 @@ public final class KeyManager {
         return symmetricKey
     }
     
-    /// Native PBKDF2 implementation using CryptoKit
+    /// PBKDF2-HMAC-SHA256 over CryptoKit `HMAC<SHA256>`.
     internal static func deriveKeyPBKDF2(password: Data, salt: Data, iterations: Int, keyLength: Int) throws -> Data {
-        // CryptoKit's HKDF can be used, but for true PBKDF2 we need to implement it
-        // For now, use a simple but secure key derivation
         var derivedKey = Data()
         
         for blockNum in 1...((keyLength + 31) / 32) {

--- a/BlazeDBCLITests/BlazeCLICoreTests.swift
+++ b/BlazeDBCLITests/BlazeCLICoreTests.swift
@@ -275,7 +275,7 @@ final class CLIMasterKeyringTests: XCTestCase {
         let status = try CLIMasterKeyringStore.initialize(passphrase: "VeryStrongMasterPassphrase_123!")
         XCTAssertTrue(status.exists)
         XCTAssertEqual(status.schemaVersion, 1)
-        XCTAssertEqual(status.kdfAlgorithm, "argon2id")
+    XCTAssertEqual(status.kdfAlgorithm, "blaze-memory-kdf")
 
         let payload = try CLIMasterKeyringStore.loadPayload(passphrase: "VeryStrongMasterPassphrase_123!")
         XCTAssertTrue(payload.databases.isEmpty)

--- a/BlazeDBTests/Tier0Core/CoreCorrectness/KDFTruthfulnessTests.swift
+++ b/BlazeDBTests/Tier0Core/CoreCorrectness/KDFTruthfulnessTests.swift
@@ -1,0 +1,34 @@
+//
+//  KDFTruthfulnessTests.swift
+//  BlazeDBTests
+//
+//  Regression tests for production PBKDF2 constants and deterministic derivation (#273).
+//
+
+import XCTest
+@testable import BlazeDBCore
+
+final class KDFTruthfulnessTests: XCTestCase {
+    func testProductionPBKDF2IterationConstantIs600k() {
+        XCTAssertEqual(KeyManager.productionPBKDF2Iterations, 600_000)
+        XCTAssertEqual(KeyManager.xctestPBKDF2Iterations, 100_000)
+    }
+
+    func testPBKDF2DerivationIsDeterministicForFixedInputs() throws {
+        let salt = Data(repeating: 0x42, count: 16)
+        let a = try KeyManager.deriveKeyPBKDF2(
+            password: Data("fixed-pass".utf8),
+            salt: salt,
+            iterations: 1_000,
+            keyLength: 32
+        )
+        let b = try KeyManager.deriveKeyPBKDF2(
+            password: Data("fixed-pass".utf8),
+            salt: salt,
+            iterations: 1_000,
+            keyLength: 32
+        )
+        XCTAssertEqual(a, b)
+        XCTAssertEqual(a.count, 32)
+    }
+}

--- a/BlazeDBTests/Tier0Core/CoreCorrectness/TxnLogRecoveryBoundaryTests.swift
+++ b/BlazeDBTests/Tier0Core/CoreCorrectness/TxnLogRecoveryBoundaryTests.swift
@@ -1,0 +1,168 @@
+//
+//  TxnLogRecoveryBoundaryTests.swift
+//  BlazeDBTests
+//
+//  Regression tests for #365: unauthenticated NDJSON txn_log must not replay into
+//  keyed PageStores on BlazeDBManager mount. Binary WAL recovery remains the
+//  authenticated crash-recovery path for BlazeDBClient / PageStore.
+//
+
+import XCTest
+@testable import BlazeDBCore
+#if canImport(CryptoKit)
+import CryptoKit
+#else
+import Crypto
+#endif
+
+final class TxnLogRecoveryBoundaryTests: XCTestCase {
+    private var tempDir: URL!
+    private let password = "TxnLogBoundary-Test-2026!"
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        KeyManager.setTestPBKDF2IterationsOverride(1_000)
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TxnLogBoundary-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        KeyManager.setTestPBKDF2IterationsOverride(nil)
+        try? FileManager.default.removeItem(at: tempDir)
+        try super.tearDownWithError()
+    }
+
+    /// Plant a committed NDJSON write beside the DB file (legacy sidecar location).
+    private func writeLegacyTxnLogSidecar(
+        beside dbURL: URL,
+        pageID: Int,
+        plaintext: Data,
+        useNamespaced: Bool = false
+    ) throws -> URL {
+        let txID = UUID().uuidString
+        let begin = try JSONEncoder().encode(TransactionLog.Operation.begin(txID: txID))
+        let write = try JSONEncoder().encode(TransactionLog.Operation.write(pageID: pageID, data: plaintext))
+        let commit = try JSONEncoder().encode(TransactionLog.Operation.commit(txID: txID))
+        var ndjson = Data()
+        ndjson.append(begin); ndjson.append(0x0A)
+        ndjson.append(write); ndjson.append(0x0A)
+        ndjson.append(commit); ndjson.append(0x0A)
+
+        let logURL: URL
+        if useNamespaced {
+            let base = dbURL.deletingPathExtension().lastPathComponent
+            let digest = SHA256.hash(data: Data(dbURL.path.utf8))
+            let digestHex = Data(digest).map { String(format: "%02x", $0) }.joined()
+            logURL = dbURL.deletingLastPathComponent()
+                .appendingPathComponent("txn_log-\(base)-\(digestHex).json")
+        } else {
+            logURL = dbURL.deletingLastPathComponent().appendingPathComponent("txn_log.json")
+        }
+        try ndjson.write(to: logURL)
+        return logURL
+    }
+
+    func testManagerMountRemovesUnauthenticatedTxnLogWithoutReplay() throws {
+        let dbURL = tempDir.appendingPathComponent("mount-txnlog.blazedb")
+
+        let store1 = try PageStore(fileURL: dbURL, key: try key(for: dbURL))
+        let original = Data(repeating: 0xAB, count: 64)
+        try store1.writePage(index: 7, plaintext: original)
+        store1.close()
+
+        let injected = Data(repeating: 0xEE, count: 64)
+        let journal = try writeLegacyTxnLogSidecar(beside: dbURL, pageID: 7, plaintext: injected)
+
+        let manager = BlazeDBManager()
+        _ = try manager.mountDatabase(named: "victim", fileURL: dbURL, password: password)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: journal.path), "sidecar must be removed, not replayed")
+        manager.unmountDatabase(named: "victim")
+
+        let store2 = try PageStore(fileURL: dbURL, key: try key(for: dbURL))
+        let readBack = try store2.readPage(index: 7)
+        XCTAssertEqual(readBack, original, "injected plaintext must not be sealed into the encrypted DB")
+        store2.close()
+    }
+
+    func testManagerMountRemovesNamespacedTxnLogSidecarWithoutReplay() throws {
+        let dbURL = tempDir.appendingPathComponent("namespaced-txnlog.blazedb")
+
+        let store1 = try PageStore(fileURL: dbURL, key: try key(for: dbURL))
+        try store1.writePage(index: 3, plaintext: Data(repeating: 0x11, count: 32))
+        store1.close()
+
+        let journal = try writeLegacyTxnLogSidecar(
+            beside: dbURL,
+            pageID: 3,
+            plaintext: Data(repeating: 0x22, count: 32),
+            useNamespaced: true
+        )
+
+        let manager = BlazeDBManager()
+        _ = try manager.mountDatabase(named: "db", fileURL: dbURL, password: password)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: journal.path))
+        manager.unmountDatabase(named: "db")
+    }
+
+    func testManagerMountWithoutTxnLogSidecarPreservesExistingPages() throws {
+        let dbURL = tempDir.appendingPathComponent("clean-mount.blazedb")
+
+        let store1 = try PageStore(fileURL: dbURL, key: try key(for: dbURL))
+        let payload = Data(repeating: 0xCD, count: 48)
+        try store1.writePage(index: 2, plaintext: payload)
+        store1.close()
+
+        let manager = BlazeDBManager()
+        _ = try manager.mountDatabase(named: "db", fileURL: dbURL, password: password)
+        manager.unmountDatabase(named: "db")
+
+        let store2 = try PageStore(fileURL: dbURL, key: try key(for: dbURL))
+        XCTAssertEqual(try store2.readPage(index: 2), payload)
+        store2.close()
+    }
+
+    func testBlazeDBClientOpenStillWorksWithoutTxnLogSidecar() throws {
+        let dbURL = tempDir.appendingPathComponent("client-open.blazedb")
+        let db = try BlazeDBClient(name: "client-open", fileURL: dbURL, password: password)
+        let id = try db.insert(BlazeDataRecord(["note": .string("durable")]))
+        try db.persist()
+        try db.close()
+
+        let db2 = try BlazeDBClient(name: "client-open", fileURL: dbURL, password: password)
+        defer { try? db2.close() }
+        let record = try db2.fetch(id: id)
+        XCTAssertEqual(record?.storage["note"]?.stringValue, "durable")
+    }
+
+    func testRecoverAllTransactionsFailsClosedWhenTxnLogPresent() throws {
+        let dbURL = tempDir.appendingPathComponent("recover-all.blazedb")
+        let manager = BlazeDBManager()
+        _ = try manager.mountDatabase(named: "db", fileURL: dbURL, password: password)
+
+        _ = try writeLegacyTxnLogSidecar(
+            beside: dbURL,
+            pageID: 1,
+            plaintext: Data(repeating: 0x99, count: 16)
+        )
+
+        XCTAssertThrowsError(try manager.recoverAllTransactions()) { error in
+            let ns = error as NSError
+            XCTAssertEqual(ns.domain, "BlazeDBManager")
+            XCTAssertEqual(ns.code, 3650)
+        }
+        manager.unmountAllDatabases()
+    }
+
+    private func key(for dbURL: URL) throws -> SymmetricKey {
+        let saltURL = dbURL.deletingPathExtension().appendingPathExtension("salt")
+        let salt: Data
+        if FileManager.default.fileExists(atPath: saltURL.path) {
+            salt = try Data(contentsOf: saltURL)
+        } else {
+            salt = try SecureRandom.bytesStrict(count: 16)
+            try salt.write(to: saltURL, options: .atomic)
+        }
+        return try KeyManager.getKey(from: password, salt: salt)
+    }
+}

--- a/BlazeShell/CLIMasterKeyring.swift
+++ b/BlazeShell/CLIMasterKeyring.swift
@@ -145,7 +145,9 @@ public enum CLIMasterKeyringStore {
 
             let isTest = ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
             let kdf = CLIMasterKDFRecord(
-                algorithm: "argon2id",
+                // Honest label for the proprietary memory-hard helper (#317).
+                // Readers still accept legacy "argon2id" envelopes for compatibility.
+                algorithm: "blaze-memory-kdf",
                 saltBase64: Data((0..<16).map { _ in UInt8.random(in: 0...255) }).base64EncodedString(),
                 memoryCost: isTest ? 16_384 : 65_536,
                 timeCost: isTest ? 2 : 3,
@@ -406,7 +408,8 @@ public enum CLIMasterKeyringStore {
         }
 
         switch kdf.algorithm.lowercased() {
-        case "argon2id":
+        case "blaze-memory-kdf", "argon2id":
+            // "argon2id" is a legacy mislabel for the proprietary Argon2KDF helper (#317).
             let params: Argon2KDF.Parameters
             if (kdf.memoryCost ?? 65_536) >= 131_072 || (kdf.timeCost ?? 3) >= 5 {
                 params = .highSecurity
@@ -417,7 +420,7 @@ public enum CLIMasterKeyringStore {
             }
             return try Argon2KDF.deriveKey(from: passphrase, salt: salt, parameters: params)
         case "pbkdf2":
-            let iters = kdf.pbkdf2Iterations ?? 600_000
+            let iters = kdf.pbkdf2Iterations ?? KeyManager.productionPBKDF2Iterations
             let derived = derivePBKDF2SHA256(password: Data(passphrase.utf8), salt: salt, iterations: iters, keyLength: kdf.keyLength)
             return SymmetricKey(data: derived)
         default:

--- a/Docs/GettingStarted/LINUX_PLATFORM_MODEL.md
+++ b/Docs/GettingStarted/LINUX_PLATFORM_MODEL.md
@@ -46,7 +46,7 @@ This document explains the feature matrix, design rationale, and explicit limita
 
 ### What Linux Provides
 
-- **Data-at-Rest Encryption**: AES-256-GCM per-page encryption with PBKDF2 (10,000 iterations) or Argon2id key derivation
+- **Data-at-Rest Encryption**: AES-256-GCM per-page encryption; password keys via PBKDF2-HMAC-SHA256 (600,000 iterations in release)
 - **CRC32 Checksums**: Optional corruption detection (IEEE 802.3 polynomial, pure Swift implementation)
 - **File Locking**: POSIX `flock()` exclusive process-level locking
 - **Access Control**: File system permissions (managed by host OS)

--- a/Docs/Security/SECURITY.md
+++ b/Docs/Security/SECURITY.md
@@ -67,14 +67,21 @@ Records are encoded to BlazeBinary, assembled into 4KB pages, encrypted with AES
 - Mitigation: Row-level security, policy evaluation
 
 4. **Storage Corruption**: Accidental or malicious data corruption
-- Mitigation: CRC32 checksums, corruption detection, automatic recovery
+- Mitigation: GCM authentication tags, binary WAL where enabled, recovery tooling
+
+### Crash recovery and journals
+
+Production `BlazeDBClient` / `PageStore` crash recovery uses the **binary write-ahead log** (`.wal`).
+
+Legacy adjacent **NDJSON `txn_log*.json` sidecars are unauthenticated plaintext**. `BlazeDBManager` **does not replay them** on mount (#365): sidecars are removed and mount proceeds using the encrypted store only. Operators with a legitimate legacy NDJSON journal must restore from an authenticated backup; there is no silent auto-replay into keyed stores.
 
 ### Attack Surfaces
 
-- **Local Storage**: Encrypted pages prevent plaintext access
+- **Local Storage**: Encrypted pages prevent plaintext access without the key
 - **Network Sync**: TLS + E2E encryption prevent interception
-- **Query Interface**: RLS policies filter unauthorized data
-- **Key Storage**: Secure Enclave prevents key extraction
+- **Query Interface**: RLS policies filter unauthorized data when enabled
+- **Key Storage**: Secure Enclave / keyring files (owner-only where supported)
+- **Legacy NDJSON `txn_log`**: Unauthenticated plaintext journals are **not** auto-applied into keyed stores (#365)
 
 ---
 

--- a/Docs/Security/SECURITY.md
+++ b/Docs/Security/SECURITY.md
@@ -2,6 +2,8 @@
 
 **Encryption model, threat model, and cryptographic pipelines.**
 
+Canonical key-management vocabulary: [KEY_MANAGEMENT_AND_COMPATIBILITY.md](../Status/KEY_MANAGEMENT_AND_COMPATIBILITY.md).
+
 ---
 
 ## Design Intent
@@ -17,30 +19,24 @@ BlazeDB encrypts all data at rest by default using AES-256-GCM with per-page gra
 All data is encrypted at rest using AES-256-GCM with unique nonces per page:
 
 - **Algorithm**: AES-256-GCM
-- **Key Derivation**: PBKDF2 (10,000 iterations) by default; Argon2id available as alternative
-- **Key Size**: 256 bits
-- **Authentication**: GCM auth tag (prevents tampering)
-- **Nonce**: Unique per page (prevents replay attacks)
+- **Password KDF (production open path)**: PBKDF2-HMAC-SHA256 with **600,000** iterations (release default; `KeyManager.productionPBKDF2Iterations`). Under XCTest the default is 100,000 unless overridden. Override via `BLAZEDB_PBKDF2_ITERATIONS`.
+- **Salt**: 16-byte per-database `.salt` sidecar (`SecureRandom`); legacy DBs without a sidecar may use a fixed compatibility salt.
+- **Derived key size**: 32 bytes (AES-256 material)
+- **Authentication**: GCM auth tag (detects ciphertext tampering)
+- **Nonce**: Unique per page
+
+There is **no** Argon2id on the production `BlazeDBClient` / `PageStore` open path. A proprietary memory-hard helper (`Argon2KDF`) exists for CLI master-keyring envelopes and layout-signature compatibility fallbacks; it is **not** RFC Argon2id and must not be documented as such.
 
 ### Key Management
 
 ```swift
-// Key derivation from user password (PBKDF2 default)
-let key = try KeyManager.getKey(
- from:.password(password),
- createIfMissing: false
-)
+// Production open path: password + per-DB salt → PBKDF2-HMAC-SHA256 → AES key
+let salt = /* 16-byte .salt sidecar */
+let key = try KeyManager.getKey(from: password, salt: salt)
 
-// Alternative: Argon2id for enhanced security
-let argon2Key = try KeyManager.getKeyArgon2(
- from: password,
- salt: databaseSalt,
- parameters:.default
-)
-
-// Secure Enclave integration (iOS/macOS)
+// Secure Enclave integration (iOS/macOS) — platform key source, not the password KDF
 let secureKey = try KeyManager.getKey(
- from:.secureEnclave(label: "com.app.blazedb"),
+ from: .secureEnclave(label: "com.app.blazedb"),
  createIfMissing: true
 )
 ```
@@ -49,7 +45,7 @@ let secureKey = try KeyManager.getKey(
 
 ### Encryption Pipeline
 
-Records are encoded to BlazeBinary, assembled into 4KB pages, encrypted with AES-256-GCM using a unique nonce per page, then written to disk. Each page is encrypted independently, enabling efficient garbage collection.
+Records are encoded to BlazeBinary, assembled into 4KB pages, encrypted with AES-256-GCM using the database symmetric key and a unique nonce per page, then written to disk. Each page is encrypted independently, enabling efficient garbage collection.
 
 ---
 
@@ -64,17 +60,18 @@ Records are encoded to BlazeBinary, assembled into 4KB pages, encrypted with AES
 - Mitigation: TLS/SSL, ECDH key exchange, end-to-end encryption
 
 3. **Malicious Application**: Compromised app process
-- Mitigation: Row-level security, policy evaluation
+- Mitigation: Row-level security, policy evaluation (client-enforced)
 
 4. **Storage Corruption**: Accidental or malicious data corruption
-- Mitigation: CRC32 checksums, corruption detection, automatic recovery
+- Mitigation: GCM authentication tags, recovery tooling, binary WAL where enabled
 
 ### Attack Surfaces
 
-- **Local Storage**: Encrypted pages prevent plaintext access
+- **Local Storage**: Encrypted pages prevent plaintext access without the key
 - **Network Sync**: TLS + E2E encryption prevent interception
-- **Query Interface**: RLS policies filter unauthorized data
-- **Key Storage**: Secure Enclave prevents key extraction
+- **Query Interface**: RLS policies filter unauthorized data when enabled and configured
+- **Key Storage**: Secure Enclave / keyring files (owner-only where platform supports it)
+- **Legacy NDJSON `txn_log`**: Unauthenticated plaintext journals are **not** auto-applied into keyed stores (see issue #365)
 
 ---
 
@@ -82,7 +79,7 @@ Records are encoded to BlazeBinary, assembled into 4KB pages, encrypted with AES
 
 ### Data at Rest: Local Encryption Pipeline
 
-User passwords are processed through PBKDF2 (10,000 iterations) by default to derive a master key. Argon2id is available as an alternative for enhanced security. HKDF derives per-page keys from the master key. Each 4KB page is encrypted with AES-256-GCM using its derived key and a unique nonce.
+User passwords are processed through **PBKDF2-HMAC-SHA256 (600,000 iterations in release)** with a per-database salt to derive a 256-bit AES key. That key seals each 4KB page with **AES-256-GCM** and a unique nonce.
 
 ### Data in Transit: Sync & Protocol Encryption
 

--- a/Docs/Security/SECURITY_AUDIT_CHECKLIST.md
+++ b/Docs/Security/SECURITY_AUDIT_CHECKLIST.md
@@ -14,7 +14,8 @@
 
 ### **Security Features**
 - [x] AES-256-GCM encryption implemented
-- [x] Argon2id KDF implemented
+- [ ] Argon2id KDF implemented (tracked separately; production open path is PBKDF2)
+- [x] PBKDF2-HMAC-SHA256 password KDF (600k release iterations)
 - [x] TLS 1.2+ enforced
 - [x] HMAC signatures for metadata
 - [x] Forward secrecy support

--- a/Docs/Status/KEY_MANAGEMENT_AND_COMPATIBILITY.md
+++ b/Docs/Status/KEY_MANAGEMENT_AND_COMPATIBILITY.md
@@ -20,7 +20,7 @@ Cryptography reuses the word “key” for several jobs. In BlazeDB they are dis
 | **Salt** | Random per-database bytes (`.salt` sidecar) | **No** — readable on disk is normal |
 | **KDF output / derived key** | 32 bytes from password + salt via PBKDF2 | Yes |
 | **AES key** | That same material as CryptoKit `SymmetricKey` | Yes — used for page seal/open |
-| **`Argon2KDF` output** | Another 32-byte derivation path | Yes — **proprietary, not Argon2id**; not the default open KDF |
+| **`Argon2KDF` / CLI `blaze-memory-kdf`** | Proprietary memory-hard helper (legacy envelopes may still say `argon2id`) | Yes — **not Argon2id**; not the default DB open KDF |
 | **Secure Enclave key** | Apple hardware/keychain-backed material | Platform-specific — usually **protects or unlocks** secrets; not “the AES page key” by itself |
 
 ### Normal open path

--- a/Docs/WALKTHROUGH_CHECKLIST.md
+++ b/Docs/WALKTHROUGH_CHECKLIST.md
@@ -29,7 +29,7 @@
 - `BlazeDB/Utils/BlazeBinaryDecoder.swift` - Decoding with corruption detection
 
 **Crypto:**
-- `BlazeDB/Crypto/KeyManager.swift` - Argon2id + HKDF key derivation
+- `BlazeDB/Crypto/KeyManager.swift` - PBKDF2-HMAC-SHA256 password → key (600k release iterations)
 - `BlazeDB/Storage/PageStore.swift` (lines 264-313) - AES-256-GCM per-page encryption
 
 **Tests (Validation):**
@@ -543,7 +543,7 @@ N+1-4095 Zero padding to 4KB
 **Key Derivation:**
 ```swift
 // BlazeDB/Crypto/KeyManager.swift
-1. Argon2id(password, salt) → derived key
+1. PBKDF2-HMAC-SHA256(password, per-DB salt, 600k iters in release) → derived key
 2. HKDF(derived key, info: "BlazeDB Encryption Key") → encryption key
 3. Key cached in memory (cleared on close)
 ```
@@ -638,7 +638,7 @@ let decrypted = try AES.GCM.open(sealedBox, using: key) // Throws if tag invalid
 - `BlazeDB/Storage/PageStore.swift:269` - Encryption: `try AES.GCM.seal(plaintext, using: key, nonce: nonce)`
 - `BlazeDB/Storage/PageStore.swift:299-301` - Nonce and tag storage in page format
 - `BlazeDB/Storage/PageStore.swift:436-456` - Decryption with tag verification
-- `BlazeDB/Crypto/KeyManager.swift` - Key derivation (Argon2id + HKDF)
+- `BlazeDB/Crypto/KeyManager.swift` - Key derivation (PBKDF2-HMAC-SHA256)
 
 **Invariant:**
 - Each page has unique nonce (prevents replay attacks)


### PR DESCRIPTION
## Summary

- Document 600k PBKDF2-HMAC-SHA256 as the release open-path KDF; expose `productionPBKDF2Iterations` / `xctestPBKDF2Iterations`
- New CLI master-keyring envelopes use `blaze-memory-kdf`; legacy `argon2id` envelopes still read
- Stop marketing `Argon2KDF` as RFC Argon2id in code comments and security docs

**Left open intentionally:**

- Archive/interview docs may still contain stale Argon2id claims (#273)
- Legacy `argon2id` metadata remains readable by design (#317)

## Test plan

- [x] `KDFTruthfulnessTests` — 600k constant, deterministic PBKDF2
- [x] `CLIMasterKeyringTests` — expects `blaze-memory-kdf` on init

Refs #273
Refs #317